### PR TITLE
Saves 7% of memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .settings
 .project
 .classpath
+blacklab.iml

--- a/pom.xml
+++ b/pom.xml
@@ -259,5 +259,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.goldmansachs</groupId>
+			<artifactId>gs-collections</artifactId>
+			<version>6.1.0</version>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/nl/inl/blacklab/externalstorage/ContentStoreDirUtf8.java
+++ b/src/main/java/nl/inl/blacklab/externalstorage/ContentStoreDirUtf8.java
@@ -29,11 +29,12 @@ import java.nio.IntBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.impl.factory.Maps;
 import nl.inl.util.ExUtil;
 
 /**
@@ -311,7 +312,7 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
 				f.delete();
 			}
 		}
-		toc = new HashMap<Integer, TocEntry>();
+		toc = Maps.mutable.empty();
 		if (tocFile.exists())
 			readToc();
 		tocModified = false;

--- a/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
+++ b/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
@@ -99,10 +99,10 @@ class ForwardIndexImplV3 extends ForwardIndex {
 	private long writeBufOffset;
 
 	/** The table of contents (where documents start in the tokens file and how long they are) */
-	private List<TocEntry> toc;
+	private ArrayList<TocEntry> toc;
 
 	/** Deleted TOC entries. Always sorted by size. */
-	private List<TocEntry> deletedTocEntries;
+	private ArrayList<TocEntry> deletedTocEntries;
 
 	/** The table of contents (TOC) file, docs.dat */
 	private File tocFile;
@@ -414,6 +414,8 @@ class ForwardIndexImplV3 extends ForwardIndex {
 		} catch (Exception e) {
 			throw ExUtil.wrapRuntimeException(e);
 		}
+		toc.trimToSize();
+		deletedTocEntries.trimToSize();
 	}
 
 	private void sortDeletedTocEntries() {

--- a/src/main/java/nl/inl/blacklab/forwardindex/TermsImplV3.java
+++ b/src/main/java/nl/inl/blacklab/forwardindex/TermsImplV3.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.gs.collections.impl.factory.Maps;
 import org.apache.log4j.Logger;
 
 /**
@@ -95,9 +96,8 @@ class TermsImplV3 extends Terms {
 			// (used later to get the terms in sort order)
 			this.termIndex = new TreeMap<String, Integer>(this.collator);
 		} else {
-			// Search mode: create a HashMap so insertion is O(1) instead of O(n log n).
 			// We already have the sort order, so TreeMap is not necessary here.
-			this.termIndex = new HashMap<String, Integer>();
+			this.termIndex = Maps.mutable.empty();
 		}
 		termIndexBuilt = true;
 	}


### PR DESCRIPTION
It looks like you've already taken two of @chrisc36's changes, so all I have to offer is this one. There are two key changes in here.

1. Call `trimToSize()` on the TOC Entries, after reading the index. When the index is used for reading, these arrays never grow, so there is no point in having them reserve extra space. Depending on the exact number of documents, the arrays can be 25% bigger than they have to be, which is several hundred megabytes if your corpus is big enough.
2. Use GS Collections instead of Java's built-in ones. They promise the same performance at a lower memory footprint, and in my tests this has been true so far. There is probably a lot more to be gained, since GS Collections has special maps for primitive types, but I was looking for a quick drop-in replacement.

Overall, this saves 7% of memory in our application.