### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/src/main/java/nl/inl/blacklab/search/grouping/HitPropValueInt.java
+++ b/src/main/java/nl/inl/blacklab/search/grouping/HitPropValueInt.java
@@ -24,6 +24,12 @@ public class HitPropValueInt extends HitPropValue {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == null)
+			return false;
+
+		if (this.getClass() != obj.getClass())
+			return false;
+			
 		return value == ((HitPropValueInt)obj).value;
 	}
 

--- a/src/main/java/nl/inl/blacklab/search/grouping/HitPropValueString.java
+++ b/src/main/java/nl/inl/blacklab/search/grouping/HitPropValueString.java
@@ -19,6 +19,12 @@ public class HitPropValueString extends HitPropValue {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == null)
+			return false;
+
+		if (this.getClass() != obj.getClass())
+			return false;
+			
 		return value.equals(((HitPropValueString)obj).value);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “ "equals(Object obj)" should test argument type ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.