### PR TITLE
 Nested "enum"s should not be declared static

### DIFF
--- a/src/main/java/nl/inl/blacklab/highlight/XmlHighlighter.java
+++ b/src/main/java/nl/inl/blacklab/highlight/XmlHighlighter.java
@@ -34,12 +34,12 @@ public class XmlHighlighter {
 	 * an open tag at the beginning for an unmatched closing tag,
 	 * or by removing the unmatched closing tag.
 	 */
-	public static enum UnbalancedTagsStrategy {
+	public enum UnbalancedTagsStrategy {
 		ADD_TAG,
 		REMOVE_TAG
 	}
 
-	static enum TagType {
+	enum TagType {
 		EXISTING_TAG,       // an existing tag
 		HIGHLIGHT_START,    // insert <hl> tag here
 		HIGHLIGHT_END,      // insert </hl> tag here

--- a/src/main/java/nl/inl/blacklab/index/complex/ComplexFieldProperty.java
+++ b/src/main/java/nl/inl/blacklab/index/complex/ComplexFieldProperty.java
@@ -60,7 +60,7 @@ public class ComplexFieldProperty {
 	}
 
 	/** How a property is to be indexed with respect to case and diacritics sensitivity. */
-	public static enum SensitivitySetting {
+	public enum SensitivitySetting {
 		ONLY_SENSITIVE,                 // only index case- and diacritics-sensitively
 		ONLY_INSENSITIVE,               // only index case- and diacritics-insensitively
 		SENSITIVE_AND_INSENSITIVE,      // case+diac sensitive as well as case+diac insensitive

--- a/src/main/java/nl/inl/blacklab/search/TextPatternPositionFilter.java
+++ b/src/main/java/nl/inl/blacklab/search/TextPatternPositionFilter.java
@@ -26,7 +26,7 @@ import nl.inl.blacklab.search.sequences.TextPatternSequence;
 public class TextPatternPositionFilter extends TextPatternCombiner {
 
 	/** The different positional operations */
-	public static enum Operation {
+	public enum Operation {
 
 		/** Producer hit contains filter hit */
 		CONTAINING,

--- a/src/main/java/nl/inl/util/ThreadPriority.java
+++ b/src/main/java/nl/inl/util/ThreadPriority.java
@@ -14,7 +14,7 @@ public class ThreadPriority {
 	/**
 	 * The different priorities a thread can have in our system.
 	 */
-	public static enum Level {
+	public enum Level {
 		PAUSED,
 		RUNNING_LOW_PRIO,
 		RUNNING

--- a/src/main/java/nl/inl/util/XmlUtil.java
+++ b/src/main/java/nl/inl/util/XmlUtil.java
@@ -298,7 +298,7 @@ public class XmlUtil {
 	/**
 	 * States of the xmlToPlainText() state machine
 	 */
-	private static enum XmlToPlainTextState {
+	private enum XmlToPlainTextState {
 
 		/** Copy these characters to the destination */
 		COPY,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2786 - “Nested "enum"s should not be declared static”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2786
Please let me know if you have any questions.
Ayman Abdelghany.