### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/nl/inl/blacklab/index/complex/ComplexFieldUtil.java
+++ b/src/main/java/nl/inl/blacklab/index/complex/ComplexFieldUtil.java
@@ -98,6 +98,9 @@ public class ComplexFieldUtil {
 		LENGTH_TOKENS_BOOKKEEP_NAME
 	);
 
+	private ComplexFieldUtil() {
+	}
+
 	public enum BookkeepFieldType {
 		CONTENT_ID,
 		FORWARD_INDEX_ID,

--- a/src/main/java/nl/inl/blacklab/queryParser/contextql/ContextQlParseUtils.java
+++ b/src/main/java/nl/inl/blacklab/queryParser/contextql/ContextQlParseUtils.java
@@ -17,7 +17,10 @@ import nl.inl.blacklab.search.sequences.TextPatternSequence;
 
 public class ContextQlParseUtils {
 
-    public static CompleteQuery clause(Searcher searcher, String index, String relation, String term, String defaultProperty) {
+	private ContextQlParseUtils() {
+	}
+
+	public static CompleteQuery clause(Searcher searcher, String index, String relation, String term, String defaultProperty) {
         if (relation == null)
             relation = "=";
         if (index == null)

--- a/src/main/java/nl/inl/blacklab/search/grouping/PropValSerializeUtil.java
+++ b/src/main/java/nl/inl/blacklab/search/grouping/PropValSerializeUtil.java
@@ -16,6 +16,9 @@ public class PropValSerializeUtil {
 
 	private final static String MULTIPLE_SEPARATOR_ESC_REGEX = StringUtil.escapeRegexCharacters(MULTIPLE_SEPARATOR);
 
+	private PropValSerializeUtil() {
+	}
+
 	public static String escapePart(String part) {
 		return part.replace("$", "$DL").replace(",", "$CM").replace(":", "$CL");
 	}

--- a/src/main/java/nl/inl/util/ArrayUtil.java
+++ b/src/main/java/nl/inl/util/ArrayUtil.java
@@ -2,6 +2,9 @@ package nl.inl.util;
 
 public class ArrayUtil {
 
+	private ArrayUtil() {
+	}
+
 	/**
 	 * Compare two arrays of ints by comparing each element in succession.
 	 *

--- a/src/main/java/nl/inl/util/ConsoleUtil.java
+++ b/src/main/java/nl/inl/util/ConsoleUtil.java
@@ -28,6 +28,9 @@ public class ConsoleUtil {
 	private static BufferedReader stdinReader = IoUtil
 			.makeBuffered(new InputStreamReader(System.in));
 
+	private ConsoleUtil() {
+	}
+
 	/**
 	 * Prompt the user for a string
 	 *

--- a/src/main/java/nl/inl/util/DateUtil.java
+++ b/src/main/java/nl/inl/util/DateUtil.java
@@ -26,6 +26,9 @@ import java.util.Locale;
  */
 public class DateUtil {
 
+	private DateUtil() {
+	}
+
 	/**
 	 * Parse a date.
 	 *

--- a/src/main/java/nl/inl/util/ExUtil.java
+++ b/src/main/java/nl/inl/util/ExUtil.java
@@ -23,6 +23,9 @@ import java.io.StringWriter;
  */
 public class ExUtil {
 
+	private ExUtil() {
+	}
+
 	/**
 	 * If the supplied exception is not already an instance of RuntimeException, wrap it in a
 	 * RuntimeException object.

--- a/src/main/java/nl/inl/util/IoUtil.java
+++ b/src/main/java/nl/inl/util/IoUtil.java
@@ -26,6 +26,9 @@ import java.io.Reader;
  */
 public class IoUtil {
 
+	private IoUtil() {
+	}
+
 	/**
 	 * Wraps the specified reader in a BufferedReader for efficient and convenient access.
 	 *

--- a/src/main/java/nl/inl/util/LocaleUtil.java
+++ b/src/main/java/nl/inl/util/LocaleUtil.java
@@ -34,6 +34,9 @@ public class LocaleUtil {
 	 */
 	private static Locale englishLocale = new Locale("en", "GB");
 
+	private LocaleUtil() {
+	}
+
 	/**
 	 * Get the dutch locale
 	 *

--- a/src/main/java/nl/inl/util/LogUtil.java
+++ b/src/main/java/nl/inl/util/LogUtil.java
@@ -33,6 +33,9 @@ public class LogUtil {
 	/** Has log4j been initialised? */
 	private static boolean log4jInitialized = false;
 
+	private LogUtil() {
+	}
+
 	/**
 	 * Initialize the log4j library, according to the specified properties file found somewhere on
 	 * the classpath.

--- a/src/main/java/nl/inl/util/LuceneUtil.java
+++ b/src/main/java/nl/inl/util/LuceneUtil.java
@@ -28,6 +28,9 @@ import org.apache.lucene.util.BytesRef;
 
 public class LuceneUtil {
 
+	private LuceneUtil() {
+	}
+
 	/**
 	 * Test if a term occurs in the index
 	 * @param reader the index

--- a/src/main/java/nl/inl/util/MemoryUtil.java
+++ b/src/main/java/nl/inl/util/MemoryUtil.java
@@ -22,6 +22,9 @@ public class MemoryUtil {
 	/** Handle to interface with the Java VM environment */
 	private static Runtime runtime = Runtime.getRuntime();
 
+	private MemoryUtil() {
+	}
+
 	/**
 	 * Returns the amount of memory that can still be allocated before we get the OutOfMemory
 	 * exception.

--- a/src/main/java/nl/inl/util/NetUtil.java
+++ b/src/main/java/nl/inl/util/NetUtil.java
@@ -26,6 +26,9 @@ public class NetUtil {
 	/** The default encoding to use in networking (as recommended by W3C) */
 	private static String defaultEncoding = "utf-8";
 
+	private NetUtil() {
+	}
+
 	/**
 	 * Get the default encoding to use in networking
 	 *

--- a/src/main/java/nl/inl/util/OsUtil.java
+++ b/src/main/java/nl/inl/util/OsUtil.java
@@ -22,6 +22,9 @@ import java.lang.management.RuntimeMXBean;
  * OS-specific utilities
  */
 public class OsUtil {
+	private OsUtil() {
+	}
+
 	/**
 	 * Are we running on windows?
 	 *

--- a/src/main/java/nl/inl/util/PropertiesUtil.java
+++ b/src/main/java/nl/inl/util/PropertiesUtil.java
@@ -28,6 +28,9 @@ import java.util.Properties;
  */
 public class PropertiesUtil {
 
+	private PropertiesUtil() {
+	}
+
 	/**
 	 * Read Properties from the specified file
 	 *

--- a/src/main/java/nl/inl/util/StringUtil.java
+++ b/src/main/java/nl/inl/util/StringUtil.java
@@ -73,6 +73,9 @@ public class StringUtil {
 
 	private static Collator englishInsensitiveCollator;
 
+	private StringUtil() {
+	}
+
 	/**
 	 * Replaces space with non-breaking space so the browser doesn't word-wrap
 	 *

--- a/src/main/java/nl/inl/util/TimeUtil.java
+++ b/src/main/java/nl/inl/util/TimeUtil.java
@@ -17,6 +17,9 @@ package nl.inl.util;
 
 public class TimeUtil {
 
+	private TimeUtil() {
+	}
+
 	public static double secondsSince(long startTime) {
 		return (System.currentTimeMillis() - startTime) / 1000.0;
 	}

--- a/src/main/java/nl/inl/util/Utilities.java
+++ b/src/main/java/nl/inl/util/Utilities.java
@@ -34,6 +34,9 @@ import nl.inl.util.FileUtil.FileTask;
  */
 public class Utilities {
 
+	private Utilities() {
+	}
+
 	/**
 	 * Removes temporary test directories that may be left over from previous test
 	 * runs because of memory mapping file locking on Windows.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.