### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/nl/inl/blacklab/filter/AbstractSynonymFilter.java
+++ b/src/main/java/nl/inl/blacklab/filter/AbstractSynonymFilter.java
@@ -127,7 +127,7 @@ public abstract class AbstractSynonymFilter extends TokenFilter {
 		// we may have to loop to the first synonym. See end of loop.
 		do {
 			// Do we have any synonyms left?
-			if (synonymStack.size() > 0) {
+			if (!synonymStack.isEmpty()) {
 				// Yes, shift one in.
 				State syn = synonymStack.pop();
 				restoreState(syn);

--- a/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
+++ b/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
@@ -552,7 +552,7 @@ class ForwardIndexImplV3 extends ForwardIndex {
 		// (always, unless we found an exact-fitting gap)
 		if (addNewEntry) {
 			// See if there's an unused entry
-			TocEntry smallestFreeEntry = deletedTocEntries.size() == 0 ? null : deletedTocEntries.get(0);
+			TocEntry smallestFreeEntry = deletedTocEntries.isEmpty() ? null : deletedTocEntries.get(0);
 			if (smallestFreeEntry != null && smallestFreeEntry.length == 0) {
 				// Yes; re-use
 				deletedTocEntries.remove(0);

--- a/src/main/java/nl/inl/blacklab/highlight/XmlHighlighter.java
+++ b/src/main/java/nl/inl/blacklab/highlight/XmlHighlighter.java
@@ -370,7 +370,7 @@ public class XmlHighlighter {
 			} else {
 				// Close tag. Did we encounter a matching open tag?
 				TagLocation openTag = null;
-				if (openTagStack.size() > 0) {
+				if (!openTagStack.isEmpty()) {
 					// Yes, this tag is matched. Find matching tag and link them.
 					openTag = openTagStack.remove(openTagStack.size() - 1);
 					openTag.name = null; // no longer necessary to remember tag name

--- a/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
+++ b/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
@@ -548,7 +548,7 @@ public abstract class DocIndexerXmlHandlers extends DocIndexerAbstract {
 					.append("=\"").append(value).append("\"");
 		}
 		// Append any namespace mapping not yet outputted
-		if (outputPrefixMapping.size() > 0) {
+		if (!outputPrefixMapping.isEmpty()) {
 			for (Map.Entry<String, String> e : outputPrefixMapping.entrySet()) {
 				if (e.getKey().length() == 0)
 					elementBuilder.append(" xmlns=\"").append(e.getValue())

--- a/src/main/java/nl/inl/blacklab/index/HookableSaxHandler.java
+++ b/src/main/java/nl/inl/blacklab/index/HookableSaxHandler.java
@@ -185,7 +185,7 @@ public class HookableSaxHandler extends DefaultHandler {
 
 		public void startElement(String localName) {
 			// Should we start a new matcher here?
-			if ((elementNames.size() == 0 || localName.equals(elementNames.get(0)))
+			if ((elementNames.isEmpty() || localName.equals(elementNames.get(0)))
 					&& (isRelativePath || depth == 0)) {
 				// Yes, start a new matcher
 				matchers.add(new ExprMatcher());

--- a/src/main/java/nl/inl/blacklab/search/Hits.java
+++ b/src/main/java/nl/inl/blacklab/search/Hits.java
@@ -1566,7 +1566,7 @@ public class Hits extends AbstractList<Hit> {
 			hitsInSameDoc.add(hit);
 			index++;
 		}
-		if (hitsInSameDoc.size() > 0)
+		if (!hitsInSameDoc.isEmpty())
 			findPartOfContext(hitsInSameDoc, index - hitsInSameDoc.size(), fis);
 
 		currentContextSize = desiredContextSize;
@@ -1899,12 +1899,12 @@ public class Hits extends AbstractList<Hit> {
 	synchronized void makeKwicsSingleDocForwardIndex(ForwardIndex forwardIndex,
 			ForwardIndex punctForwardIndex, Map<String, ForwardIndex> attrForwardIndices,
 			int wordsAroundHit, Map<Hit, Kwic> kwics) {
-		if (hits.size() == 0)
+		if (hits.isEmpty())
 			return;
 
 		// Save existing context so we can restore it afterwards
 		int[][] oldContexts = null;
-		if (hits.size() > 0 && contexts != null)
+		if (!hits.isEmpty() && contexts != null)
 			oldContexts = saveContexts();
 
 		// TODO: more efficient to get all contexts with one getContextWords() call!
@@ -2108,7 +2108,7 @@ public class Hits extends AbstractList<Hit> {
 	 */
 	private synchronized void makeConcordancesSingleDocContentStore(String fieldName, int wordsAroundHit, Map<Hit, Concordance> conc,
 			XmlHighlighter hl) {
-		if (hits.size() == 0)
+		if (hits.isEmpty())
 			return;
 		int doc = hits.get(0).doc;
 		int arrayLength = hits.size() * 2;

--- a/src/main/java/nl/inl/blacklab/search/Kwic.java
+++ b/src/main/java/nl/inl/blacklab/search/Kwic.java
@@ -187,7 +187,7 @@ public class Kwic {
 	public Concordance toConcordance() {
 		String[] conc = new String[3];
 		List<String> match = getMatch();
-		String addPunctAfter = match.size() > 0 ? match.get(0) : "";
+		String addPunctAfter = !match.isEmpty() ? match.get(0) : "";
 		conc[0] = xmlString(getLeft(), addPunctAfter, true);
 		conc[1] = xmlString(match, null, true);
 		conc[2] = xmlString(getRight(), null, false);

--- a/src/main/java/nl/inl/blacklab/search/TextPatternAndNot.java
+++ b/src/main/java/nl/inl/blacklab/search/TextPatternAndNot.java
@@ -72,16 +72,16 @@ public class TextPatternAndNot extends TextPattern {
 		for (TextPattern cl : exclude) {
 			chResultsNot.add(cl.translate(translator, context));
 		}
-		if (chResults.size() == 1 && chResultsNot.size() == 0) {
+		if (chResults.size() == 1 && chResultsNot.isEmpty()) {
 			// Single positive clause
 			return chResults.get(0);
-		} else if (chResults.size() == 0) {
+		} else if (chResults.isEmpty()) {
 			// All negative clauses, so it's really just a NOT query. Should've been rewritten, but ok.
 			return translator.not(context, translator.and(context, chResultsNot));
 		}
 		// Combination of positive and possibly negative clauses
 		T include = chResults.size() == 1 ? chResults.get(0) : translator.and(context, chResults);
-		if (chResultsNot.size() == 0)
+		if (chResultsNot.isEmpty())
 			return include;
 		T exclude = chResultsNot.size() == 1 ? chResultsNot.get(0) : translator.and(context, chResultsNot);
 		return translator.andNot(context, include, exclude);
@@ -104,7 +104,7 @@ public class TextPatternAndNot extends TextPattern {
 
 	@Override
 	public TextPattern inverted() {
-		if (exclude.size() == 0) {
+		if (exclude.isEmpty()) {
 			// In this case, it's better to just wrap this in TextPatternNot,
 			// so it will be recognized by other rewrite()s.
 			return super.inverted();
@@ -125,12 +125,12 @@ public class TextPatternAndNot extends TextPattern {
 	@Override
 	protected boolean okayToInvertForOptimization() {
 		// Inverting is "free" if it will still be an AND NOT query (i.e. will have a positive component).
-		return producesSingleTokens() && exclude.size() > 0;
+		return producesSingleTokens() && !exclude.isEmpty();
 	}
 
 	@Override
 	public boolean isSingleTokenNot() {
-		return producesSingleTokens() && include.size() == 0;
+		return producesSingleTokens() && include.isEmpty();
 	}
 
 	@Override
@@ -175,7 +175,7 @@ public class TextPatternAndNot extends TextPattern {
 			isNot = true;
 		}
 
-		if (rewrittenCl.size() == 0) {
+		if (rewrittenCl.isEmpty()) {
 			// All-negative; node should be rewritten to OR.
 			if (rewrittenNotCl.size() == 1)
 				return rewrittenCl.get(0).inverted();
@@ -202,21 +202,21 @@ public class TextPatternAndNot extends TextPattern {
 
 	@Override
 	public boolean hasConstantLength() {
-		if (include.size() == 0)
+		if (include.isEmpty())
 			return true;
 		return include.get(0).hasConstantLength();
 	}
 
 	@Override
 	public int getMinLength() {
-		if (include.size() == 0)
+		if (include.isEmpty())
 			return 1;
 		return include.get(0).getMinLength();
 	}
 
 	@Override
 	public int getMaxLength() {
-		if (include.size() == 0)
+		if (include.isEmpty())
 			return 1;
 		return include.get(0).getMaxLength();
 	}
@@ -228,7 +228,7 @@ public class TextPatternAndNot extends TextPattern {
 
 	@Override
 	public String toString(QueryExecutionContext context) {
-		if (exclude.size() == 0)
+		if (exclude.isEmpty())
 			return "AND(" + clausesToString(include, context) + ")";
 		return "ANDNOT([" + clausesToString(include, context) + "], [" + clausesToString(exclude, context) + "])";
 	}

--- a/src/main/java/nl/inl/blacklab/search/TextPatternBoolean.java
+++ b/src/main/java/nl/inl/blacklab/search/TextPatternBoolean.java
@@ -52,14 +52,14 @@ public class TextPatternBoolean extends TextPattern {
 
 		// MUST and SHOULD
 		TextPattern tpMust = null, tpShould = null;
-		if (must.size() > 0) {
+		if (!must.isEmpty()) {
 			// Build a TextPattern that combines all MUST queries with AND
 			if (must.size() == 1)
 				tpMust = must.get(0);
 			else
 				tpMust = new TextPatternDocLevelAnd(must.toArray(new TextPattern[0]));
 		}
-		if (should.size() > 0) {
+		if (!should.isEmpty()) {
 			if (should.size() == 1)
 				tpShould = should.get(0);
 			else {
@@ -77,7 +77,7 @@ public class TextPatternBoolean extends TextPattern {
 		}
 
 		// MUST NOT
-		if (mustNot.size() > 0) {
+		if (!mustNot.isEmpty()) {
 			// Build a TextPattern that combines all MUST NOT queries with AND
 			translated = new TextPatternDocLevelAndNot(translated, new TextPatternDocLevelAnd(
 					mustNot.toArray(new TextPattern[0])));

--- a/src/main/java/nl/inl/blacklab/search/TextPatternTags.java
+++ b/src/main/java/nl/inl/blacklab/search/TextPatternTags.java
@@ -83,7 +83,7 @@ public class TextPatternTags extends TextPattern {
 
 	@Override
 	public String toString(QueryExecutionContext context) {
-		if (attr != null && attr.size() > 0)
+		if (attr != null && !attr.isEmpty())
 			return "TAGS(" + elementName + ", " + StringUtil.join(attr) + ")";
 		return "TAGS(" + elementName + ")";
 	}

--- a/src/main/java/nl/inl/blacklab/search/TextPatternTranslatorString.java
+++ b/src/main/java/nl/inl/blacklab/search/TextPatternTranslatorString.java
@@ -65,7 +65,7 @@ public class TextPatternTranslatorString extends TextPatternTranslator<String> {
 
 	@Override
 	public String tags(QueryExecutionContext context, String elementName, Map<String, String> attr) {
-		if (attr != null && attr.size() > 0)
+		if (attr != null && !attr.isEmpty())
 			return "TAGS(" + elementName + ", " + StringUtil.join(attr) + ")";
 		return "TAGS(" + elementName + ")";
 	}

--- a/src/main/java/nl/inl/blacklab/search/indexstructure/IndexStructure.java
+++ b/src/main/java/nl/inl/blacklab/search/indexstructure/IndexStructure.java
@@ -730,7 +730,7 @@ public class IndexStructure {
 					fieldsFound.add(e.getKey());
 			}
 		}
-		if (fieldsFound.size() == 0)
+		if (fieldsFound.isEmpty())
 			return null;
 
 		// Sort (so we get titleLevel1 not titleLevel2 for example)

--- a/src/main/java/nl/inl/blacklab/search/lucene/BLSpanOrQuery.java
+++ b/src/main/java/nl/inl/blacklab/search/lucene/BLSpanOrQuery.java
@@ -170,7 +170,7 @@ public class BLSpanOrQuery extends SpanOrQuery {
 				}
 			}
 		}
-		if (subSpans.size() == 0)
+		if (subSpans.isEmpty())
 			return null;
 		else if (subSpans.size() == 1)
 			return BLSpansWrapper.optWrap(subSpans.get(0));

--- a/src/main/java/nl/inl/blacklab/search/lucene/SpansTags.java
+++ b/src/main/java/nl/inl/blacklab/search/lucene/SpansTags.java
@@ -181,7 +181,7 @@ class SpansTags extends BLSpans {
 		for (Integer tag: startsAndEnds) {
 			if (tag > 0) {
 				int startPositionToStore = tag - 2;  // subtract 2 again to get original position (see above)
-				if (emptyElementIndices.size() > 0) {
+				if (!emptyElementIndices.isEmpty()) {
 					// We have an unmatched close tag, probably an empty element between tokens (see below).
 					// Is this the corresponding start tag?
 					int index = emptyElementIndices.remove(emptyElementIndices.size() - 1);
@@ -200,7 +200,7 @@ class SpansTags extends BLSpans {
 			} else {
 				// Close tag. Are there unmatched open tags?
 				int endPositionToStore = -tag - 2 + 1; // subtract 2 and add 1 to let it point to the next token again (see above)
-				if (unmatchedOpenTagIndices.size() == 0) {
+				if (unmatchedOpenTagIndices.isEmpty()) {
 					// No. This must be an empty element between two tokens. Because we don't know the
 					// relative order of tags between tokens (this information is not in the index),
 					// our sort messes this up.
@@ -215,10 +215,10 @@ class SpansTags extends BLSpans {
 				}
 			}
 		}
-		if (unmatchedOpenTagIndices.size() > 0) {
+		if (!unmatchedOpenTagIndices.isEmpty()) {
 			throw new RuntimeException("Unmatched open tags left for document");
 		}
-		if (emptyElementIndices.size() > 0) {
+		if (!emptyElementIndices.isEmpty()) {
 			throw new RuntimeException("Unmatched close tag left for document");
 		}
 	}

--- a/src/main/java/nl/inl/blacklab/search/lucene/TextPatternTranslatorSpanQuery.java
+++ b/src/main/java/nl/inl/blacklab/search/lucene/TextPatternTranslatorSpanQuery.java
@@ -87,7 +87,7 @@ public class TextPatternTranslatorSpanQuery extends TextPatternTranslator<SpanQu
 			// Older index, with end tags stored in separate property
 			allTags = new SpanQueryTagsOld(context, elementName);
 		}
-		if (attr == null || attr.size() == 0)
+		if (attr == null || attr.isEmpty())
 			return allTags;
 
 		// Construct attribute filters

--- a/src/main/java/nl/inl/blacklab/search/sequences/SpansInBucketsPerStartPoint.java
+++ b/src/main/java/nl/inl/blacklab/search/sequences/SpansInBucketsPerStartPoint.java
@@ -189,7 +189,7 @@ class SpansInBucketsPerStartPoint extends DocIdSetIterator implements SpansInBuc
 
 	@Override
 	public void getCapturedGroups(int indexInBucket, Span[] capturedGroups) {
-		if (!doCapturedGroups || capturedGroupsPerEndpoint.size() == 0)
+		if (!doCapturedGroups || capturedGroupsPerEndpoint.isEmpty())
 			return;
 		Span[] previouslyCapturedGroups = capturedGroupsPerEndpoint.get(indexInBucket);
 		if (previouslyCapturedGroups != null) {

--- a/src/main/java/nl/inl/blacklab/search/sequences/TextPatternSequence.java
+++ b/src/main/java/nl/inl/blacklab/search/sequences/TextPatternSequence.java
@@ -39,7 +39,7 @@ public class TextPatternSequence extends TextPatternAndNot {
 
 	@Override
 	public <T> T translate(TextPatternTranslator<T> translator, QueryExecutionContext context) {
-		if (exclude.size() > 0)
+		if (!exclude.isEmpty())
 			throw new RuntimeException("clausesNot not empty!");
 
 		List<T> chResults = new ArrayList<>();
@@ -152,7 +152,7 @@ public class TextPatternSequence extends TextPatternAndNot {
 
 	@Override
 	public TextPattern rewrite() {
-		if (exclude.size() > 0)
+		if (!exclude.isEmpty())
 			throw new RuntimeException("clausesNot not empty!");
 
 		boolean anyRewritten = false;
@@ -269,7 +269,7 @@ public class TextPatternSequence extends TextPatternAndNot {
 			TextPattern combined = child;
 			while (true) {
 				// Do we have a previous part?
-				previousPart = seqCombined.size() == 0 ? null : seqCombined.get(seqCombined.size() - 1);
+				previousPart = seqCombined.isEmpty() ? null : seqCombined.get(seqCombined.size() - 1);
 				if (previousPart == null)
 					break;
 				// Yes, try to combine with it.

--- a/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -205,7 +205,7 @@ public class IndexTool {
 		}
 		System.out.println(op + " index in " + indexDir + File.separator + " from " + inputDir + strGlob + " ("
 				+ docFormat + ")");
-		if (indexerParam.size() > 0) {
+		if (!indexerParam.isEmpty()) {
 			System.out.println("Indexer parameters:");
 			for (Map.Entry<String,String> e: indexerParam.entrySet()) {
 				System.out.println("  " + e.getKey() + ": " + e.getValue());

--- a/src/main/java/nl/inl/util/SimpleResourcePool.java
+++ b/src/main/java/nl/inl/util/SimpleResourcePool.java
@@ -91,7 +91,7 @@ public abstract class SimpleResourcePool<T> {
 	 */
 	public synchronized T acquire() {
 		try {
-			if (neverPool || freePool.size() == 0) {
+			if (neverPool || freePool.isEmpty()) {
 				return createResource();
 			}
 			return freePool.remove(0);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.