### PR TITLE
Only create a new payload array if already present for an annotation

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -403,7 +403,9 @@ public class AnnotationWriter {
 //        } else {
             values = new ArrayList<>();
             increments = new IntArrayList();
-            payloads = new ArrayList<>();
+            if (payloads != null) {
+                payloads = new ArrayList<>();
+            }
 //        }
     }
 


### PR DESCRIPTION
I was getting an exception on indexing:

```
An error occurred during indexing!
error: java.util.NoSuchElementException (in /input/blacklab.xml)
nl.inl.blacklab.exceptions.BlackLabRuntimeException: java.util.NoSuchElementException
	at nl.inl.blacklab.exceptions.BlackLabRuntimeException.wrap(BlackLabRuntimeException.java:14)
	at nl.inl.blacklab.indexers.config.DocIndexerBase.endDocument(DocIndexerBase.java:456)
	at nl.inl.blacklab.indexers.config.DocIndexerXPath.indexDocument(DocIndexerXPath.java:227)
	at nl.inl.blacklab.indexers.config.DocIndexerXPath.index(DocIndexerXPath.java:194)
	at nl.inl.blacklab.index.IndexerImpl$DocIndexerWrapper.impl(IndexerImpl.java:114)
	at nl.inl.blacklab.index.IndexerImpl$DocIndexerWrapper.file(IndexerImpl.java:91)
	at nl.inl.util.FileProcessor.lambda$processInputStream$4(FileProcessor.java:417)
	at nl.inl.util.FileProcessor.lambda$makeRunnable$6(FileProcessor.java:517)
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1626)
	at nl.inl.util.MainThreadExecutorService.execute(MainThreadExecutorService.java:66)
	at java.util.concurrent.CompletableFuture.asyncRunStage(CompletableFuture.java:1640)
	at java.util.concurrent.CompletableFuture.runAsync(CompletableFuture.java:1858)
	at nl.inl.util.FileProcessor.processInputStream(FileProcessor.java:417)
	at nl.inl.util.FileProcessor.processFile(FileProcessor.java:382)
	at nl.inl.util.FileProcessor.processFile(FileProcessor.java:379)
	at nl.inl.blacklab.index.IndexerImpl.index(IndexerImpl.java:591)
	at nl.inl.blacklab.tools.IndexTool.main(IndexTool.java:288)
Caused by: java.util.NoSuchElementException
	at java.util.ArrayList$Itr.next(ArrayList.java:854)
	at nl.inl.blacklab.index.annotated.TokenStreamFromList.incrementToken(TokenStreamFromList.java:84)
	at nl.inl.blacklab.analysis.DesensitizeFilter.incrementToken(DesensitizeFilter.java:57)
	at org.apache.lucene.index.DefaultIndexingChain$PerField.invert(DefaultIndexingChain.java:634)
	at org.apache.lucene.index.DefaultIndexingChain.processField(DefaultIndexingChain.java:365)
	at org.apache.lucene.index.DefaultIndexingChain.processDocument(DefaultIndexingChain.java:321)
	at org.apache.lucene.index.DocumentsWriterPerThread.updateDocument(DocumentsWriterPerThread.java:234)
	at org.apache.lucene.index.DocumentsWriter.updateDocument(DocumentsWriter.java:450)
	at org.apache.lucene.index.IndexWriter.updateDocument(IndexWriter.java:1477)
	at org.apache.lucene.index.IndexWriter.addDocument(IndexWriter.java:1256)
	at nl.inl.blacklab.index.IndexerImpl.add(IndexerImpl.java:504)
	at nl.inl.blacklab.indexers.config.DocIndexerBase.endDocument(DocIndexerBase.java:454)
	... 15 more
```

This appeared to be caused by the payload list being erroneously recreated by the `AnnotationWriter`'s clear method. This PR fixes that.

I'm still very new to this codebase, so feel free to ignore/amend as necessary.
