### PR TITLE
Capture groups

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/results/HitsFromQueryParallel.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitsFromQueryParallel.java
@@ -161,6 +161,10 @@ public class HitsFromQueryParallel extends Hits {
             currentSpansReader = null;
             itSpansReader = spansReaders.iterator();
             hitIndexInCurrentSpansReader = -1;
+
+            if (hitQueryContext.numberOfCapturedGroups() > 0) {
+                capturedGroups = new CapturedGroupsImpl(hitQueryContext.getCapturedGroupNames());
+            }
         } catch (IOException e) {
             throw BlackLabRuntimeException.wrap(e);
         }
@@ -228,6 +232,7 @@ public class HitsFromQueryParallel extends Hits {
                     // Get the next hit from the spans, moving to the next
                     // segment when necessary.
                     Hit hit = null;
+                    Span[] capturedGroupsForHit = null;
                     while (true) {
                         
                         if (currentSpansReader == null) {
@@ -254,6 +259,9 @@ public class HitsFromQueryParallel extends Hits {
                         } else {
                             // We're at the next hit
                             hit = spansResults.get(hitIndexInCurrentSpansReader);
+                            if (currentSpansReader.capturedGroups != null) {
+                                capturedGroupsForHit = currentSpansReader.capturedGroups.get(hit);
+                            }
                             break;
                         }
                     }
@@ -272,10 +280,8 @@ public class HitsFromQueryParallel extends Hits {
                         previousHitDoc = hit.doc();
                     }
                     if (!maxHitsProcessed) {
-                        if (capturedGroups != null) {
-                            Span[] groups = new Span[hitQueryContext.numberOfCapturedGroups()];
-                            hitQueryContext.getCapturedGroups(groups);
-                            capturedGroups.put(hit, groups);
+                        if (capturedGroups != null && capturedGroupsForHit != null) {
+                            capturedGroups.put(hit, capturedGroupsForHit);
                         }
                         results.add(hit);
                         if (maxHitsToProcess >= 0 && results.size() >= maxHitsToProcess) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -34,6 +34,7 @@ import nl.inl.blacklab.search.results.QueryInfo;
 import nl.inl.blacklab.search.results.ResultCount;
 import nl.inl.blacklab.search.results.Results;
 import nl.inl.blacklab.search.results.ResultsStats;
+import nl.inl.blacklab.search.Span;
 import nl.inl.blacklab.search.textpattern.TextPattern;
 import nl.inl.blacklab.server.BlackLabServer;
 import nl.inl.blacklab.server.datastream.DataStream;
@@ -235,6 +236,21 @@ public class RequestHandlerHits extends RequestHandler {
             ds.entry("docPid", pid);
             ds.entry("start", hit.start());
             ds.entry("end", hit.end());
+
+            if (window.hasCapturedGroups()) {
+                Map<String, Span> capturedGroups = window.capturedGroups().getMap(hit);
+                ds.startEntry("captureGroups").startList();
+
+                for (Map.Entry<String, Span> capturedGroup : capturedGroups.entrySet()) {
+                    ds.startEntry("group");
+                    ds.entry("name", capturedGroup.getKey());
+                    ds.entry("start", capturedGroup.getValue().start());
+                    ds.entry("end", capturedGroup.getValue().end());
+                    ds.endEntry();
+                }
+
+                ds.endList().endEntry();
+            }
 
             if (contextSettings.concType() == ConcordanceType.CONTENT_STORE) {
                 // Add concordance from original XML


### PR DESCRIPTION
This PR includes two fixes:

1. Adds support for capture groups to `HitsFromQueryParallel` by collecting them from the `SpansReader` objects.

1. Add captured groups to BL server output.