### PR TITLE
Thread captured groups through in grouped queries

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/results/HitGroup.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitGroup.java
@@ -29,8 +29,8 @@ public class HitGroup extends Group<Hit> {
         return new HitGroup(queryInfo, groupIdentity, totalSize);
     }
 
-    public static HitGroup fromList(QueryInfo queryInfo, PropertyValue groupIdentity, List<Hit> storedResults, int totalSize) {
-        return new HitGroup(queryInfo, groupIdentity, storedResults, totalSize);
+    public static HitGroup fromList(QueryInfo queryInfo, PropertyValue groupIdentity, List<Hit> storedResults, CapturedGroups capturedGroups, int totalSize) {
+        return new HitGroup(queryInfo, groupIdentity, storedResults, capturedGroups, totalSize);
     }
 
     public static HitGroup fromHits(PropertyValue groupIdentity, Hits storedResults, int totalSize) {
@@ -48,10 +48,11 @@ public class HitGroup extends Group<Hit> {
      *
      * @param queryInfo query info
      * @param storedResults the hits we actually stored
+     * @param capturedGroups captured groups for hits in this group
      * @param totalSize total group size
      */
-    protected HitGroup(QueryInfo queryInfo, PropertyValue groupIdentity, List<Hit> storedResults, int totalSize) {
-        super(groupIdentity, Hits.fromList(queryInfo, storedResults), totalSize);
+    protected HitGroup(QueryInfo queryInfo, PropertyValue groupIdentity, List<Hit> storedResults, CapturedGroups capturedGroups, int totalSize) {
+        super(groupIdentity, Hits.fromList(queryInfo, storedResults, capturedGroups), totalSize);
     }
 
     /**

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitGroups.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitGroups.java
@@ -128,8 +128,15 @@ public class HitGroups extends Results<HitGroup> implements ResultGroups<Hit> {
         for (Map.Entry<PropertyValue, List<Hit>> e : groupLists.entrySet()) {
             PropertyValue groupId = e.getKey();
             List<Hit> hitList = e.getValue();
+            CapturedGroupsImpl capturedGroups = null;
+            if (hits.capturedGroups() != null) {
+                capturedGroups = new CapturedGroupsImpl(hits.capturedGroups().names());
+                for (Hit hit : hitList) {
+                    capturedGroups.put(hit, hits.capturedGroups().get(hit));
+                }
+            }
             Integer groupSize = groupSizes.get(groupId);
-            HitGroup group = HitGroup.fromList(queryInfo(), groupId, hitList, groupSize);
+            HitGroup group = HitGroup.fromList(queryInfo(), groupId, hitList, capturedGroups, groupSize);
             groups.put(groupId, group);
             results.add(group);
         }

--- a/core/src/main/java/nl/inl/blacklab/search/results/Hits.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/Hits.java
@@ -53,6 +53,20 @@ public abstract class Hits extends Results<Hit> {
     /**
      * Make a wrapper Hits object for a list of Hit objects.
      *
+     * Does not copy the list, but reuses it.
+     *
+     * @param queryInfo information about the original query
+     * @param hits the list of hits to wrap, or null for empty Hits object
+     * @param capturedGroups the list of hits to wrap, or null for no captured groups
+     * @return hits found
+     */
+    public static Hits fromList(QueryInfo queryInfo, List<Hit> hits, CapturedGroups capturedGroups) {
+        return new HitsList(queryInfo, hits, capturedGroups);
+    }
+
+    /**
+     * Make a wrapper Hits object for a list of Hit objects.
+     *
      * Will create Hit objects from the arrays. Mainly useful for testing.
      * 
      * @param queryInfo information about the original query

--- a/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/HitsList.java
@@ -42,7 +42,21 @@ public class HitsList extends Hits {
             }
         }
     }
-    
+
+    /**
+     * Make a wrapper Hits object for a list of Hit objects.
+     *
+     * Does not copy the list, but reuses it.
+     *
+     * @param queryInfo query info
+     * @param hits the list of hits to wrap, or null for a new list
+     * @param capturedGroups the list of hits to wrap, or null for no captured groups
+     */
+    protected HitsList(QueryInfo queryInfo, List<Hit> hits, CapturedGroups capturedGroups) {
+        this(queryInfo, hits);
+        this.capturedGroups = (CapturedGroupsImpl) capturedGroups;
+    }
+
     /**
      * Create a list of hits from three arrays.
      *


### PR DESCRIPTION
Related to #89, I noticed that capture groups weren't being displayed when viewing grouped results. This PR threads them through in `HitGroups` so they get displayed.