### PR TITLE
Null guards for missing capture groups

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
@@ -69,6 +69,8 @@ public class CapturedGroupsImpl implements CapturedGroups {
         Map<String, Span> result = new TreeMap<>(); // TreeMap to maintain group ordering
         List<String> names = names();
         Span[] groups = capturedGroups.get(hit);
+        if (groups == null)
+            return null;
         for (int i = 0; i < names.size(); i++) {
             result.put(names.get(i), groups[i]);
         }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -245,11 +245,13 @@ public class RequestHandlerHits extends RequestHandler {
                 ds.startEntry("captureGroups").startList();
 
                 for (Map.Entry<String, Span> capturedGroup : capturedGroups.entrySet()) {
-                    ds.startItem("group").startMap();
-                    ds.entry("name", capturedGroup.getKey());
-                    ds.entry("start", capturedGroup.getValue().start());
-                    ds.entry("end", capturedGroup.getValue().end());
-                    ds.endMap().endItem();
+                    if (capturedGroup.getValue() != null) {
+                        ds.startItem("group").startMap();
+                        ds.entry("name", capturedGroup.getKey());
+                        ds.entry("start", capturedGroup.getValue().start());
+                        ds.entry("end", capturedGroup.getValue().end());
+                        ds.endMap().endItem();
+                    }
                 }
 
                 ds.endList().endEntry();


### PR DESCRIPTION
When a user writes a query with a capture group that may optionally no content (e.g. `foo:(["bar"]*)`), a null `Span` is returned, which was causing an NPE. This PR introduces null guards to handle that case.