### PR TITLE
Surface insufficient memory exceptions

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import nl.inl.blacklab.exceptions.InsufficientMemoryAvailable;
 import nl.inl.blacklab.exceptions.InterruptedSearch;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.server.config.BLSConfig;
@@ -276,6 +277,8 @@ public class BlackLabServer extends HttpServlet {
                 httpCode = Response.error(es, e.getBlsErrorCode(), e.getMessage(), e.getHttpStatusCode());
             } catch (InterruptedSearch e) {
                 httpCode = Response.error(es, "INTERRUPTED", "Search was interrupted", HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            } catch (InsufficientMemoryAvailable e) {
+                httpCode = Response.error(es, "INSUFFICIENT_MEMORY", e.getMessage(), HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             } catch (RuntimeException e) {
                 httpCode = Response.internalError(es, e, debugMode, "INTERR_HANDLING_REQUEST");
             } finally {


### PR DESCRIPTION
This allowed us to report memory errors to the user for easier diagnosing of the problem.