### PR TITLE
Fix NPE from a rewritten OR query with a null field

### DIFF
--- a/core/src/main/java/nl/inl/blacklab/search/lucene/BLSpanOrQuery.java
+++ b/core/src/main/java/nl/inl/blacklab/search/lucene/BLSpanOrQuery.java
@@ -199,6 +199,7 @@ public final class BLSpanOrQuery extends BLSpanQuery {
             BLSpanOrQuery result = new BLSpanOrQuery(rewrittenCl.toArray(new BLSpanQuery[0]));
             result.setHitsAreFixedLength(fixedHitLength);
             result.setClausesAreSimpleTermsInSameProperty(clausesAreSimpleTermsInSameProperty);
+            result.setField(getRealField());
             return result;
         }
 


### PR DESCRIPTION
We were seeing an NPE when running queries on very small (one-document) corpora. Sadly I went on vacation and misplaced the stack trace, but this change fixed it.