### PR TITLE
Indexing performance

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -438,13 +438,12 @@
             <artifactId>Saxon-HE</artifactId>
             <version>9.9.1-5</version>
         </dependency>
-          <!-- https://mvnrepository.com/artifact/com.googlecode.juniversalchardet/juniversalchardet -->
         <dependency>
-            <groupId>com.googlecode.juniversalchardet</groupId>
+            <groupId>com.github.albfernandez</groupId>
             <artifactId>juniversalchardet</artifactId>
-            <version>1.0.3</version>
+            <version>2.3.2</version>
         </dependency>
-
+        
     </dependencies>
 
     <reporting>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -429,6 +429,13 @@
             <artifactId>vtd-xml</artifactId>
             <version>2.13.4</version>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/com.googlecode.juniversalchardet/juniversalchardet -->
+        <dependency>
+            <groupId>com.googlecode.juniversalchardet</groupId>
+            <artifactId>juniversalchardet</artifactId>
+            <version>1.0.3</version>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStore.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStore.java
@@ -72,7 +72,7 @@ public abstract class ContentStore {
      */
     public abstract int store(String content);
 
-    public abstract int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs);
+    public abstract int store(byte[] content, int offset, int length, Charset cs);
     
     
     /**
@@ -85,7 +85,7 @@ public abstract class ContentStore {
      */
     public abstract void storePart(String content);
     
-    public abstract void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs); 
+    public abstract void storePart(byte[] content, int offset, int length, Charset cs); 
 
     /**
      * Retrieve a document from the content store.

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStore.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStore.java
@@ -72,6 +72,9 @@ public abstract class ContentStore {
      */
     public abstract int store(String content);
 
+    public abstract int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs);
+    
+    
     /**
      * Store part of a large document.
      *
@@ -81,6 +84,8 @@ public abstract class ContentStore {
      * @param content part of the content of the document to store
      */
     public abstract void storePart(String content);
+    
+    public abstract void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs); 
 
     /**
      * Retrieve a document from the content store.

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
@@ -24,9 +24,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.IntBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -474,6 +477,10 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
         currentBlockContents.append(contentPart);
     }
 
+    public void addToBlock(char[] contentPart, int start, int length) {
+        currentBlockContents.append(contentPart);
+    }
+
     /**
      * Encode and write the block we've compiled so far and reset for next block
      * 
@@ -563,6 +570,34 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
         }
     }
 
+    @Override
+    public void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+        if (documentLengthBytes <= 0)
+            return;
+        if (blockOffsetWhileStoring.isEmpty())
+            blockOffsetWhileStoring.add(0); // first offset is always 0
+
+        OutputStream os = openCurrentStoreFile();
+
+        CharsetDecoder cd = cs.newDecoder();
+        ByteBuffer in = ByteBuffer.wrap(inputDocument, documentByteOffset, documentLengthBytes);
+        CharBuffer out = CharBuffer.allocate(newEntryBlockSizeCharacters);
+        while (in.remaining() > 0) {
+            int charsLeftInCurrentBlock = (blockOffsetWhileStoring.size()*newEntryBlockSizeCharacters) - charsFromEntryWritten;
+            out.limit(charsLeftInCurrentBlock);
+        
+            cd.decode(in, out, true);
+            addToBlock(out.array(), 0, out.length());
+            charsFromEntryWritten += out.length();
+            out.position(0);
+
+            if ((charsFromEntryWritten % newEntryBlockSizeCharacters) == 0) {
+                writeCurrentBlock(os);
+                blockOffsetWhileStoring.add(bytesWritten);
+            }
+        }
+    }
+
     /**
      * Convert the String representation of a block to a byte buffer
      *
@@ -594,6 +629,16 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
     @Override
     public synchronized int store(String content) {
         storePart(content);
+        return store();
+    }
+
+    @Override
+    public int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+        storePart(inputDocument, documentByteOffset, documentLengthBytes, cs);
+        return store();
+    }
+
+    private int store() {
         if (currentBlockContents.length() > 0) {
             // Write the last (not completely full) block
             OutputStream os = openCurrentStoreFile();

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
@@ -587,8 +587,8 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
             out.limit(charsLeftInCurrentBlock);
         
             cd.decode(in, out, true);
-            addToBlock(out.array(), 0, out.length());
-            charsFromEntryWritten += out.length();
+            addToBlock(out.array(), 0, out.position());
+            charsFromEntryWritten += out.position();
             out.position(0);
 
             if ((charsFromEntryWritten % newEntryBlockSizeCharacters) == 0) {

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
@@ -575,8 +575,8 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
     }
 
     @Override
-    public void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
-        if (documentLengthBytes <= 0)
+    public void storePart(byte[] content, int offset, int length, Charset cs) {
+        if (length <= 0)
             return;
         if (blockOffsetWhileStoring.isEmpty())
             blockOffsetWhileStoring.add(0); // first offset is always 0
@@ -584,7 +584,7 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
         OutputStream os = openCurrentStoreFile();
 
         CharsetDecoder cd = cs.newDecoder();
-        ByteBuffer in = ByteBuffer.wrap(inputDocument, documentByteOffset, documentLengthBytes);
+        ByteBuffer in = ByteBuffer.wrap(content, offset, length);
         CharBuffer out = CharBuffer.allocate(newEntryBlockSizeCharacters);
         while (in.remaining() > 0) {
             int charsLeftInCurrentBlock = (blockOffsetWhileStoring.size() * newEntryBlockSizeCharacters) - charsFromEntryWritten;
@@ -637,8 +637,8 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
     }
 
     @Override
-    public int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
-        storePart(inputDocument, documentByteOffset, documentLengthBytes, cs);
+    public int store(byte[] content, int offset, int length, Charset cs) {
+        storePart(content, offset, length, cs);
         return store();
     }
 

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
@@ -256,14 +256,18 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
 
     /**
      * What block size to use when adding a new document to the content store.
-     * Contributing factors for choosing block size: - larger blocks improve
-     * compression ratio - larger blocks decrease number of blocks you have to read
-     * - smaller blocks decrease the decompression time - smaller blocks increase
-     * the chance that we only have to read one disk block for a single concordance
-     * (disk blocks are generally 2 or 4K) - consider OS I/O caching and memory
-     * mapping. Then it becomes the difference between reading a few bytes from
+     * Contributing factors for choosing block size:
+     * 
+     * <ul>
+     * <li>larger blocks improve compression ratio</li>
+     * <li>larger blocks decrease number of blocks you have to read</li>
+     * <li>smaller blocks decrease the decompression time</li>
+     * <li>smaller blocks increase the chance that we only have to read 
+     * one disk block for a single concordance (disk blocks are generally 2 or 4K)</li>
+     * <li>consider OS I/O caching and memory mapping. Then it becomes the difference between reading a few bytes from
      * memory and reading a few kilobytes and decompressing them. Right now, making
-     * concordances is often CPU-bound (because of decompression?)
+     * concordances is often CPU-bound (because of decompression?)</li>
+     * </ul>
      */
     protected int newEntryBlockSizeCharacters = 4000;
 
@@ -583,7 +587,7 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
         ByteBuffer in = ByteBuffer.wrap(inputDocument, documentByteOffset, documentLengthBytes);
         CharBuffer out = CharBuffer.allocate(newEntryBlockSizeCharacters);
         while (in.remaining() > 0) {
-            int charsLeftInCurrentBlock = (blockOffsetWhileStoring.size()*newEntryBlockSizeCharacters) - charsFromEntryWritten;
+            int charsLeftInCurrentBlock = (blockOffsetWhileStoring.size() * newEntryBlockSizeCharacters) - charsFromEntryWritten;
             out.limit(charsLeftInCurrentBlock);
         
             cd.decode(in, out, true);

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreDirUtf8.java
@@ -478,7 +478,7 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
     }
 
     public void addToBlock(char[] contentPart, int start, int length) {
-        currentBlockContents.append(contentPart);
+        currentBlockContents.append(contentPart, start, length);
     }
 
     /**

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
@@ -239,7 +239,7 @@ public class ContentStoreFixedBlockReader extends ContentStoreFixedBlock {
     }
 
     @Override
-    public int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+    public int store(byte[] content, int offset, int length, Charset cs) {
         throw new UnsupportedOperationException("Not supported if not in index mode");
     }
 
@@ -249,7 +249,7 @@ public class ContentStoreFixedBlockReader extends ContentStoreFixedBlock {
     }
     
     @Override
-    public void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+    public void storePart(byte[] content, int offset, int length, Charset cs) {
         throw new UnsupportedOperationException("Not supported if not in index mode");
     }
 

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
@@ -22,6 +22,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.charset.Charset;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
@@ -238,7 +239,17 @@ public class ContentStoreFixedBlockReader extends ContentStoreFixedBlock {
     }
 
     @Override
+    public int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+        throw new UnsupportedOperationException("Not supported if not in index mode");
+    }
+
+    @Override
     public void storePart(String content) {
+        throw new UnsupportedOperationException("Not supported if not in index mode");
+    }
+    
+    @Override
+    public void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
         throw new UnsupportedOperationException("Not supported if not in index mode");
     }
 

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
@@ -356,7 +356,7 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
         CharBuffer out = CharBuffer.allocate(1024);
         while (in.hasRemaining()) {
             cd.decode(in, out, true);
-            unwrittenContents.append(out.array(), 0, out.length());
+            unwrittenContents.append(out.array(), 0, out.position());
             out.position(0);
         } 
         writeBlocks(false);

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
@@ -109,7 +109,7 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
     /** Contents still waiting to be written to the contents file in blocks */
     StringBuilder unwrittenContents = new StringBuilder(BLOCK_SIZE_BYTES * 10);
     
-    /** Character index in unwrittenContents */
+    /** Index of the first unwritten character in unwrittenContents */
     protected int unwrittenIndex = 0;
 
     /**  unwritten content buffer is not flushed immediately after writing, as that is very slow in some situations (large documents in particular) */
@@ -258,7 +258,8 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
         ensureContentsFileOpen();
 
         // Do we have a block to write?
-        while (writeLastBlock && getUnwrittenCharCount() > 0 || getUnwrittenCharCount() >= WRITE_BLOCK_WHEN_CHARACTERS_AVAILABLE) {
+        while (writeLastBlock && getUnwrittenCharCount() > 0 
+                || getUnwrittenCharCount() >= WRITE_BLOCK_WHEN_CHARACTERS_AVAILABLE) {
             int offsetBefore = unwrittenIndex;
             byte[] encoded = encodeBlock(); // encode a number of characters to produce a 4K block
             int offsetAfter = unwrittenIndex;

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
@@ -108,7 +108,8 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
 
     /** Contents still waiting to be written to the contents file in blocks */
     StringBuilder unwrittenContents = new StringBuilder(BLOCK_SIZE_BYTES * 10);
-    /** Byte index in unwrittenContents */
+    
+    /** Character index in unwrittenContents */
     protected int unwrittenIndex = 0;
 
     /**  unwritten content buffer is not flushed immediately after writing, as that is very slow in some situations (large documents in particular) */
@@ -257,7 +258,7 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
         ensureContentsFileOpen();
 
         // Do we have a block to write?
-        while (writeLastBlock && getUnwrittenByteCount() > 0 || getUnwrittenByteCount() >= WRITE_BLOCK_WHEN_CHARACTERS_AVAILABLE) {
+        while (writeLastBlock && getUnwrittenCharCount() > 0 || getUnwrittenCharCount() >= WRITE_BLOCK_WHEN_CHARACTERS_AVAILABLE) {
             int offsetBefore = unwrittenIndex;
             byte[] encoded = encodeBlock(); // encode a number of characters to produce a 4K block
             int offsetAfter = unwrittenIndex;
@@ -275,13 +276,13 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
         }
 
         // Free memory
-        if (unwrittenIndex > 0 && getUnwrittenByteCount() == 0) {
+        if (unwrittenIndex > 0 && getUnwrittenCharCount() == 0) {
             this.unwrittenContents = new StringBuilder(BLOCK_SIZE_BYTES*10);
             unwrittenIndex = 0;
         }
     }
 
-    private int getUnwrittenByteCount() {
+    private int getUnwrittenCharCount() {
         return this.unwrittenContents.length() - this.unwrittenIndex;
     }
 
@@ -395,7 +396,7 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
     
     /** The store routine (after appending to unwrittenContents) */
     private int store() {
-        if (getUnwrittenByteCount() > 0) {
+        if (getUnwrittenCharCount() > 0) {
             // Write the last (not completely full) block
             writeBlocks(true);
         }
@@ -482,7 +483,7 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
     protected byte[] encodeBlock() {
 
         int length = TYPICAL_BLOCK_SIZE_CHARACTERS;
-        int available = getUnwrittenByteCount();
+        int available = getUnwrittenCharCount();
         if (length > available)
             length = available;
 

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
@@ -342,19 +342,18 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
      * store chunks of content, but MUST be *finished* by calling the "normal"
      * store() method. You may call store() with the empty string if you wish.
      *  
-     * @param inputDocument the content of the document
-     * @param documentByteOffset byte offset to begin storing
-     * @param documentLengthBytes length of the data to store 
+     * @param content content to store
+     * @param offset byte offset to begin storing
+     * @param length number of bytes to store 
      * @param cs the charset the document is in. Required to convert the bytes to their proper characters.
      */
     @Override
-    public synchronized void storePart(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
-        if (documentLengthBytes == 0) {
+    public synchronized void storePart(byte[] content, int offset, int length, Charset cs) {
+        if (length == 0) {
             return;
         }
-        
         CharsetDecoder cd = cs.newDecoder();
-        ByteBuffer in = ByteBuffer.wrap(inputDocument, documentByteOffset, documentLengthBytes);
+        ByteBuffer in = ByteBuffer.wrap(content, offset, length);
         CharBuffer out = CharBuffer.allocate(1024);
         while (in.hasRemaining()) {
             cd.decode(in, out, true);
@@ -364,11 +363,13 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
         writeBlocks(false);
     }
 
-    
-    
     /**
      * Store the given content and assign an id to it.
-     * If you are not already working with a string, consider using {@link #storePart(byte[], int, int, Charset)} instead,
+     * 
+     * Parts of the document may already have been stored before. This is the final part and will
+     * assign and return the document's content id. 
+     *
+     * NOTE: If you are not already working with a string, consider using {@link #storePart(byte[], int, int, Charset)} instead,
      * as it will prevent having to make a temporary string copy of your data just for the store procedure. 
      *
      * @param content the content to store
@@ -382,16 +383,19 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
     
     /**
      * Store the given content and assign an id to it.
+     * 
+     * Parts of the document may already have been stored before. This is the final part and will
+     * assign and return the document's content id. 
      *
-     * @param inputDocument the content of the document
-     * @param documentByteOffset byte offset to begin storing
-     * @param documentLengthBytes length of the data to store 
+     * @param content the content of the document
+     * @param offset byte offset to begin storing
+     * @param length number of bytes to store 
      * @param cs the charset the document is in. Required to convert the bytes to their proper characters.
-     * @return the id assigned to the content
+     * @return the id assigned to the document
      */
     @Override
-    public synchronized int store(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
-        storePart(inputDocument, documentByteOffset, documentLengthBytes, cs);
+    public synchronized int store(byte[] content, int offset, int length, Charset cs) {
+        storePart(content, offset, length, cs);
         return store();
     }
     

--- a/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
+++ b/core/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockWriter.java
@@ -276,8 +276,8 @@ public class ContentStoreFixedBlockWriter extends ContentStoreFixedBlock {
             }
         }
 
-        // Free memory
-        if (unwrittenIndex > 0 && getUnwrittenCharCount() == 0) {
+        // Free memory if unwrittenContents gets too large
+        if (getUnwrittenCharCount() == 0 && unwrittenContents.capacity() >= MAX_UNWRITTEN_INDEX) {
             this.unwrittenContents = new StringBuilder(BLOCK_SIZE_BYTES*10);
             unwrittenIndex = 0;
         }

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexer.java
@@ -144,6 +144,7 @@ public abstract class DocIndexer implements AutoCloseable {
     }
 
     /**
+     * @deprecated use {@link #setDocument(byte[], Charset)}
      * Set the document to index.
      *
      * NOTE: you should generally prefer calling the File or byte[] versions of this
@@ -152,14 +153,17 @@ public abstract class DocIndexer implements AutoCloseable {
      *
      * @param reader document
      */
+    @Deprecated
     public abstract void setDocument(Reader reader);
 
     /**
+     * @deprecated use {@link #setDocument(byte[], Charset)}
      * Set the document to index.
      *
      * @param is document contents
      * @param cs charset to use if no BOM found, or null for the default (utf-8)
      */
+    @Deprecated
     public void setDocument(InputStream is, Charset cs) {
         try {
             UnicodeStream unicodeStream = new UnicodeStream(is, cs);
@@ -171,6 +175,7 @@ public abstract class DocIndexer implements AutoCloseable {
     }
 
     /**
+     * 
      * Set the document to index.
      *
      * @param contents document contents
@@ -181,6 +186,7 @@ public abstract class DocIndexer implements AutoCloseable {
     }
 
     /**
+     * @deprecated use {@link #setDocument(byte[], Charset)}
      * Set the document to index.
      *
      * @param file file to index
@@ -188,6 +194,7 @@ public abstract class DocIndexer implements AutoCloseable {
      *            (utf-8)
      * @throws FileNotFoundException if not found
      */
+    @Deprecated
     public void setDocument(File file, Charset charset) throws FileNotFoundException {
         setDocument(new FileInputStream(file), charset);
     }

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexer.java
@@ -157,13 +157,11 @@ public abstract class DocIndexer implements AutoCloseable {
     public abstract void setDocument(Reader reader);
 
     /**
-     * @deprecated use {@link #setDocument(byte[], Charset)}
      * Set the document to index.
      *
      * @param is document contents
      * @param cs charset to use if no BOM found, or null for the default (utf-8)
      */
-    @Deprecated
     public void setDocument(InputStream is, Charset cs) {
         try {
             UnicodeStream unicodeStream = new UnicodeStream(is, cs);
@@ -186,7 +184,6 @@ public abstract class DocIndexer implements AutoCloseable {
     }
 
     /**
-     * @deprecated use {@link #setDocument(byte[], Charset)}
      * Set the document to index.
      *
      * @param file file to index
@@ -194,7 +191,6 @@ public abstract class DocIndexer implements AutoCloseable {
      *            (utf-8)
      * @throws FileNotFoundException if not found
      */
-    @Deprecated
     public void setDocument(File file, Charset charset) throws FileNotFoundException {
         setDocument(new FileInputStream(file), charset);
     }

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactory.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactory.java
@@ -153,7 +153,6 @@ public interface DocIndexerFactory {
             throws UnsupportedOperationException;
 
     /**
-     * @Deprecated (since 2.0) use byte[] version
      * Instantiating a DocIndexer from an input stream.
      *
      * @param formatIdentifier the formatIdentifier for the document
@@ -166,12 +165,10 @@ public interface DocIndexerFactory {
      *             formatIdentifier (use
      *             {@link DocIndexerFactory#isSupported(String)})
      */
-    @Deprecated
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is, Charset cs)
             throws UnsupportedOperationException;
 
     /**
-     * @Deprecated (since 2.0) use byte[] version
      * Instantiating a DocIndexer from a file.
      *
      * @param formatIdentifier the formatIdentifier for the document
@@ -185,7 +182,6 @@ public interface DocIndexerFactory {
      *             formatIdentifier (use
      *             {@link DocIndexerFactory#isSupported(String)})
      */
-    @Deprecated
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws UnsupportedOperationException, FileNotFoundException;
 

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactory.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactory.java
@@ -136,6 +136,7 @@ public interface DocIndexerFactory {
     Format getFormat(String formatIdentifier);
 
     /**
+     * @Deprecated (since 2.0) use byte[] version
      * Instantiating a DocIndexer from a reader.
      *
      * @param formatIdentifier the formatIdentifier for the document
@@ -147,10 +148,12 @@ public interface DocIndexerFactory {
      *             formatIdentifier (use
      *             {@link DocIndexerFactory#isSupported(String)})
      */
+    @Deprecated
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader)
             throws UnsupportedOperationException;
 
     /**
+     * @Deprecated (since 2.0) use byte[] version
      * Instantiating a DocIndexer from an input stream.
      *
      * @param formatIdentifier the formatIdentifier for the document
@@ -163,10 +166,12 @@ public interface DocIndexerFactory {
      *             formatIdentifier (use
      *             {@link DocIndexerFactory#isSupported(String)})
      */
+    @Deprecated
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is, Charset cs)
             throws UnsupportedOperationException;
 
     /**
+     * @Deprecated (since 2.0) use byte[] version
      * Instantiating a DocIndexer from a file.
      *
      * @param formatIdentifier the formatIdentifier for the document
@@ -180,6 +185,7 @@ public interface DocIndexerFactory {
      *             formatIdentifier (use
      *             {@link DocIndexerFactory#isSupported(String)})
      */
+    @Deprecated
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws UnsupportedOperationException, FileNotFoundException;
 
@@ -199,8 +205,6 @@ public interface DocIndexerFactory {
     DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, byte[] b, Charset cs)
             throws UnsupportedOperationException;
 
-
-    
     /**
      * If this format exists but has an error, return the error.
      * 

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryClass.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryClass.java
@@ -155,7 +155,6 @@ public class DocIndexerFactoryClass implements DocIndexerFactory {
     }
 
     @Override
-    @Deprecated
     public DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is, Charset cs) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier
@@ -185,7 +184,6 @@ public class DocIndexerFactoryClass implements DocIndexerFactory {
     }
 
     @Override
-    @Deprecated
     public DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryClass.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryClass.java
@@ -121,6 +121,7 @@ public class DocIndexerFactoryClass implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier
@@ -154,6 +155,7 @@ public class DocIndexerFactoryClass implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is, Charset cs) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier
@@ -183,6 +185,7 @@ public class DocIndexerFactoryClass implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryConfig.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryConfig.java
@@ -235,8 +235,6 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
         } catch (InvalidInputFormatConfig | IOException e) {
             formatErrors.put(formatIdentifier, e.getMessage());
             throw e;
-//            //e.printStackTrace(); // TODO: don't sweep this error under the rug please!
-//            return Optional.empty();
         }
     }
 
@@ -257,6 +255,7 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexerConfig get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader) {
         if (!isSupported(formatIdentifier))
             throw new UnsupportedOperationException("Unknown format '" + formatIdentifier
@@ -270,6 +269,7 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexerConfig get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is,
             Charset cs) {
         if (!isSupported(formatIdentifier))
@@ -284,6 +284,7 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
     }
 
     @Override
+    @Deprecated
     public DocIndexerConfig get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws FileNotFoundException {
         if (!isSupported(formatIdentifier))

--- a/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryConfig.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocIndexerFactoryConfig.java
@@ -269,7 +269,6 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
     }
 
     @Override
-    @Deprecated
     public DocIndexerConfig get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is,
             Charset cs) {
         if (!isSupported(formatIdentifier))
@@ -284,7 +283,6 @@ public class DocIndexerFactoryConfig implements DocIndexerFactory {
     }
 
     @Override
-    @Deprecated
     public DocIndexerConfig get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws FileNotFoundException {
         if (!isSupported(formatIdentifier))

--- a/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
@@ -156,10 +156,18 @@ public class DocumentFormats {
     }
 
     /**
-     * @deprecated (since 2.0) use byte[] version 
-     * Convenience function. 
+     * Convenience function.
+     *  
      * Note that it is usually faster to offer the document as byte[] and charset, 
      * because that allows the buffer to be passed on without copying. 
+     * 
+     * @param formatIdentifier format to get the DocIndexer for
+     * @param indexer our indexer
+     * @param documentName document name
+     * @param reader file contents
+     * @return the DocIndexer
+     * @throws UnsupportedOperationException 
+     * @deprecated (since 2.2) use byte[] version 
      */
     @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader)
@@ -169,12 +177,19 @@ public class DocumentFormats {
     }
 
     /** 
-     * @deprecated (since 2.0) use byte[] version 
-     * Convenience function. 
+     * Convenience function.
+     * 
      * Note that it is usually faster to offer the document as byte[] and charset, 
-     * because that allows the buffer to be passed on without copying. 
+     * because that allows the buffer to be passed on without copying.
+     * 
+     * @param formatIdentifier format to get the DocIndexer for
+     * @param indexer our indexer
+     * @param documentName document name
+     * @param is contents
+     * @param cs file encoding
+     * @return the DocIndexer
+     * @throws UnsupportedOperationException 
      */
-    @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is,
             Charset cs)
             throws UnsupportedOperationException {
@@ -182,18 +197,33 @@ public class DocumentFormats {
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, is, cs) : null;
     }
 
-    /**
-     * @deprecated (since 2.0) use byte[] version 
-     * Convenience function. 
+    /** Convenience function.
+     * 
+     * @param formatIdentifier format to get the DocIndexer for
+     * @param indexer our indexer
+     * @param documentName document name
+     * @param f file
+     * @param cs file encoding
+     * @return the DocIndexer
+     * @throws UnsupportedOperationException 
+     * @throws FileNotFoundException 
      */
-    @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws UnsupportedOperationException, FileNotFoundException {
         DocIndexerFactory fac = getFactory(formatIdentifier);
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, f, cs) : null;
     }
 
-    /** Convenience function. */
+    /** Convenience function.
+     * 
+     * @param formatIdentifier format to get the DocIndexer for
+     * @param indexer our indexer
+     * @param documentName document name
+     * @param b file contents
+     * @param cs file encoding
+     * @return the DocIndexer
+     * @throws UnsupportedOperationException 
+     */
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, byte[] b, Charset cs)
             throws UnsupportedOperationException {
         DocIndexerFactory fac = getFactory(formatIdentifier);

--- a/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
@@ -155,11 +155,13 @@ public class DocumentFormats {
         return factory != null ? factory.getFormat(formatIdentifier) : null;
     }
 
-    /** 
+    /**
+     * @deprecated (since 2.0) use byte[] version 
      * Convenience function. 
      * Note that it is usually faster to offer the document as byte[] and charset, 
      * because that allows the buffer to be passed on without copying. 
      */
+    @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader)
             throws UnsupportedOperationException {
         DocIndexerFactory fac = getFactory(formatIdentifier);
@@ -167,10 +169,12 @@ public class DocumentFormats {
     }
 
     /** 
+     * @deprecated (since 2.0) use byte[] version 
      * Convenience function. 
      * Note that it is usually faster to offer the document as byte[] and charset, 
      * because that allows the buffer to be passed on without copying. 
      */
+    @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is,
             Charset cs)
             throws UnsupportedOperationException {
@@ -178,7 +182,11 @@ public class DocumentFormats {
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, is, cs) : null;
     }
 
-    /** Convenience function. */
+    /**
+     * @deprecated (since 2.0) use byte[] version 
+     * Convenience function. 
+     */
+    @Deprecated
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws UnsupportedOperationException, FileNotFoundException {
         DocIndexerFactory fac = getFactory(formatIdentifier);

--- a/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
+++ b/core/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
@@ -155,14 +155,22 @@ public class DocumentFormats {
         return factory != null ? factory.getFormat(formatIdentifier) : null;
     }
 
-    // Convenience
+    /** 
+     * Convenience function. 
+     * Note that it is usually faster to offer the document as byte[] and charset, 
+     * because that allows the buffer to be passed on without copying. 
+     */
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, Reader reader)
             throws UnsupportedOperationException {
         DocIndexerFactory fac = getFactory(formatIdentifier);
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, reader) : null;
     }
 
-    // Convenience
+    /** 
+     * Convenience function. 
+     * Note that it is usually faster to offer the document as byte[] and charset, 
+     * because that allows the buffer to be passed on without copying. 
+     */
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, InputStream is,
             Charset cs)
             throws UnsupportedOperationException {
@@ -170,14 +178,14 @@ public class DocumentFormats {
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, is, cs) : null;
     }
 
-    // Convenience
+    /** Convenience function. */
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, File f, Charset cs)
             throws UnsupportedOperationException, FileNotFoundException {
         DocIndexerFactory fac = getFactory(formatIdentifier);
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, f, cs) : null;
     }
 
-    // Convenience
+    /** Convenience function. */
     public static DocIndexer get(String formatIdentifier, DocWriter indexer, String documentName, byte[] b, Charset cs)
             throws UnsupportedOperationException {
         DocIndexerFactory fac = getFactory(formatIdentifier);

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.lucene.document.Document;
@@ -141,14 +142,17 @@ public interface Indexer {
     void update(Term term, Document document) throws IOException;
 
     /**
+     * @deprecated (since 2.0)
      * Index a document or archive from an InputStream.
      *
      * @param documentName name for the InputStream (e.g. name of the file)
      * @param input the stream
      */
+    @Deprecated
     void index(String documentName, InputStream input);
 
     /**
+     * @deprecated (sinced 2.0)
      * Index a document from a Reader.
      *
      * NOTE: it is generally better to supply an (UTF-8) InputStream or byte array
@@ -165,9 +169,11 @@ public interface Indexer {
      * @throws MalformedInputFile if the input file was invalid
      * @throws PluginException if an error in a plugin occurred
      */
+    @Deprecated
     void index(String documentName, Reader reader) throws IOException, MalformedInputFile, PluginException;
 
     /**
+     * @deprecated (since 2.0)
      * Index a document (or archive if enabled by
      * {@link #setProcessArchivesAsDirectories(boolean)}
      *
@@ -175,33 +181,40 @@ public interface Indexer {
      * @param input
      * @param fileNameGlob
      */
+    @Deprecated
     void index(String fileName, InputStream input, String fileNameGlob);
 
-    /**
-     * Index the file or directory specified.
-     *
-     * Indexes all files in a directory or archive (previously only indexed *.xml;
-     * specify a glob if you want this behaviour back, see
-     * {@link #index(File, String)}.
-     *
-     * Recurses into subdirs only if that setting is enabled.
-     *
-     * @param file the input file or directory
-     */
-    void index(File file);
     
-    void index(String fileName, byte[] contents);
-
-    /**
-     * Index a document, archive (if enabled by
-     * {@link #setProcessArchivesAsDirectories(boolean)}, or directory, optionally
-     * recursively if set by {@link #setRecurseSubdirs(boolean)}
-     *
-     * @param file
-     * @param fileNameGlob only files
+    /** 
+     * Index a file or archive of files from memory.
+     * 
+     * @param fileName name of the file including extension. Used to detect archives/file types.
+     * @param contents file contents
+     * @param fileNameGlob 
+     *  Only used if this file is determined to be an archive. Only process files matching the glob.
      */
-    // TODO this is nearly a literal copy of index for a stream, unify them somehow (take care that file might be a directory)
-    void index(File file, String fileNameGlob);
+    void index(String fileName, byte[] contents, Optional<String> fileNameGlob);
+    /** 
+     * Index a file or archive of files from memory.
+     * 
+     * @param fileName name of the file including extension. Used to detect archives/file types.
+     * @param contents file contents 
+     */
+    default void index(String fileName, byte[] contents) { index(fileName, contents, Optional.empty()); }
+    /** 
+     * Index a file, archive of files, or directory.
+     * 
+     * @param file the file    
+     * @param fileNameGlob 
+     *  Only used if this file is a directory or is determined to be an archive or directory. Only processes files matching the glob.
+     */
+    void index(File file, Optional<String> fileNameGlob);
+    /** 
+     * Index a file, archive of files, or directory.
+     * 
+     * @param file the file    
+     */
+    default void index(File file) { index(file, Optional.empty()); }
 
     /**
      * Get our index directory

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -8,7 +8,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.lucene.document.Document;
@@ -184,6 +183,21 @@ public interface Indexer {
     @Deprecated
     void index(String fileName, InputStream input, String fileNameGlob);
 
+    /** 
+     * Index a file, archive of files, or directory.
+     * 
+     * @param file the file    
+     */
+    default void index(File file) { index(file, null); }
+
+    /** 
+     * Index a file, archive of files, or directory.
+     * 
+     * @param file the file    
+     * @param fileNameGlob 
+     *  Only used if this file is a directory or is determined to be an archive or directory. Only processes files matching the glob.
+     */
+    void index(File file, String fileNameGlob);
     
     /** 
      * Index a file or archive of files from memory.
@@ -193,29 +207,16 @@ public interface Indexer {
      * @param fileNameGlob 
      *  Only used if this file is determined to be an archive. Only process files matching the glob.
      */
-    void index(String fileName, byte[] contents, Optional<String> fileNameGlob);
+    void index(String fileName, byte[] contents, String fileNameGlob);
+    
     /** 
      * Index a file or archive of files from memory.
      * 
      * @param fileName name of the file including extension. Used to detect archives/file types.
      * @param contents file contents 
      */
-    default void index(String fileName, byte[] contents) { index(fileName, contents, Optional.empty()); }
-    /** 
-     * Index a file, archive of files, or directory.
-     * 
-     * @param file the file    
-     * @param fileNameGlob 
-     *  Only used if this file is a directory or is determined to be an archive or directory. Only processes files matching the glob.
-     */
-    void index(File file, Optional<String> fileNameGlob);
-    /** 
-     * Index a file, archive of files, or directory.
-     * 
-     * @param file the file    
-     */
-    default void index(File file) { index(file, Optional.empty()); }
-
+    default void index(String fileName, byte[] contents) { index(fileName, contents, null); }
+    
     /**
      * Get our index directory
      *

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -149,33 +149,33 @@ public interface Indexer {
     void index(String documentName, InputStream input);
 
     /**
-     * @deprecated (sinced 2.0)
+     * @deprecated (since 2.2)
      * Index a document from a Reader.
      *
      * NOTE: it is generally better to supply an (UTF-8) InputStream or byte array
      * directly, as this can in some cases be parsed more efficiently (e.g. using
      * VTD-XML).
      *
-     * Catches and reports any errors that occur.
+     * Catches and reports any errors that occur to the IndexListener.
      *
      * @param documentName some (preferably unique) name for this document (for
      *            example, the file name or path)
      * @param reader where to index from
      *
-     * @throws IOException if an I/O error occurred
-     * @throws MalformedInputFile if the input file was invalid
-     * @throws PluginException if an error in a plugin occurred
      */
     @Deprecated
-    void index(String documentName, Reader reader) throws IOException, MalformedInputFile, PluginException;
+    void index(String documentName, Reader reader);
 
     /**
      * Index a document (or archive if enabled by
      * {@link #setProcessArchivesAsDirectories(boolean)}
+     * 
+     * Catches and reports any errors that occur to the IndexListener.  
      *
      * @param fileName
      * @param input
      * @param fileNameGlob
+     * Only used if this file is a directory or is determined to be an archive. Only process files matching the glob.
      */
     void index(String fileName, InputStream input, String fileNameGlob);
 
@@ -199,18 +199,18 @@ public interface Indexer {
      *
      * @param file
      * @param fileNameGlob 
-     *  Only used if this file is a directory or is determined to be an archive or directory. Only processes files matching the glob.
+     * Only used if this file is a directory or is determined to be an archive. Only process files matching the glob.
      */
     void index(File file, String fileNameGlob);
     
     /** 
      * Index a file or archive of files from memory.
+     * Encoding is guessed based on file contents.
      * 
      * @param fileName name of the file including extension. Used to detect archives/file types.
      * @param contents file contents
      * @param fileNameGlob 
-     *  Only used if this file is determined to be an archive. Only process files matching the glob.
-     */
+     * Only used if this file is a directory or is determined to be an archive. Only process files matching the glob.     */
     void index(String fileName, byte[] contents, String fileNameGlob);
     
     /** 

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -15,8 +15,6 @@ import org.apache.lucene.index.Term;
 
 import nl.inl.blacklab.exceptions.DocumentFormatNotFound;
 import nl.inl.blacklab.exceptions.ErrorOpeningIndex;
-import nl.inl.blacklab.exceptions.MalformedInputFile;
-import nl.inl.blacklab.exceptions.PluginException;
 import nl.inl.blacklab.search.BlackLabIndexWriter;
 
 public interface Indexer {

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -189,6 +189,8 @@ public interface Indexer {
      * @param file the input file or directory
      */
     void index(File file);
+    
+    void index(String fileName, byte[] contents);
 
     /**
      * Index a document, archive (if enabled by

--- a/core/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/core/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -141,13 +141,11 @@ public interface Indexer {
     void update(Term term, Document document) throws IOException;
 
     /**
-     * @deprecated (since 2.0)
      * Index a document or archive from an InputStream.
      *
      * @param documentName name for the InputStream (e.g. name of the file)
      * @param input the stream
      */
-    @Deprecated
     void index(String documentName, InputStream input);
 
     /**
@@ -172,7 +170,6 @@ public interface Indexer {
     void index(String documentName, Reader reader) throws IOException, MalformedInputFile, PluginException;
 
     /**
-     * @deprecated (since 2.0)
      * Index a document (or archive if enabled by
      * {@link #setProcessArchivesAsDirectories(boolean)}
      *
@@ -180,20 +177,27 @@ public interface Indexer {
      * @param input
      * @param fileNameGlob
      */
-    @Deprecated
     void index(String fileName, InputStream input, String fileNameGlob);
 
-    /** 
-     * Index a file, archive of files, or directory.
-     * 
-     * @param file the file    
+    /**
+     * Index the file or directory specified.
+     *
+     * Indexes all files in a directory or archive (previously only indexed *.xml;
+     * specify a glob if you want this behaviour back, see
+     * {@link #index(File, String)}.
+     *
+     * Recurses into subdirs only if that setting is enabled.
+     *
+     * @param file the input file or directory
      */
     default void index(File file) { index(file, null); }
 
-    /** 
-     * Index a file, archive of files, or directory.
-     * 
-     * @param file the file    
+    /**
+     * Index a document, archive (if enabled by
+     * {@link #setProcessArchivesAsDirectories(boolean)}, or directory, optionally
+     * recursively if set by {@link #setRecurseSubdirs(boolean)}
+     *
+     * @param file
      * @param fileNameGlob 
      *  Only used if this file is a directory or is determined to be an archive or directory. Only processes files matching the glob.
      */

--- a/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -569,7 +568,7 @@ class IndexerImpl implements DocWriter, Indexer {
     	try {
     		index(documentName, IOUtils.toByteArray(reader, DEFAULT_INPUT_ENCODING), null); // convert to our default encoding
     	} catch (IOException e) {
-    		listener().errorOccurred(e, documentName, null);
+    	    listener().errorOccurred(e, documentName, null);
     	}
     }
 

--- a/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -99,15 +99,16 @@ class IndexerImpl implements DocWriter, Indexer {
             if (!indexer.continueIndexing())
                 return;
 
-            // FIXME progress reporting is broken in multithreaded indexing, as the listener is shared between threads
-            // So a docIndexer that didn't index anything can slip through if another thread did index some data in the
-            // meantime
             listener().fileStarted(documentName);
             int docsDoneBefore = indexWriter.writer().numDocs();
             long tokensDoneBefore = listener().getTokensProcessed();
 
             indexer.index();
             listener().fileDone(documentName);
+            
+            // FIXME the following checks are broken in multithreaded indexing, as the listener is shared between threads
+            // So a docIndexer that didn't index anything can slip through if another thread did index some data in the
+            // meantime
             int docsDoneAfter = indexWriter.writer().numDocs();
             if (docsDoneAfter == docsDoneBefore) {
                 logger.warn("No docs found in " + documentName + "; wrong format?");

--- a/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/core/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -566,19 +566,11 @@ class IndexerImpl implements DocWriter, Indexer {
     @Deprecated
     @Override
     public void index(String documentName, Reader reader) {
-        try {
-            index(documentName, IOUtils.toString(reader).getBytes(StandardCharsets.UTF_8));
-        } catch (MalformedInputFile e) {
-            listener().errorOccurred(e, documentName, null);
-            logger.error("Parsing " + documentName + " failed:");
-            e.printStackTrace();
-            logger.error("(continuing indexing)");
-        } catch (Exception e) {
-            listener().errorOccurred(e, documentName, null);
-            logger.error("Parsing " + documentName + " failed:");
-            e.printStackTrace();
-            logger.error("(continuing indexing)");
-        }
+    	try {
+    		index(documentName, IOUtils.toByteArray(reader, DEFAULT_INPUT_ENCODING), null); // convert to our default encoding
+    	} catch (IOException e) {
+    		listener().errorOccurred(e, documentName, null);
+    	}
     }
 
     @Override

--- a/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -491,7 +491,7 @@ public abstract class DocIndexerBase extends DocIndexer {
         currentLuceneDoc.add(new IntField(contentIdFieldName, contentId, Store.YES));
     }
     
-    protected void storeWholeDocument(byte[] inputDocument, int documentByteOffset, int documentLengthBytes, Charset cs) {
+    protected void storeWholeDocument(byte[] content, int offset, int length, Charset cs) {
         // Finish storing the document in the document store,
         // retrieve the content id, and store that in Lucene.
         // (Note that we do this after adding the dummy token, so the character
@@ -513,7 +513,7 @@ public abstract class DocIndexerBase extends DocIndexer {
         int contentId = -1;
         if (docWriter != null) {
             ContentStore contentStore = docWriter.contentStore(contentStoreName);
-            contentId = contentStore.store(inputDocument, documentByteOffset, documentLengthBytes, cs);
+            contentId = contentStore.store(content, offset, length, cs);
         }
         currentLuceneDoc.add(new IntField(contentIdFieldName, contentId, Store.YES));
     }

--- a/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -1,26 +1,5 @@
 package nl.inl.blacklab.indexers.config;
 
-import nl.inl.blacklab.contentstore.ContentStore;
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
-import nl.inl.blacklab.exceptions.InvalidInputFormatConfig;
-import nl.inl.blacklab.exceptions.MalformedInputFile;
-import nl.inl.blacklab.exceptions.MaxDocsReached;
-import nl.inl.blacklab.index.DocIndexer;
-import nl.inl.blacklab.index.DocumentFormats;
-import nl.inl.blacklab.index.DownloadCache;
-import nl.inl.blacklab.index.Indexer;
-import nl.inl.blacklab.index.MetadataFetcher;
-import nl.inl.blacklab.index.annotated.AnnotatedFieldWriter;
-import nl.inl.blacklab.index.annotated.AnnotationWriter;
-import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
-import nl.inl.util.FileProcessor;
-import nl.inl.util.StringUtil;
-import org.apache.commons.io.IOUtils;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
-import org.apache.lucene.util.BytesRef;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -38,6 +17,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.util.BytesRef;
+
+import nl.inl.blacklab.contentstore.ContentStore;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.exceptions.InvalidInputFormatConfig;
+import nl.inl.blacklab.exceptions.MalformedInputFile;
+import nl.inl.blacklab.exceptions.MaxDocsReached;
+import nl.inl.blacklab.index.DocIndexer;
+import nl.inl.blacklab.index.DocumentFormats;
+import nl.inl.blacklab.index.DownloadCache;
+import nl.inl.blacklab.index.Indexer;
+import nl.inl.blacklab.index.MetadataFetcher;
+import nl.inl.blacklab.index.annotated.AnnotatedFieldWriter;
+import nl.inl.blacklab.index.annotated.AnnotationWriter;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
+import nl.inl.util.FileProcessor;
+import nl.inl.util.StringUtil;
 
 public abstract class DocIndexerBase extends DocIndexer {
 
@@ -455,7 +456,7 @@ public abstract class DocIndexerBase extends DocIndexer {
         uniqueStrings.clear();
     }
 
-       /**
+    /**
      * Store the entire document at once.
      *
      * Subclasses that simply capture the entire document can use this in their

--- a/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/core/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
-
 import com.ximpleware.AutoPilot;
 import com.ximpleware.BookMark;
 import com.ximpleware.NavException;
@@ -876,7 +875,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
 
     @Override
     protected void storeDocument() {
-        storeWholeDocument(new String(inputDocument, documentByteOffset, documentLengthBytes, StandardCharsets.UTF_8));
+        storeWholeDocument(inputDocument, documentByteOffset, documentLengthBytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/core/src/main/java/nl/inl/blacklab/indexers/preprocess/DocIndexerConvertAndTag.java
+++ b/core/src/main/java/nl/inl/blacklab/indexers/preprocess/DocIndexerConvertAndTag.java
@@ -117,10 +117,8 @@ public class DocIndexerConvertAndTag extends DocIndexerConfig {
         this.outputIndexer.setDocumentName(this.documentName);
         this.outputIndexer.setConfigInputFormat(config);
 
-        try (InputStream is = new ByteArrayInputStream(output.toByteArray())) {
-            this.outputIndexer.setDocument(is, charset);
-            this.outputIndexer.index();
-        }
+        this.outputIndexer.setDocument(output.toByteArray(), charset);
+        this.outputIndexer.index();
     }
 
     @Override

--- a/core/src/main/java/nl/inl/blacklab/testutil/Example.java
+++ b/core/src/main/java/nl/inl/blacklab/testutil/Example.java
@@ -15,10 +15,8 @@
  *******************************************************************************/
 package nl.inl.blacklab.testutil;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.exceptions.ErrorOpeningIndex;
 import nl.inl.blacklab.exceptions.InvalidQuery;
@@ -96,7 +94,7 @@ public class Example {
         try {
             indexer = Indexer.createNewIndex(indexDir, "exampleformat");
             for (int i = 0; i < testData.length; i++) {
-                indexer.index("test" + (i + 1), new ByteArrayInputStream(testData[i].getBytes(StandardCharsets.UTF_8)));
+                indexer.index("test" + (i + 1), testData[i].getBytes(StandardCharsets.UTF_8));
             }
 
         } catch (Exception e) {

--- a/core/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/core/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -295,7 +294,7 @@ public class IndexTool {
         try {
             if (glob.contains("*") || glob.contains("?")) {
                 // Real wildcard glob
-                indexer.index(inputDir, Optional.of(glob));
+                indexer.index(inputDir, glob);
             } else {
                 // Single file.
                 indexer.index(new File(inputDir, glob));

--- a/core/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/core/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -292,10 +293,10 @@ public class IndexTool {
         try {
             if (glob.contains("*") || glob.contains("?")) {
                 // Real wildcard glob
-                indexer.index(inputDir, glob);
+                indexer.index(inputDir, Optional.of(glob));
             } else {
                 // Single file.
-                indexer.index(new File(inputDir, glob), "*");
+                indexer.index(new File(inputDir, glob));
             }
         } catch (Exception e) {
             System.err.println(

--- a/core/src/main/java/nl/inl/util/FileProcessor.java
+++ b/core/src/main/java/nl/inl/util/FileProcessor.java
@@ -51,10 +51,9 @@ public class FileProcessor implements AutoCloseable {
         /**
          * Handle a file stream.
          * <p>
-         * Called for all processed files that match the {@link FileProcessor#pattGlob},
-         * including the input file. Not called for archives if
-         * {@link FileProcessor#isProcessArchives()} is true (though it will then be
-         * called for files within those archives).
+         * For effiency, the {@link FileHandler#file(String, byte[], File)} version will almost always be used. 
+         * The sole exception is when the {@link FileProcessor#processInputStream(String, InputStream, File)} is called
+         * with a file that is not an archive. Files within archives are always returned as byte[].
          * <p>
          * This function may be called in multiple threads when FileProcessor was
          * created with thread support (see

--- a/core/src/test/java/nl/inl/blacklab/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/TestIndex.java
@@ -1,6 +1,5 @@
 package nl.inl.blacklab;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,7 +129,7 @@ public class TestIndex {
             try {
                 // Index each of our test "documents".
                 for (int i = 0; i < testData.length; i++) {
-                    indexer.index("test" + (i + 1), new ByteArrayInputStream(testData[i].getBytes()));
+                    indexer.index("test" + (i + 1), testData[i].getBytes());
                 }
                 if (testDelete) {
                     // Delete the first doc, to test deletion.

--- a/core/src/test/java/nl/inl/blacklab/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/TestIndex.java
@@ -36,7 +36,7 @@ import nl.inl.util.UtilsForTesting;
 
 public class TestIndex {
     
-    private static final class IndexListenerThrowOnError extends IndexListener {
+    private static final class IndexListenerAbortOnError extends IndexListener {
         @Override
         public boolean errorOccurred(Throwable e, String path, File f) {
             // FileProcessor doesn't like when we re-throw the exception.
@@ -125,7 +125,7 @@ public class TestIndex {
         DocumentFormats.registerFormat(testFormat, DocIndexerExample.class);
         try {
             Indexer indexer = Indexer.createNewIndex(indexDir, testFormat);
-            indexer.setListener(new IndexListenerThrowOnError()); // throw on error
+            indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {
                 // Index each of our test "documents".
                 for (int i = 0; i < testData.length; i++) {

--- a/core/src/test/java/nl/inl/util/TestFileProcessor.java
+++ b/core/src/test/java/nl/inl/util/TestFileProcessor.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -213,7 +212,7 @@ public class TestFileProcessor {
         }
 
         @Override
-        public synchronized void file(String path, InputStream is, File file) throws Exception {
+        public synchronized void file(String path, byte[] contents, File file) throws Exception {
             this.filesReceived.add(FilenameUtils.getName(path));
             if (triggerException)
                 throw new TestException();
@@ -238,7 +237,7 @@ public class TestFileProcessor {
         try (FileProcessor proc = new FileProcessor(useThreads ? 2 : 1, recurseSubdirs, processArchives)) {
             proc.setFileHandler(fileHandler);
             proc.setErrorHandler(errorHandler);
-            proc.processFile(this.inputFile, "");
+            proc.processFile(this.inputFile);
         }
 
         if (!shouldTriggerException) {

--- a/core/src/test/java/nl/inl/util/TestFileProcessor.java
+++ b/core/src/test/java/nl/inl/util/TestFileProcessor.java
@@ -3,7 +3,7 @@ package nl.inl.util;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -212,6 +212,13 @@ public class TestFileProcessor {
         }
 
         @Override
+        public synchronized void file(String path, InputStream is, File file) throws Exception {
+            this.filesReceived.add(FilenameUtils.getName(path));
+            if (triggerException)
+                throw new TestException();
+        }
+
+        @Override
         public synchronized void file(String path, byte[] contents, File file) throws Exception {
             this.filesReceived.add(FilenameUtils.getName(path));
             if (triggerException)
@@ -230,7 +237,7 @@ public class TestFileProcessor {
     }
 
     @Test
-    public void test() throws FileNotFoundException {
+    public void test() {
         LoggingFileHandler fileHandler = new LoggingFileHandler(shouldTriggerException);
         LoggingErrorHandler errorHandler = new LoggingErrorHandler();
 

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
@@ -3,7 +3,6 @@ package nl.inl.blacklab.server.requesthandlers;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -108,12 +107,11 @@ public class RequestHandlerAddToIndex extends RequestHandler {
 
         try {
             for (FileItem file : dataFiles) {
-                try (InputStream is = file.getInputStream()) {
-                    indexer.index(file.getName(), is/*, "*.xml"*/);
-                }
+                indexer.index(file.getName(), file.get());
+//                try (InputStream is = file.getInputStream()) {
+//                    indexer.index(file.getName(), is/*, "*.xml"*/);
+//                }
             }
-        } catch (IOException e) {
-            throw new InternalServerError("Error occured during indexing: " + e.getMessage(), "INTERR_WHILE_INDEXING2");
         } finally {
             if (indexError == null) {
                 if (indexer.listener().getFilesProcessed() == 0)

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerAddToIndex.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.fileupload.FileItem;
@@ -108,9 +107,6 @@ public class RequestHandlerAddToIndex extends RequestHandler {
         try {
             for (FileItem file : dataFiles) {
                 indexer.index(file.getName(), file.get());
-//                try (InputStream is = file.getInputStream()) {
-//                    indexer.index(file.getName(), is/*, "*.xml"*/);
-//                }
             }
         } finally {
             if (indexError == null) {


### PR DESCRIPTION
Ran into the issues again today where indexing takes up quite a lot of memory.
This branch is still quite a bit faster and memory efficient (at least for indexing using blacklab-server).

Should probably take a good deep look at it again some time soon and see if we can merge it (or bring it more up to date if required).  