### PR TITLE
Adds null pointer check when the clause of a SpanNot is not present

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpansNot.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpansNot.java
@@ -241,7 +241,7 @@ class SpansNot extends BLSpans {
             return NO_MORE_POSITIONS;
         }
         // Advance us to just before the requested start point, then call nextStartPosition().
-        clauseStart = clause.advanceStartPosition(target);
+        clauseStart = clause == null ? NO_MORE_POSITIONS : clause.advanceStartPosition(target);
         currentStart = target - 1;
         currentEnd = target;
         return nextStartPosition();


### PR DESCRIPTION
Hey @jan-niestadt.

We recently found a very curious null pointer exception when executing a search and wanted to:
1) Check with you, to make sure the proposed fix is indeed the right fix
2) If it is not, I would love work with you to find a proper fix and upstream it to the INL repository.

The stacktrace of the problem we are seeing is detailed below

```
 INTERNAL ERROR INTERR_WHILE_SEARCHING:
2021-09-30T03:09:28.452Z java.lang.NullPointerException
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansNot.advanceStartPosition(SpansNot.java:244)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansAnd.catchUpMatchStart(SpansAnd.java:207)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansAnd.synchronizePosition(SpansAnd.java:137)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansAnd.synchronizeDoc(SpansAnd.java:182)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansAnd.advance(SpansAnd.java:229)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansSequenceSimple.realignDoc(SpansSequenceSimple.java:128)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansSequenceSimple.nextDoc(SpansSequenceSimple.java:71)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansSequenceWithGap.nextDoc(SpansSequenceWithGap.java:215)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansInBucketsAbstract.nextDoc(SpansInBucketsAbstract.java:137)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.PerDocumentSortedSpans.nextDoc(PerDocumentSortedSpans.java:98)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansSequenceWithGap.nextDoc(SpansSequenceWithGap.java:215)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansCaptureGroup.nextDoc(SpansCaptureGroup.java:99)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansFiltered.nextDoc(SpansFiltered.java:67)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.lucene.SpansUnique.nextDoc(SpansUnique.java:63)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.results.HitsFromQuery.ensureResultsRead(HitsFromQuery.java:287)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.results.Results.ensureAllResultsRead(Results.java:372)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.results.Results.resultsProcessedTotal(Results.java:394)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.results.Results$1.processedTotal(Results.java:116)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.search.results.ResultCount.processedTotal(ResultCount.java:73)
2021-09-30T03:09:28.452Z 	at nl.inl.blacklab.server.search.BlsCacheEntry$SearchTask.run(BlsCacheEntry.java:85)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
2021-09-30T03:09:28.452Z 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

We unfortunately can not reliably replicate this problem, it does seem to happen when the blacklab server is under load. Happy to get your input on this PR