### PR TITLE
Changes to provide an instrumentation package to allow for metrics gathering

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabEngine.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabEngine.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.logging.log4j.ThreadContext;
 import org.apache.lucene.index.IndexReader;
 
 import nl.inl.blacklab.exceptions.ErrorOpeningIndex;

--- a/instrumentation/instrumentation-impl/pom.xml
+++ b/instrumentation/instrumentation-impl/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<modelVersion>4.0.0</modelVersion>
+
+<parent>
+    <groupId>nl.inl.blacklab</groupId>
+    <artifactId>blacklab-all</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+</parent>
+<artifactId>blacklab-instrumentation-impl</artifactId>
+<packaging>jar</packaging>
+
+<name>BlackLab Instrumentation Implementation</name>
+<description>
+    Instrumentation implementation for blacklab server. Including metrics
+</description>
+
+<dependencies>
+    <dependency>
+        <groupId>${project.parent.groupId}</groupId>
+        <artifactId>blacklab-instrumentation</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+</project>

--- a/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
+++ b/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
@@ -1,0 +1,37 @@
+package nl.inl.blacklab.instrumentation.impl;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import nl.inl.blacklab.instrumentation.MetricsProvider;
+
+/**
+ * Creates a registry that tracks via
+ * micrometer's SimpleRegistry
+ */
+public class SimpleMetricsProvider implements MetricsProvider {
+    @Override
+    public MeterRegistry getRegistry() {
+        SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+        addSystemMetrics(simpleMeterRegistry);
+        return simpleMeterRegistry;
+    }
+
+    /**
+     * Adds metrics to measure the behaviour of the underlying JVM.
+     * @param registry the registry
+     */
+    private void addSystemMetrics(MeterRegistry registry) {
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new JvmHeapPressureMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+    }
+
+
+}

--- a/instrumentation/instrumentation/pom.xml
+++ b/instrumentation/instrumentation/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>nl.inl.blacklab</groupId>
+        <artifactId>blacklab-all</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>blacklab-instrumentation</artifactId>
+    <packaging>jar</packaging>
+
+    <name>BlackLab Instrumentation</name>
+    <description>
+        Instrumentation for blacklab server. Including metrics
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/instrumentation/instrumentation/src/main/java/nl/inl/blacklab/instrumentation/MetricsProvider.java
+++ b/instrumentation/instrumentation/src/main/java/nl/inl/blacklab/instrumentation/MetricsProvider.java
@@ -1,0 +1,17 @@
+package nl.inl.blacklab.instrumentation;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * MetricsProvider provides a meaningful MeterRegistry object
+ * that will be used to gather metrics.
+ */
+public interface MetricsProvider {
+    MeterRegistry getRegistry();
+
+    default  boolean metricsEnabled() {
+        String result = System.getProperty("metrics.enabled", "true");
+        boolean disabled = result.equalsIgnoreCase("false");
+        return !disabled;
+    }
+}

--- a/instrumentation/instrumentation/src/main/java/nl/inl/blacklab/instrumentation/RequestInstrumentationProvider.java
+++ b/instrumentation/instrumentation/src/main/java/nl/inl/blacklab/instrumentation/RequestInstrumentationProvider.java
@@ -1,0 +1,34 @@
+package nl.inl.blacklab.instrumentation;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * RequestInstrumentationProvider provides information used
+ * to augment logging messages and other instrumentation information.
+ */
+public interface RequestInstrumentationProvider {
+
+    /**
+     * Returns a request id that will be logged in each blacklab
+     * request
+     * @return the request id
+     */
+    Optional<String> getRequestID(HttpServletRequest request);
+
+    /**
+     * A RequestIdProvider that does not create a request id
+     */
+    static RequestInstrumentationProvider noOpProvider() {
+        return new RequestInstrumentationProvider() {
+            @Override
+            public Optional<String> getRequestID(HttpServletRequest request) {
+                return Optional.empty();
+            }
+        };
+    }
+}
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
         <module>contrib/convert-and-tag</module>
         <module>contrib/legacy-docindexers</module>
+        <module>instrumentation/instrumentation</module>
     </modules>
 
     <properties>
@@ -367,6 +368,12 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>with-instrumentation</id>
+            <modules>
+                <module>instrumentation/instrumentation-impl</module>
+            </modules>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
+            <artifactId>blacklab-instrumentation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>blacklab-mocks</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -59,8 +64,19 @@
             <artifactId>commons-dbcp</artifactId>
             <version>1.4</version>
         </dependency>
-
     </dependencies>
 
-
+    <!-- Selective decide via maven profiles if we want to have instrumentation -->
+    <profiles>
+        <profile>
+            <id>with-instrumentation</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.parent.groupId}</groupId>
+                    <artifactId>blacklab-instrumentation-impl</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigDebug.java
+++ b/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigDebug.java
@@ -1,5 +1,6 @@
 package nl.inl.blacklab.server.config;
 
+
 import java.util.Collections;
 import java.util.List;
 
@@ -9,6 +10,12 @@ public class BLSConfigDebug {
 
     /** Run all local requests in debug mode */
     boolean alwaysAllowDebugInfo = false;
+
+    /** For metrics gathering purpouses */
+    String metricsProvider = "";
+
+    /** For instrumentation purpouses */
+    String requestInstrumentationProvider = "";
 
     public List<String> getAddresses() {
         return addresses;
@@ -33,4 +40,19 @@ public class BLSConfigDebug {
         this.alwaysAllowDebugInfo = alwaysAllowDebugInfo;
     }
 
+    public String getMetricsProvider() {
+        return metricsProvider;
+    }
+
+    public void setMetricsProviderName(String metricsProviderName) {
+        this.metricsProvider = metricsProviderName;
+    }
+
+    public String getRequestInstrumentationProvider() {
+        return requestInstrumentationProvider;
+    }
+
+    public void setRequestInstrumentationProvider(String requestInstrumentationProvider) {
+        this.requestInstrumentationProvider = requestInstrumentationProvider;
+    }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -10,6 +10,8 @@ import java.util.concurrent.ExecutionException;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import nl.inl.blacklab.searches.SearchCacheEntry;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.document.Document;
@@ -78,6 +80,8 @@ import nl.inl.blacklab.server.util.BlsUtils;
  * Request handler for hit results.
  */
 public class RequestHandlerHits extends RequestHandler {
+
+    private static final Logger logger = LogManager.getLogger(RequestHandlerHits.class);
 
     public RequestHandlerHits(BlackLabServer servlet, HttpServletRequest request, User user, String indexName,
             String urlResource, String urlPathPart) {
@@ -176,11 +180,11 @@ public class RequestHandlerHits extends RequestHandler {
 
         // The summary
         ds.startEntry("summary").startMap();
-
         // Search time should be time user (originally) had to wait for the response to this request.
         // Count time is the time it took (or is taking) to iterate through all the results to count the total.
         long searchTime = cacheEntryWindow.timeUserWaitedMs() + kwicTimeMs;
         long countTime = cacheEntry.threwException() ? -1 : cacheEntry.timeUserWaitedMs();
+        logger.info("Total search time is:{} ms", searchTime);
         addSummaryCommonFields(ds, searchParam, searchTime, countTime, null, window.windowStats());
         addNumberOfResultsSummaryTotalHits(ds, hitsCount, docsCount, countTime < 0, null);
         if (includeTokenCount)

--- a/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
@@ -16,6 +16,7 @@ import nl.inl.blacklab.searches.Search;
 import nl.inl.blacklab.searches.SearchCacheEntry;
 import nl.inl.blacklab.searches.SearchCount;
 import nl.inl.blacklab.server.datastream.DataStream;
+import org.apache.logging.log4j.ThreadContext;
 
 public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
 
@@ -113,7 +114,11 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
         if (future != null)
             throw new RuntimeException("Search already started");
         started = true;
-        future = search.queryInfo().index().blackLab().searchExecutorService().submit(() -> executeSearch());
+        final String requestId = ThreadContext.get("requestId");
+        future = search.queryInfo().index().blackLab().searchExecutorService().submit(() -> {
+            ThreadContext.put("requestId", requestId);
+            executeSearch();
+        });
     }
 
     /** Perform the requested search.


### PR DESCRIPTION
This change contributes  instrumentation changes  that have allowed to understand the state of blacklab at runtime. This setup has been specially useful when chasing hard to replicate bugs. 

This pull requests also proposes a change to identify server requests via an id, and track that id in the logs. This has also been essential when observing the performance of blacklab.

I have provided simple implementations in hopes that other people can adapt them to their needs. For example a typical scenario would be track metrics via [prometheus](https://prometheus.io) (if this is of interest I can provide the implementation we are using for prometheus)

It is important to note that one of the key uses of this code is to gather information from blacklab itself, in a similar fashion as other instrumentation efforts.