### PR TITLE
Adds configurations to control response of Hits and GroupedHists and number of indices

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/config/BLConfigIndexing.java
+++ b/engine/src/main/java/nl/inl/blacklab/config/BLConfigIndexing.java
@@ -17,6 +17,8 @@ public class BLConfigIndexing {
     
     int numberOfThreads = 2;
 
+    int maxNumberOfIndicesPerUser = 10;
+
     public boolean isDownloadAllowed() {
         return downloadAllowed;
     }
@@ -69,5 +71,13 @@ public class BLConfigIndexing {
     public int getNumberOfThreads() {
         return numberOfThreads;
     }
-    
+
+    public int getMaxNumberOfIndicesPerUser() {
+        return maxNumberOfIndicesPerUser;
+    }
+
+    public void setMaxNumberOfIndicesPerUser(int maxNumberOfIndicesPerUser) {
+        this.maxNumberOfIndicesPerUser = maxNumberOfIndicesPerUser;
+    }
+
 }

--- a/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
@@ -19,6 +19,10 @@ public class BLSConfigParameters {
     DefaultMax pageSize = DefaultMax.get(50, 3000);
     
     DefaultMax contextSize = DefaultMax.get(5, 200);
+
+    private boolean writeHitsAndDocsInGroupedHits = false;
+
+    private boolean addSurroundingWordsToHits = true;
     
     @JsonGetter("defaultSearchSensitivity")
     public String getDefaultSearchSensitivityName() {
@@ -84,5 +88,21 @@ public class BLSConfigParameters {
 
     public void setDefaultSearchSensitivity(MatchSensitivity defaultSearchSensitivity) {
         this.defaultSearchSensitivity = defaultSearchSensitivity;
+    }
+
+    public boolean isWriteHitsAndDocsInGroupedHits() {
+        return writeHitsAndDocsInGroupedHits;
+    }
+
+    public void setWriteHitsAndDocsInGroupedHits(boolean writeHitsAndDocsInGroupedHits) {
+        this.writeHitsAndDocsInGroupedHits = writeHitsAndDocsInGroupedHits;
+    }
+
+    public boolean isAddSurroundingWordsToHits() {
+        return addSurroundingWordsToHits;
+    }
+
+    public void setAddSurroundingWordsToHits(boolean addSurroundingWordsToHits) {
+        this.addSurroundingWordsToHits = addSurroundingWordsToHits;
     }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigParameters.java
@@ -22,8 +22,7 @@ public class BLSConfigParameters {
 
     private boolean writeHitsAndDocsInGroupedHits = false;
 
-    private boolean addSurroundingWordsToHits = true;
-    
+
     @JsonGetter("defaultSearchSensitivity")
     public String getDefaultSearchSensitivityName() {
         return defaultSearchSensitivity.toString();
@@ -96,13 +95,5 @@ public class BLSConfigParameters {
 
     public void setWriteHitsAndDocsInGroupedHits(boolean writeHitsAndDocsInGroupedHits) {
         this.writeHitsAndDocsInGroupedHits = writeHitsAndDocsInGroupedHits;
-    }
-
-    public boolean isAddSurroundingWordsToHits() {
-        return addSurroundingWordsToHits;
-    }
-
-    public void setAddSurroundingWordsToHits(boolean addSurroundingWordsToHits) {
-        this.addSurroundingWordsToHits = addSurroundingWordsToHits;
     }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -250,21 +250,31 @@ public class RequestHandlerHits extends RequestHandler {
                         }
                     }
                     ds.endList().endEntry();
+                } else {
+                    logger.warn("MISSING CAPTURE GROUP: " + pid + ", query: " + searchParam.getString("patt"));
                 }
             }
 
             if (contextSettings.concType() == ConcordanceType.CONTENT_STORE) {
                 // Add concordance from original XML
                 Concordance c = concordances.get(hit);
-                ds.startEntry("left").plain(c.left()).endEntry()
+                if (searchMan.config().getParameters().isAddSurroundingWordsToHits()) {
+                    ds.startEntry("left").plain(c.left()).endEntry()
                         .startEntry("match").plain(c.match()).endEntry()
                         .startEntry("right").plain(c.right()).endEntry();
+                } else {
+                    ds.startEntry("match").plain(c.match()).endEntry();
+                }
             } else {
                 // Add KWIC info
                 Kwic c = kwics.get(hit);
-                ds.startEntry("left").contextList(c.annotations(), annotationsToList, c.left()).endEntry()
+                if (searchMan.config().getParameters().isAddSurroundingWordsToHits()) {
+                    ds.startEntry("left").contextList(c.annotations(), annotationsToList, c.left()).endEntry()
                         .startEntry("match").contextList(c.annotations(), annotationsToList, c.match()).endEntry()
                         .startEntry("right").contextList(c.annotations(), annotationsToList, c.right()).endEntry();
+                } else {
+                    ds.startEntry("match").contextList(c.annotations(), annotationsToList, c.match()).endEntry();
+                }
             }
             ds.endMap().endItem();
         }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -258,7 +258,7 @@ public class RequestHandlerHits extends RequestHandler {
             if (contextSettings.concType() == ConcordanceType.CONTENT_STORE) {
                 // Add concordance from original XML
                 Concordance c = concordances.get(hit);
-                if (searchMan.config().getParameters().isAddSurroundingWordsToHits()) {
+                if (searchParam.getContextSettings().size().left() > 0){
                     ds.startEntry("left").plain(c.left()).endEntry()
                         .startEntry("match").plain(c.match()).endEntry()
                         .startEntry("right").plain(c.right()).endEntry();
@@ -268,7 +268,7 @@ public class RequestHandlerHits extends RequestHandler {
             } else {
                 // Add KWIC info
                 Kwic c = kwics.get(hit);
-                if (searchMan.config().getParameters().isAddSurroundingWordsToHits()) {
+                if (searchParam.getContextSettings().size().left() > 0) {
                     ds.startEntry("left").contextList(c.annotations(), annotationsToList, c.left()).endEntry()
                         .startEntry("match").contextList(c.annotations(), annotationsToList, c.match()).endEntry()
                         .startEntry("right").contextList(c.annotations(), annotationsToList, c.right()).endEntry();

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -154,7 +154,7 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
                     }
                 }
 
-                if (searchMan.config().getParameters().isWriteHitsAndDocsInGroupedHits()) {
+                if (searchParam.includeGroupContents()) {
                     Hits hitsInGroup = group.storedResults();
                     writeHits(ds, hitsInGroup, pids);
                 }
@@ -164,7 +164,7 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
         }
         ds.endList().endEntry();
 
-        if (searchMan.config().getParameters().isWriteHitsAndDocsInGroupedHits()) {
+        if (searchParam.includeGroupContents()) {
             writeDocInfos(ds, groups, pids, first, requestedWindowSize);
         }
         ds.endMap();

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -2,10 +2,20 @@ package nl.inl.blacklab.server.requesthandlers;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import javax.servlet.http.HttpServletRequest;
 
+import nl.inl.blacklab.search.*;
+import nl.inl.blacklab.search.indexmetadata.Annotation;
+import nl.inl.blacklab.search.indexmetadata.MetadataField;
+import nl.inl.blacklab.search.results.*;
+import nl.inl.blacklab.server.jobs.ContextSettings;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BooleanQuery.Builder;
@@ -30,6 +40,8 @@ import nl.inl.blacklab.server.exceptions.BlsException;
 import nl.inl.blacklab.server.jobs.User;
 import nl.inl.blacklab.server.jobs.WindowSettings;
 import nl.inl.blacklab.server.search.BlsCacheEntry;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import nl.inl.util.BlockTimer;
 
 /**
@@ -97,6 +109,8 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
         boolean isMultiValueGroup = groups.groupCriteria() instanceof HitPropertyMultiple;
         List<HitProperty> prop = isMultiValueGroup ? ((HitPropertyMultiple) groups.groupCriteria()).props() : Arrays.asList(groups.groupCriteria());
 
+        Map<Integer, String> pids = new HashMap<>();
+
         ds.startEntry("hitGroups").startList();
         int last = Math.min(first + requestedWindowSize, groups.size());
 
@@ -139,13 +153,122 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
                         addSubcorpusSize(ds, subcorpusSize);
                     }
                 }
+
+                if (searchMan.config().getParameters().isWriteHitsAndDocsInGroupedHits()) {
+                    Hits hitsInGroup = group.storedResults();
+                    writeHits(ds, hitsInGroup, pids);
+                }
+
                 ds.endMap().endItem();
             }
         }
         ds.endList().endEntry();
+
+        if (searchMan.config().getParameters().isWriteHitsAndDocsInGroupedHits()) {
+            writeDocInfos(ds, groups, pids, first, requestedWindowSize);
+        }
         ds.endMap();
 
         return HTTP_OK;
+    }
+
+    private void writeHits(DataStream ds, Hits hits, Map<Integer, String> pids) throws BlsException {
+        ds.startEntry("hits").startList();
+        BlackLabIndex index = hits.index();
+        ContextSettings contextSettings = searchParam.getContextSettings();
+        Concordances concordances = null;
+        Kwics kwics = null;
+        if (contextSettings.concType() == ConcordanceType.CONTENT_STORE)
+            concordances = hits.concordances(contextSettings.size(), ConcordanceType.CONTENT_STORE);
+        else
+            kwics = hits.kwics(contextSettings.size());
+
+        for (Hit hit : hits) {
+            ds.startItem("hit").startMap();
+
+            // Find pid
+            String pid = pids.get(hit.doc());
+            if (pid == null) {
+                Document document = index.doc(hit.doc()).luceneDoc();
+                pid = getDocumentPid(index, hit.doc(), document);
+                pids.put(hit.doc(), pid);
+            }
+
+            // TODO: use RequestHandlerDocSnippet.getHitOrFragmentInfo()
+
+            // Add basic hit info
+            ds.entry("docPid", pid);
+            ds.entry("start", hit.start());
+            ds.entry("end", hit.end());
+
+            if (hits.hasCapturedGroups()) {
+                Map<String, Span> capturedGroups = hits.capturedGroups().getMap(hit);
+                ds.startEntry("captureGroups").startList();
+
+                for (Map.Entry<String, Span> capturedGroup : capturedGroups.entrySet()) {
+                    if (capturedGroup.getValue() != null) {
+                        ds.startItem("group").startMap();
+                        ds.entry("name", capturedGroup.getKey());
+                        ds.entry("start", capturedGroup.getValue().start());
+                        ds.entry("end", capturedGroup.getValue().end());
+                        ds.endMap().endItem();
+                    }
+                }
+
+                ds.endList().endEntry();
+            }
+
+            if (contextSettings.concType() == ConcordanceType.CONTENT_STORE) {
+                // Add concordance from original XML
+                Concordance c = concordances.get(hit);
+                ds.startEntry("left").plain(c.left()).endEntry()
+                        .startEntry("match").plain(c.match()).endEntry()
+                        .startEntry("right").plain(c.right()).endEntry();
+            } else {
+                // Add KWIC info
+                Kwic c = kwics.get(hit);
+                Set<Annotation> annotationsToList = new HashSet<>(getAnnotationsToWrite());
+                ds.startEntry("left").contextList(c.annotations(), annotationsToList, c.left()).endEntry()
+                        .startEntry("match").contextList(c.annotations(), annotationsToList, c.match()).endEntry()
+                        .startEntry("right").contextList(c.annotations(), annotationsToList, c.right()).endEntry();
+            }
+            ds.endMap().endItem();
+        }
+        ds.endList().endEntry();
+    }
+
+    private void writeDocInfos(DataStream ds, HitGroups hitGroups, Map<Integer, String> pids, int first, int requestedWindowSize) throws BlsException {
+        ds.startEntry("docInfos").startMap();
+        //DataObjectMapAttribute docInfos = new DataObjectMapAttribute("docInfo", "pid");
+        BlackLabIndex index = hitGroups.index();
+        MutableIntSet docsDone = new IntHashSet();
+        Document doc = null;
+        String lastPid = "";
+        Set<MetadataField> metadataFieldsTolist = new HashSet<>(this.getMetadataToWrite());
+
+        int i = 0;
+        for (HitGroup group : hitGroups) {
+            if (i >= first && i < first + requestedWindowSize) {
+                for (Hit hit : group.storedResults()) {
+                    String pid = pids.get(hit.doc());
+
+                    // Add document info if we didn't already
+                    if (!docsDone.contains(hit.doc())) {
+                        docsDone.add(hit.doc());
+                        ds.startAttrEntry("docInfo", "pid", pid);
+                        if (!pid.equals(lastPid)) {
+                            doc = index.doc(hit.doc()).luceneDoc();
+                            lastPid = pid;
+                        }
+                        dataStreamDocumentInfo(ds, index, doc, metadataFieldsTolist);
+                        ds.endAttrEntry();
+                    }
+                }
+            }
+            i++;
+        }
+
+        ds.endMap().endEntry();
     }
 
     static CorpusSize findSubcorpusSize(SearchParameters searchParam, Query metadataFilterQuery, DocProperty property, PropertyValue value, boolean countTokens) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -417,6 +417,13 @@ public class SearchParameters {
         return new ContextSettings(contextSize, concType);
     }
 
+    public boolean includeGroupContents() {
+        if (containsKey("includegroupcontents")) {
+            return getBoolean("includegroupcontents");
+        }
+        return searchManager.config().getParameters().isWriteHitsAndDocsInGroupedHits();
+    }
+
     private List<DocProperty> getFacets() {
         if (facetProps == null) {
             String facets = getString("facets");


### PR DESCRIPTION
This change adds settings to control:

- The size of the hits response by not including concordances, thus reducing the response size.
- The size of the grouped response by including hits, docs.
- The number of indices per user.
By default this settings match current blacklab logic.