### PR TITLE
Fix bug where for-each subannotation would skip undeclared annotations

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -652,31 +652,25 @@ public class DocIndexerXPath extends DocIndexerConfig {
 
                         // This for-each now processing for a sibling sub-annotation that has its own config, so use that config.
                         // BUT, use the xpath from the for-each, not the from sibling definition (if it configures an xpath, that will run on its own at another point in the loop)
-                        //
-                        if (actualSubAnnot != null) {
-                            if (actualSubAnnot.getValuePath() != null && !actualSubAnnot.getValuePath().isEmpty()) {
-                                // this sibling subannotation has its own value path,
-                                // skip it while processing the for-each.
-                                continue;
-                            }
-                            boolean reuseParentAnnotationValue = subAnnot.getValuePath().equals(annotation.getValuePath()) &&
-                                actualSubAnnot.isMultipleValues() == annotation.isMultipleValues() &&
-                                actualSubAnnot.isAllowDuplicateValues() == annotation.isAllowDuplicateValues() &&
-                                actualSubAnnot.isCaptureXml() == annotation.isCaptureXml();
-
-                            findAnnotationMatches(actualSubAnnot, subAnnot.getValuePath(), indexAtPositions, reuseParentAnnotationValue ? annotValue : null, subAnnot.getProcess());
-                        } else {
-                            // The annotation on whose behalf we're indexing does not have its own definition
-                            // So use the for-each as stand-in
-
-                            boolean reuseParentAnnotationValue = subAnnot.getValuePath().equals(annotation.getValuePath()) &&
-                                subAnnot.isMultipleValues() == annotation.isMultipleValues() &&
-                                subAnnot.isAllowDuplicateValues() == annotation.isAllowDuplicateValues() &&
-                                subAnnot.isCaptureXml() == annotation.isCaptureXml();
-
-                            // Note: pass null as process, findAnnotationMatches will use them already from the subAnnot argument.
-                            findAnnotationMatches(subAnnot, subAnnot.getValuePath(), indexAtPositions, reuseParentAnnotationValue ? annotValue : null, null);
+                        
+                        if (actualSubAnnot == null) {
+                            actualSubAnnot = subAnnot.copy();
+                            actualSubAnnot.setForEachPath(null);
+                            actualSubAnnot.setName(subannotationName);
+                            actualSubAnnot.setValuePath(subAnnot.getValuePath()); // value comes from already retrieved subAnnot.valuePath
+                            subAnnot.addSubAnnotation(actualSubAnnot);
+                        } else if (actualSubAnnot.getValuePath() != null && !actualSubAnnot.getValuePath().isEmpty()) {
+                            // this sibling subannotation has its own value path,
+                            // skip it while processing the for-each.
+                            continue;
                         }
+
+                        boolean reuseParentAnnotationValue = subAnnot.getValuePath().equals(annotation.getValuePath()) &&
+                            actualSubAnnot.isMultipleValues() == annotation.isMultipleValues() &&
+                            actualSubAnnot.isAllowDuplicateValues() == annotation.isAllowDuplicateValues() &&
+                            actualSubAnnot.isCaptureXml() == annotation.isCaptureXml();
+
+                        findAnnotationMatches(actualSubAnnot, subAnnot.getValuePath(), indexAtPositions, reuseParentAnnotationValue ? annotValue : null, subAnnot.getProcess());
                     }
                     releaseAutoPilot(apForEach);
                     releaseAutoPilot(apName);
@@ -689,6 +683,8 @@ public class DocIndexerXPath extends DocIndexerConfig {
                         subAnnot.isAllowDuplicateValues() == annotation.isAllowDuplicateValues() &&
                         subAnnot.isCaptureXml() == annotation.isCaptureXml();
 
+                    
+                    
                     findAnnotationMatches(subAnnot, subAnnot.getValuePath(), indexAtPositions, reuseParentAnnotationValue ? annotValue : null, null);
                 }
             }


### PR DESCRIPTION
In the spirit of more code-reviews:

I encountered a bug where in the following example the `<feat>` is not indexed and a warning is emitted.
> 11:32:24.829 [pool-3-thread-1] ERROR nl.inl.blacklab.index.DocIndexer - (...)\ONW-processed-metadata-v3\leys_1957.xml: skipping undeclared annotation ./@name


What happens is the following
1. [we resolve the `namePath` to `featureName`](https://github.com/INL/BlackLab/blob/63d6ba31485841513cb87105c14a7742e3ad807a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java#L650) and transform it into `pos_featureName` (because it's a subannot of `pos`)
2. However we [use the `forEach` annotation to get settings for multipleValues, indexXml, etc., because no annotation pos_featureName exists](https://github.com/INL/BlackLab/blob/63d6ba31485841513cb87105c14a7742e3ad807a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java#L669) in the config
3. Confusingly, the name of the `forEach` annotation used is **`./@name`**, [because of how it's read from the yaml](https://github.com/INL/BlackLab/blob/63d6ba31485841513cb87105c14a7742e3ad807a/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java#L402)
4. [when attempting to write the value (arguments `./@name`, `featureValue`) , the annotation cannot be found and we get a warning](https://github.com/INL/BlackLab/blob/63d6ba31485841513cb87105c14a7742e3ad807a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java#L761)

```xml
<w lemma="test">
  test
  <pos>
    head
    <feat name="featureName">featureValue</feat>
  </pos>
</w>
```

```yaml
- name: pos
  basePath: pos
  valuePath: ./text()
  
  subannotations:
  - forEachPath: ./feat
     namePath: "./@name"
     valuePath: "."
```

----
What I've done here is detect when a for-each matches an annotation that does not exist yet, and instance that annotation on the fly, copying settings from the for-each. 

Now I can recall something where annotations that weren't declared up front from the config were problematic for the forward index or somesuch? It seems to work in my (limited) testing