### PR TITLE
Changes index cleanup to async via file system listening

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -586,7 +586,7 @@ public class IndexManager {
                         .findFirst();
                     indexToDelete.ifPresent(i -> {
                         logger.info("Deleting index {}, {}", i.getId(), i.getDir().getAbsolutePath());
-                        indices.remove(i.getId());
+                        indices.remove(i.getId()).close();
                     });
                 }
             }

--- a/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -58,6 +58,11 @@ public class IndexManager {
      */
     private static final String PENDING_DELETION_FILE_MARKER = ".markedfordeletion";
 
+    /**
+     * The frequency at which we check for removed indices in the file system.
+     */
+    private static final int REMOVED_INDICES_MONITOR_CHECK_IN_MS = 1000;
+
     private static final Logger logger = LogManager.getLogger(IndexManager.class);
 
     private SearchManager searchMan;
@@ -133,7 +138,7 @@ public class IndexManager {
         List<File> allDirs = new ArrayList<>(collectionsDirs);
         allDirs.add(userCollectionsDir);
         try {
-            startRemovedIndicesMonitor(allDirs, 1000);
+            startRemovedIndicesMonitor(allDirs, REMOVED_INDICES_MONITOR_CHECK_IN_MS);
         } catch (Exception ex) {
             throw  BlackLabRuntimeException.wrap(ex);
         }


### PR DESCRIPTION
This change switches to index cleanup of removed indices in the FS to a file system monitor, as opposed to always checking via `cleanupRemovedIndices()`.

`cleanupRemovedIndices()` is called very frequently in a few paths, including every search request. Furthermore the method walks all indices in the file system, creating bottlenecks in the presence of many indices.

The proposed solution switches to a polling the filesystem on periodic basis(harcoded now, we can make this into a setting) and clean up references to the delete items.