### PR TITLE
Adds an prometheus implementation to MetricsProvider, wires in system metrics

### DIFF
--- a/instrumentation/instrumentation-impl/pom.xml
+++ b/instrumentation/instrumentation-impl/pom.xml
@@ -23,5 +23,10 @@
         <artifactId>blacklab-instrumentation</artifactId>
         <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+        <version>1.7.0</version>
+    </dependency>
 </dependencies>
 </project>

--- a/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/PrometheusMetricsProvider.java
+++ b/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/PrometheusMetricsProvider.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -16,7 +17,12 @@ import org.apache.logging.log4j.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 
+/**
+ * Create a registry backed by prometheus
+ * Adds system metrics to the registry
+ */
 public class PrometheusMetricsProvider implements MetricsProvider {
     private static final Logger logger = LogManager.getLogger(PrometheusMetricsProvider.class);
     private static final String DEFAULT_PROM_ENDPOINT = "/metrics";
@@ -51,18 +57,24 @@ public class PrometheusMetricsProvider implements MetricsProvider {
      * @param request
      * @param responseObject
      * @param charEncoding
-     * @return
+     * @return true if the request was handled, false otherwise
      */
-    protected static boolean handlePrometheus(MeterRegistry registry, HttpServletRequest request, HttpServletResponse responseObject, String charEncoding) {
+    public static boolean handlePrometheus(MeterRegistry registry, HttpServletRequest request, HttpServletResponse responseObject, String charEncoding) {
         if (!request.getRequestURI().contains(DEFAULT_PROM_ENDPOINT)) {
             return false;
         }
-        if (!(registry instanceof PrometheusMeterRegistry)) {
+        Optional<MeterRegistry> aRegistry = Optional.of(registry);
+        if (registry instanceof CompositeMeterRegistry) {
+            CompositeMeterRegistry composite = (CompositeMeterRegistry) registry;
+             aRegistry = composite.getRegistries().stream().filter(r -> r instanceof PrometheusMeterRegistry).findFirst();
+        }
+        if (!aRegistry.isPresent() || !(aRegistry.get() instanceof PrometheusMeterRegistry)) {
             logger.warn("Can not respond to /metrics without a PrometheusRegistry");
+            responseObject.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return true;
         }
 
-        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) registry;
+        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) aRegistry.get();
 
         try {
             prometheusMeterRegistry.scrape(responseObject.getWriter());

--- a/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/PrometheusMetricsProvider.java
+++ b/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/PrometheusMetricsProvider.java
@@ -1,0 +1,77 @@
+package nl.inl.blacklab.instrumentation.impl;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import nl.inl.blacklab.instrumentation.MetricsProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class PrometheusMetricsProvider implements MetricsProvider {
+    private static final Logger logger = LogManager.getLogger(PrometheusMetricsProvider.class);
+    private static final String DEFAULT_PROM_ENDPOINT = "/metrics";
+
+    private final MeterRegistry theRegistry;
+
+    public PrometheusMetricsProvider() {
+        theRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        addSystemMetrics(theRegistry);
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+        return theRegistry;
+    }
+
+    /**
+     * Adds metrics to measure the behaviour of the underlying JVM.
+     * @param registry the registry
+     */
+    private void addSystemMetrics(MeterRegistry registry) {
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new JvmHeapPressureMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+    }
+
+    /**
+     * A simple request handler that responds to prometheus  metrics scrapping requests
+     * @param registry must be of type {@link PrometheusMeterRegistry}
+     * @param request
+     * @param responseObject
+     * @param charEncoding
+     * @return
+     */
+    protected static boolean handlePrometheus(MeterRegistry registry, HttpServletRequest request, HttpServletResponse responseObject, String charEncoding) {
+        if (!request.getRequestURI().contains(DEFAULT_PROM_ENDPOINT)) {
+            return false;
+        }
+        if (!(registry instanceof PrometheusMeterRegistry)) {
+            logger.warn("Can not respond to /metrics without a PrometheusRegistry");
+            return true;
+        }
+
+        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) registry;
+
+        try {
+            prometheusMeterRegistry.scrape(responseObject.getWriter());
+            responseObject.setStatus(HttpServletResponse.SC_OK);
+            responseObject.setCharacterEncoding(charEncoding);
+            responseObject.setContentType(TextFormat.CONTENT_TYPE_004);
+        } catch (IOException exception) {
+            logger.error("Can't scrape prometheus metrics", exception);
+        }
+        return true;
+    }
+}

--- a/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
+++ b/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
@@ -17,21 +17,10 @@ public class SimpleMetricsProvider implements MetricsProvider {
     @Override
     public MeterRegistry getRegistry() {
         SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
-        addSystemMetrics(simpleMeterRegistry);
         return simpleMeterRegistry;
     }
 
-    /**
-     * Adds metrics to measure the behaviour of the underlying JVM.
-     * @param registry the registry
-     */
-    private void addSystemMetrics(MeterRegistry registry) {
-        new JvmMemoryMetrics().bindTo(registry);
-        new JvmGcMetrics().bindTo(registry);
-        new JvmHeapPressureMetrics().bindTo(registry);
-        new JvmThreadMetrics().bindTo(registry);
-        new ProcessorMetrics().bindTo(registry);
-    }
+
 
 
 }

--- a/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
+++ b/instrumentation/instrumentation-impl/src/main/java/nl/inl/blacklab/instrumentation/impl/SimpleMetricsProvider.java
@@ -14,10 +14,15 @@ import nl.inl.blacklab.instrumentation.MetricsProvider;
  * micrometer's SimpleRegistry
  */
 public class SimpleMetricsProvider implements MetricsProvider {
+    private final MeterRegistry registry;
+
+    public SimpleMetricsProvider() {
+        registry = new SimpleMeterRegistry();
+    }
+
     @Override
     public MeterRegistry getRegistry() {
-        SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
-        return simpleMeterRegistry;
+        return registry;
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <module>contrib/convert-and-tag</module>
         <module>contrib/legacy-docindexers</module>
         <module>instrumentation/instrumentation</module>
+        <module>instrumentation/instrumentation-impl</module>
     </modules>
 
     <properties>
@@ -368,12 +369,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>with-instrumentation</id>
-            <modules>
-                <module>instrumentation/instrumentation-impl</module>
-            </modules>
-        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -64,19 +64,10 @@
             <artifactId>commons-dbcp</artifactId>
             <version>1.4</version>
         </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>blacklab-instrumentation-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
-
-    <!-- Selective decide via maven profiles if we want to have instrumentation -->
-    <profiles>
-        <profile>
-            <id>with-instrumentation</id>
-            <dependencies>
-                <dependency>
-                    <groupId>${project.parent.groupId}</groupId>
-                    <artifactId>blacklab-instrumentation-impl</artifactId>
-                    <version>${project.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import nl.inl.blacklab.instrumentation.MetricsProvider;
 import nl.inl.blacklab.instrumentation.RequestInstrumentationProvider;
+import nl.inl.blacklab.instrumentation.impl.PrometheusMetricsProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -246,6 +247,10 @@ public class BlackLabServer extends HttpServlet {
                     return;
                 }
             }
+        }
+
+        if (PrometheusMetricsProvider.handlePrometheus(Metrics.globalRegistry, request, responseObject, OUTPUT_ENCODING.name())) {
+            return;
         }
 
         // === Create RequestHandler object


### PR DESCRIPTION
These changes add an implementation of MetricsProvider backed by Prometheus, they also add some basic system metrics to allow for the monitoring of the JVM. Prometheus is a pull based system so you can actually observe the data generated by 
```curl localhost:[port]/metrics```. Of course you need a running version of prometheus to collect/store/query and analyze such metrics ( which can be done fairly easily via a [docker container](https://prometheus.io/docs/prometheus/latest/installation/))

The idea behind this change is to allow for the observability of different parts of blacklab in any running environment, including production environments.

I am happy to discuss where we can inject metrics to better understand blacklab's behaviour. Some places that come to mind:
- Metrics for the cache
- Metrics for search performance and timing.
- Metrics for indexing operations


This PR also refactors some of the classes as well as the pom dependencies.