### PR TITLE
add a null check to prevent an Exception

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -136,7 +136,7 @@ public class IndexManager {
 
         checkAnyIndexesAvailable();
         List<File> allDirs = new ArrayList<>(collectionsDirs);
-        allDirs.add(userCollectionsDir);
+        if(userCollectionsDir != null) allDirs.add(userCollectionsDir); // Since userCollectionsDir is initialized as null, and might still be null here, check for nullity
         try {
             startRemovedIndicesMonitor(allDirs, REMOVED_INDICES_MONITOR_CHECK_IN_MS);
         } catch (Exception ex) {


### PR DESCRIPTION
When no user collections exists, a null value was added to allDirs, which is passed here:

https://github.com/INL/BlackLab/blob/e980656ea21f4b05ec8de5bcbed4220726912fd7/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java#L141

and will cause an exception in this stream:

https://github.com/INL/BlackLab/blob/e980656ea21f4b05ec8de5bcbed4220726912fd7/server/src/main/java/nl/inl/blacklab/server/index/IndexManager.java#L576

Resulting in a failure to reply to requests. I ran in to this issue when trying out the dockerized version of BlackLab.