### PR TITLE
Fixes repetitive metadata during index creation when indexing multiple documents

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
@@ -590,6 +590,7 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
                 super.addMetadataField(fieldName, s);
             }
         }
+        sortedMetadataValues.clear();
         super.endDocument();
     }
 }


### PR DESCRIPTION
Hey all, wanted to reach out with a fix for index creation when using custom input formats.

We have  noticed that metadata from previous documents gets repeated when indexing multiple documents at the time. It seems like the accumulator we use to process metadata values is not getting reset after a document is done indexing.
The fix below addresses such issue by simply reseting the map of field to values after document processing. Happy to hear feedback on this possible fix.
@KCMertens it seems like this change: https://github.com/inl/BlackLab/commit/7a5ae3922b5959e0b302e4fce736afea34d82ecb, might have introduced the bug, curious to know what you think about this fix.

