### PR TITLE
Implements workaround when metadata contains newlines and colons

### DIFF
--- a/util/src/main/java/nl/inl/util/Json.java
+++ b/util/src/main/java/nl/inl/util/Json.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 /**
  * Supports reading/writing JSON and YAML files.
@@ -25,7 +26,7 @@ public class Json {
 
     static private ObjectMapper jsonObjectMapper;
 
-    static private JsonFactory yamlFactory;
+    static private YAMLFactory yamlFactory;
 
     static private ObjectMapper yamlObjectMapper;
 
@@ -40,6 +41,7 @@ public class Json {
         jsonObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
 
         yamlFactory = new YAMLFactory();
+        yamlFactory.configure(YAMLGenerator.Feature.CANONICAL_OUTPUT, true);
         yamlObjectMapper = new ObjectMapper(yamlFactory);
         yamlObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
     }
@@ -80,7 +82,7 @@ public class Json {
      */
     public static String getString(JsonNode parent, String name, String defVal) {
         if (parent.has(name))
-            return parent.get(name).textValue();
+            return parent.get(name).asText(defVal);
         return defVal;
     }
 
@@ -94,8 +96,9 @@ public class Json {
      * @return the boolean value
      */
     public static boolean getBoolean(JsonNode parent, String name, boolean defVal) {
-        if (parent.has(name))
-            return parent.get(name).booleanValue();
+        if (parent.has(name)) {
+            return parent.get(name).asBoolean(defVal);
+        }
         return defVal;
     }
 
@@ -110,7 +113,7 @@ public class Json {
      */
     public static long getLong(ObjectNode parent, String name, long defVal) {
         if (parent.has(name))
-            return parent.get(name).longValue();
+            return parent.get(name).asLong(defVal);
         return defVal;
     }
 
@@ -125,7 +128,7 @@ public class Json {
      */
     public static int getInt(ObjectNode parent, String name, int defVal) {
         if (parent.has(name))
-            return parent.get(name).intValue();
+            return parent.get(name).asInt(defVal);
         return defVal;
     }
 
@@ -143,7 +146,7 @@ public class Json {
         List<String> result = new ArrayList<>();
         if (arr != null) {
             for (int i = 0; i < arr.size(); i++) {
-                result.add(arr.get(i).textValue());
+                result.add(arr.get(i).asText());
             }
         }
         return result;

--- a/util/src/test/java/nl/inl/util/TestXmlUtil.java
+++ b/util/src/test/java/nl/inl/util/TestXmlUtil.java
@@ -15,8 +15,19 @@
  *******************************************************************************/
 package nl.inl.util;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TestXmlUtil {
 
@@ -49,5 +60,30 @@ public class TestXmlUtil {
         // Replace with non-breaking spaces; keep trailing space
         Assert.assertEquals("test\u00A0test\u00A0", XmlUtil.xmlToPlainText("test test ", true));
     }
+
+    @Test
+    public void testYamlMultiLineWithCanonical() throws Exception {
+        String []keys = new String[]{"SomeKeyString:\n\nAnotherLine", "SomeKeyInteger:\n\nAnotherLine","SomeKeyBoolean:\n\nAnotherLine", "Simple"};
+        ObjectMapper jsonMapper = Json.getJsonObjectMapper();
+        ObjectNode jsonRoot = jsonMapper.createObjectNode();
+        jsonRoot.put(keys[0], "valstring");
+        jsonRoot.put(keys[1], 20);
+        jsonRoot.put(keys[2], true);
+        jsonRoot.put(keys[3], "simple");
+
+        ObjectMapper yamlObjectMapper = Json.getYamlObjectMapper();
+        yamlObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        StringWriter swriter = new StringWriter();
+
+        yamlObjectMapper.writeValue(swriter, jsonRoot);
+
+        ObjectMapper readMapper =  Json.getYamlObjectMapper();
+        ObjectNode readJsonRoot = (ObjectNode) readMapper.readTree(swriter.toString());
+        Assert.assertEquals("valstring", Json.getString(readJsonRoot, keys[0], ""));
+        Assert.assertEquals(20, Json.getInt(readJsonRoot, keys[1], 0));
+        Assert.assertEquals(true, Json.getBoolean(readJsonRoot, keys[2], false));
+        Assert.assertEquals("simple", Json.getString(readJsonRoot, keys[3], ""));
+    }
+
 
 }


### PR DESCRIPTION
Hey all

We found a problem when processing metadata containing combinations of colons and newlines. The parser breaks, presumably because of a bug in the yaml [parser.](https://github.com/FasterXML/jackson-dataformats-text/issues/306)

I have implemented a workaround for this and I wanted to get your opinion on it. 
There is a unittest now covering this problem