### PR TITLE
Only load document fields we actually need

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocFieldLengthGetter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DocumentStoredFieldVisitor;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.Terms;
@@ -21,6 +22,9 @@ import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
  *
  * This is used by SpanQueryNot and SpanQueryExpansion to make sure we don't go
  * beyond the document end.
+ *
+ * This class is instantiated and used by a single Spans to get lengths for a single
+ * index segment. It does not need to be thread-safe.
  */
 class DocFieldLengthGetter implements Closeable {
     /**
@@ -50,6 +54,9 @@ class DocFieldLengthGetter implements Closeable {
     /** Field name to check for the length of the field in tokens */
     private String lengthTokensFieldName;
 
+    /** Field visitor to get the field value (without loading the entire document) */
+    private final DocumentStoredFieldVisitor lengthTokensFieldVisitor;
+
     /** Lengths may have been cached using FieldCache */
     private NumericDocValues cachedFieldLengths;
 
@@ -59,6 +66,7 @@ class DocFieldLengthGetter implements Closeable {
         this.reader = reader;
         this.fieldName = fieldName;
         lengthTokensFieldName = AnnotatedFieldNameUtil.lengthTokensField(fieldName);
+        lengthTokensFieldVisitor = new DocumentStoredFieldVisitor(lengthTokensFieldName);
 
         if (fieldName.equals(Indexer.DEFAULT_CONTENTS_FIELD_NAME)) {
             // Cache the lengths for this field to speed things up
@@ -142,7 +150,8 @@ class DocFieldLengthGetter implements Closeable {
             // We either know the field length is stored in the index,
             // or we haven't checked yet and should do so now.
             try {
-                Document document = reader.document(doc);
+                reader.document(doc, lengthTokensFieldVisitor);
+                Document document = lengthTokensFieldVisitor.getDocument();
                 String strLength = document.get(lengthTokensFieldName);
                 lookedForLengthField = true;
                 if (strLength != null) {

--- a/test/test/hits-grouped.js
+++ b/test/test/hits-grouped.js
@@ -102,17 +102,35 @@ expectHitsGrouped('"a"', 'field:title', 3, 17, 3, {
     "identityDisplay": "interview about conference experience and impressions of city",
     "size": 8,
     "properties": [
-      {
-        "name": "field:title",
-        "value": "interview about conference experience and impressions of city"
-      }
+        {
+            "name": "field:title",
+            "value": "interview about conference experience and impressions of city"
+        }
     ],
     "numberOfDocs": 1,
     "subcorpusSize": {
-      "documents": 1,
-      "tokens": 268
+        "documents": 1,
+        "tokens": 268
     }
 });
+
+// Compare hit grouping with regular (HitGroupFromHits) and fast (HitGroupsTokenFrequencies) path.
+// Results should be identical
+const wordFreqParam = ['hit:word:i', 210, 766, 3, {
+    "identity": "cws:word:i:_0",
+    "identityDisplay": "_0",
+    "size": 43,
+    "properties": [
+        {
+            "name": "hit:word:i",
+            "value": "_0"
+        }
+    ],
+    "numberOfDocs": 3
+}];
+expectHitsGrouped('[word != "abcdefg"]', ...wordFreqParam); // regular path
+expectHitsGrouped('[]', ...wordFreqParam); // fast path, same results expected
+
 
 // A few simpler tests, just checking matching text
 //expectHitsGrouped('"two|four"', 3, 1, "two");


### PR DESCRIPTION
If we know in advance we only need to know the document length, or forward index ids for a document, we don't need to load the entire Lucene document. We can only load the fields we need using DocumentStoredFieldVisitor.

Also adds tests to verify that this didn't break anything, and while we're at it, compare the results of the HitGroupsTokenFrequencies fast path to the regular HitGroupsFromHits path.