### PR TITLE
Fixed intermittent crashes using synchronization. Bug in Contexts.

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/AnnotationForwardIndexReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/AnnotationForwardIndexReader.java
@@ -15,19 +15,29 @@
  *******************************************************************************/
 package nl.inl.blacklab.forwardindex;
 
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
-import nl.inl.blacklab.search.indexmetadata.Annotation;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.*;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
-import java.util.*;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.search.indexmetadata.Annotation;
 
 /**
  * Keeps a forward index of documents, to quickly answer the question "what word
@@ -266,16 +276,20 @@ class AnnotationForwardIndexReader extends AnnotationForwardIndex {
             if (whichChunk == null) {
                 throw new BlackLabRuntimeException("Tokens file chunk containing document not found. fiid = " + fiid);
             }
-            ((Buffer)whichChunk).position((int) (offset[fiid] * SIZEOF_INT - chunkOffsetBytes));
-            ib = whichChunk.asIntBuffer();
-
             int snippetLength = end - start;
             int[] snippet = new int[snippetLength];
+            synchronized (whichChunk) {
+                ((Buffer) whichChunk).position((int) (offset[fiid] * SIZEOF_INT - chunkOffsetBytes));
+                ib = whichChunk.asIntBuffer();
 
-            // The file is mem-mapped (search mode).
-            // Position us at the correct place in the file.
-            ib.position(start);
-            ib.get(snippet);
+                // The file is mem-mapped (search mode).
+                // Position us at the correct place in the file.
+                if (start > ib.limit()) {
+                    logger.debug("  start=" + start + ", ib.limit()=" + ib.limit());
+                }
+                ib.position(start);
+                ib.get(snippet);
+            }
             result.add(snippet);
         }
 

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/DocProperty.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/DocProperty.java
@@ -15,21 +15,26 @@
  *******************************************************************************/
 package nl.inl.blacklab.resultproperty;
 
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
-import nl.inl.blacklab.search.BlackLabIndex;
-import nl.inl.blacklab.search.results.DocResult;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.Query;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.search.BlackLabIndex;
+import nl.inl.blacklab.search.results.DocResult;
 
 /**
  * Abstract base class for criteria on which to group DocResult objects.
  * Subclasses implement specific grouping criteria (number of hits, the value of
  * a stored field in the Lucene document, ...)
+ *
+ * This class is thread-safe.
+ * Some DocProperty instances use synchronization for threadsafety, e.g. DocPropertyStoredField,
+ * because they store DocValues instances, which may only be used from one thread at a time.
  */
 public abstract class DocProperty implements ResultProperty<DocResult>, Comparator<DocResult> {
     protected static final Logger logger = LogManager.getLogger(DocProperty.class);

--- a/engine/src/main/java/nl/inl/blacklab/search/fimatch/ForwardIndexAccessorImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/fimatch/ForwardIndexAccessorImpl.java
@@ -20,6 +20,8 @@ import nl.inl.blacklab.search.lucene.DocIntFieldGetter;
  * Allows the forward index matching subsystem to access the forward indices,
  * including an easy and fast way to read any annotation at any position from a
  * document.
+ *
+ * Thread-safe.
  */
 class ForwardIndexAccessorImpl extends ForwardIndexAccessor {
 
@@ -101,6 +103,11 @@ class ForwardIndexAccessorImpl extends ForwardIndexAccessor {
         return new ForwardIndexAccessorLeafReaderImpl(reader);
     }
 
+    /**
+     * Forward index accessor for a single LeafReader.
+     *
+     * Thread-safe.
+     */
     class ForwardIndexAccessorLeafReaderImpl extends ForwardIndexAccessorLeafReader {
 
         private List<DocIntFieldGetter> fiidGetters;

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/DocIntFieldGetter.java
@@ -16,6 +16,10 @@ import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
  * Used to get an integer field value for a document.
  *
  * This is used by SpanQueryFiSeq to get the forward index id (fiid).
+ *
+ * This class is thread-safe.
+ * (using synchronization on DocValues instance; DocValues are stored for each LeafReader,
+ *  and each of those should only be used from one thread at a time)
  */
 public class DocIntFieldGetter implements Closeable {
 
@@ -27,9 +31,6 @@ public class DocIntFieldGetter implements Closeable {
 
     /** Lengths may have been cached using FieldCache */
     private NumericDocValues docValues;
-
-    /** Reader for getting docValues even when they weren't explicitly indexed */
-    private UninvertingReader uninv;
 
     public DocIntFieldGetter(LeafReader reader, String fieldName) {
         this.reader = reader;
@@ -53,13 +54,7 @@ public class DocIntFieldGetter implements Closeable {
 
     @Override
     public void close() {
-        if (uninv != null) {
-            try {
-                uninv.close();
-            } catch (IOException e) {
-                throw BlackLabRuntimeException.wrap(e);
-            }
-        }
+        // NOP
     }
 
     /**
@@ -72,7 +67,9 @@ public class DocIntFieldGetter implements Closeable {
 
         // Cached doc values?
         if (docValues != null) {
-            return (int) docValues.get(doc);
+            synchronized (docValues) {
+                return (int) docValues.get(doc);
+            }
         }
 
         // No; get the field value from the Document object.

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
@@ -150,8 +150,8 @@ public class Contexts implements Iterable<int[]> {
      * Get context words from the forward index.
      *
      * @param hits the hits
-     * @param start inclusive
-     * @param end exclusive
+     * @param start first hit to get context words for
+     * @param end first hit NOT to get context for (hit after the last to get context for)
      * @param contextSize how many words of context we want
      * @param contextSources forward indices to get context from
      * @param fiidLookups how to find the forward index ids of documents
@@ -313,6 +313,7 @@ public class Contexts implements Iterable<int[]> {
                     int[][] docContextArray = getContextWordsSingleDocument(ha, firstHitInCurrentDoc, i, contextSize, fis, fiidLookups);
                     for (int[] contextForHit : docContextArray) { contexts.add(contextForHit); }
                     // start a new document
+                    prevDoc = curDoc;
                     firstHitInCurrentDoc = i;
                 }
             }
@@ -336,7 +337,7 @@ public class Contexts implements Iterable<int[]> {
     /**
      * Return the context(s) for the specified hit number
      *
-     * @param hit which hit we want the context(s) for
+     * @param index which hit we want the context(s) for
      * @return the context(s)
      */
     public int[] get(int index) {

--- a/engine/src/main/java/nl/inl/blacklab/search/results/DocResults.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/DocResults.java
@@ -15,26 +15,43 @@
  *******************************************************************************/
 package nl.inl.blacklab.search.results;
 
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
-import nl.inl.blacklab.exceptions.InterruptedSearch;
-import nl.inl.blacklab.resultproperty.*;
-import nl.inl.blacklab.search.results.Hits.EphemeralHit;
-import nl.inl.blacklab.search.results.Hits.HitsArrays;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.Weight;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.exceptions.InterruptedSearch;
+import nl.inl.blacklab.resultproperty.DocProperty;
+import nl.inl.blacklab.resultproperty.DocPropertyAnnotatedFieldLength;
+import nl.inl.blacklab.resultproperty.HitProperty;
+import nl.inl.blacklab.resultproperty.HitPropertyDoc;
+import nl.inl.blacklab.resultproperty.PropertyValue;
+import nl.inl.blacklab.resultproperty.PropertyValueDoc;
+import nl.inl.blacklab.resultproperty.PropertyValueInt;
+import nl.inl.blacklab.search.results.Hits.EphemeralHit;
+import nl.inl.blacklab.search.results.Hits.HitsArrays;
 
 /**
  * A list of DocResult objects (document-level query results).
+ *
+ * This class is thread-safe.
  */
 public class DocResults extends ResultsList<DocResult, DocProperty> implements ResultGroups<Hit> {
 

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Hits.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Hits.java
@@ -1,5 +1,19 @@
 package nl.inl.blacklab.search.results;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.exceptions.WildcardTermTooBroad;
@@ -13,16 +27,13 @@ import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 import nl.inl.blacklab.search.lucene.BLSpanQuery;
 import nl.inl.util.Sort;
 import nl.inl.util.Sort.Sortable;
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 
-import java.util.*;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
-
+/**
+ * A collection of matches.
+ *
+ * Mostly thread-safe. Deprecated method sortInPlace() is not and
+ * should be avoided.
+ */
 public abstract class Hits extends Results<Hit, HitProperty> {
 
     /** A mutable implementation of Hit, to be used for short-lived
@@ -292,7 +303,10 @@ public abstract class Hits extends Results<Hit, HitProperty> {
          * Note this will be less efficient than regular sort(), because this avoids allocating copies of internal data, thus needing more swaps.
          * In order to do that, more swaps and pointer chases are required (in practice, 0.5n pointer chases of average length log2(n), and 0.5n
          * swaps)
+         *
+         * @deprecated unused and not threadsafe
          */
+        @Deprecated
         public void sortInPlace(HitProperty p) {
             this.lock.writeLock().lock();
 

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Results.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Results.java
@@ -18,6 +18,8 @@ import nl.inl.util.ThreadAborter;
 /**
  * A list of results of some type.
  *
+ * All subclasses should be thread-safe.
+ *
  * @param <T> result type, e.g. Hit
  */
 public abstract class Results<T, P extends ResultProperty<T>> implements SearchResult, Iterable<T> {


### PR DESCRIPTION
There would occassionaly be strange crashes while searching, mostly related to reading
from the Lucene index or the forward index.

An example of a query that frequently crashed, especially shortly after starting the server:

/test/hits?patt=%5B%5D&sort=wordleft%3Aword%3Ai%2Cwordright%3Aword%3Ai%2Cfield%3Apid&wordsaroundhit=1
(usecache=no, waitfortotal=true were also passed)

The problems appear to have been introduced when some operations were parallelized, but because
classes weren't clearly marked as threadsafe or not, not all necessary synchronization was done.

This adds synchronization where needed and marks several important classes as
thread-safe (or not). This appears to solve the intermittent crashes.

It would be good to investigate and document the thread-safety of more classes.

In addition to the concurrency issues, a bug in the Contexts constructor also caused problems when sorting by context.