### PR TITLE
Some more optimizations for hit frequencies

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/AnnotationForwardIndex.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/AnnotationForwardIndex.java
@@ -252,6 +252,16 @@ public abstract class AnnotationForwardIndex {
     public abstract List<int[]> retrievePartsInt(int fiid, int[] start, int[] end);
 
     /**
+     * Retrieve token ids for the entire document.
+     * @param fiid forward index id
+     * @return token ids for the entire document.
+     */
+    public int[] getDocument(int fiid) {
+        int[] fullDoc = new int[] { -1 };
+        return retrievePartsInt(fiid, fullDoc, fullDoc).get(0);
+    }
+
+    /**
      * Get the Terms object in order to translate ids to token strings
      * 
      * @return the Terms object
@@ -306,8 +316,7 @@ public abstract class AnnotationForwardIndex {
         if (!initialized)
             initialize();
         for (Integer fiid: idSet()) {
-            int[] tokenIds = retrievePartsInt(fiid, new int[] { -1 }, new int[] { -1 }).get(0);
-            task.perform(fiid, tokenIds);
+            task.perform(fiid, getDocument(fiid));
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/Terms.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/Terms.java
@@ -1,8 +1,5 @@
 package nl.inl.blacklab.forwardindex;
 
-import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
-import org.eclipse.collections.api.set.primitive.MutableIntSet;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.Buffer;
@@ -12,6 +9,10 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.charset.Charset;
 import java.text.Collator;
+
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 
 /**
  * Keeps a list of unique terms and their sort positions.
@@ -174,6 +175,7 @@ public abstract class Terms {
      * @return the sort position
      */
     public abstract int idToSortPosition(int id, MatchSensitivity sensitivity);
+
 
     /**
      * Convert an array of term ids to sort positions

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReader.java
@@ -285,31 +285,6 @@ public class TermsReader extends Terms {
         return sensitivity.isCaseSensitive() ? this.getSortPositionSensitive(id): this.getSortPositionInsensitive(id);
     }
 
-    /**
-     * Get the sort position for an array of terms based on its term id
-     *
-     * CAUTION: for maximum speed, does not verify that the term ids are valid!
-     * This is not a problem if you e.g. read them from the forward index, but
-     * it is if they came from e.g. a URL parameter.
-     *
-     * @param ids the term ids
-     * @param sensitivity whether we want the sensitive or insensitive sort position
-     * @return the sort positions
-     */
-    public int[] idToSortPositionUnsafe(int[] ids, MatchSensitivity sensitivity) {
-        int[] sortValues = new int[ids.length];
-        if (sensitivity.isCaseSensitive()) {
-            for (int tokenIndex = 0; tokenIndex < ids.length; ++tokenIndex) {
-                sortValues[tokenIndex] = this.termId2SensitivePosition[ids[tokenIndex]];
-            }
-        } else {
-            for (int tokenIndex = 0; tokenIndex < ids.length; ++tokenIndex) {
-                sortValues[tokenIndex] = this.termId2InsensitivePosition[ids[tokenIndex]];
-            }
-        }
-        return sortValues;
-    }
-
     @Override
     public String get(int id) {
         if (id >= numberOfTerms || id < 0) { return ""; }

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReader.java
@@ -285,6 +285,31 @@ public class TermsReader extends Terms {
         return sensitivity.isCaseSensitive() ? this.getSortPositionSensitive(id): this.getSortPositionInsensitive(id);
     }
 
+    /**
+     * Get the sort position for an array of terms based on its term id
+     *
+     * CAUTION: for maximum speed, does not verify that the term ids are valid!
+     * This is not a problem if you e.g. read them from the forward index, but
+     * it is if they came from e.g. a URL parameter.
+     *
+     * @param ids the term ids
+     * @param sensitivity whether we want the sensitive or insensitive sort position
+     * @return the sort positions
+     */
+    public int[] idToSortPositionUnsafe(int[] ids, MatchSensitivity sensitivity) {
+        int[] sortValues = new int[ids.length];
+        if (sensitivity.isCaseSensitive()) {
+            for (int tokenIndex = 0; tokenIndex < ids.length; ++tokenIndex) {
+                sortValues[tokenIndex] = this.termId2SensitivePosition[ids[tokenIndex]];
+            }
+        } else {
+            for (int tokenIndex = 0; tokenIndex < ids.length; ++tokenIndex) {
+                sortValues[tokenIndex] = this.termId2InsensitivePosition[ids[tokenIndex]];
+            }
+        }
+        return sortValues;
+    }
+
     @Override
     public String get(int id) {
         if (id >= numberOfTerms || id < 0) { return ""; }

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsWriter.java
@@ -1,13 +1,6 @@
 
 package nl.inl.blacklab.forwardindex;
 
-import net.jcip.annotations.NotThreadSafe;
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
-import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.eclipse.collections.api.set.primitive.MutableIntSet;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -21,6 +14,14 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+
+import net.jcip.annotations.NotThreadSafe;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 
 /**
  * Keeps a first-come-first-serve list of unique terms. Each term gets a unique

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/HitProperty.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/HitProperty.java
@@ -15,6 +15,11 @@
  *******************************************************************************/
 package nl.inl.blacklab.resultproperty;
 
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
@@ -22,11 +27,11 @@ import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
-import nl.inl.blacklab.search.results.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
+import nl.inl.blacklab.search.results.ContextSize;
+import nl.inl.blacklab.search.results.Contexts;
+import nl.inl.blacklab.search.results.Hit;
+import nl.inl.blacklab.search.results.Hits;
+import nl.inl.blacklab.search.results.Results;
 
 /**
  * Abstract base class for a property of a hit, like document title, hit text,
@@ -342,6 +347,8 @@ public abstract class HitProperty implements ResultProperty<Hit>, IntComparator 
      * return the latter as a DocPropertyStoredField.
      * 
      * This is used for calculating the relative frequency when grouping on a metadata field.
+     *
+     * It is also used in HitGroupsTokenFrequencies to speed up large frequency list requests.
      * 
      * @return metadata portion of this property, or null if there is none
      */

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
@@ -183,7 +183,7 @@ public class HitGroupsTokenFrequencies {
         SearchSettings searchSettings = source.searchSettings();
 
         try {
-            /** This is where we store our groups while we're computing/gathering them. Maps from group Id to number of hits (left) and number of docs (right) */
+            /** This is where we store our groups while we're computing/gathering them. Maps from group Id to number of hits and number of docs */
             final ConcurrentHashMap<GroupIdHash, OccurranceCounts> occurances = new ConcurrentHashMap<>();
 
             final BlackLabIndex index = queryInfo.index();

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
@@ -368,10 +368,7 @@ public class HitGroupsTokenFrequencies {
 
                             // now we have all values for all relevant annotations for this document
                             // iterate again and pair up the nth entries for all annotations, then store that as a group.
-                            /**
-                             * Bookkeeping: track which groups we've already seen in this document,
-                             * so we only count this document once per group
-                             */
+                            /** Keep track of term occurrences in this document; later we'll merge it with the global term frequencies */
                             Map<GroupIdHash, OccurranceCounts> occsInDoc = new HashMap<>();
                             try (BlockTimer f = c.child("Group tokens")) {
 
@@ -392,6 +389,7 @@ public class HitGroupsTokenFrequencies {
                                     }
                                     final GroupIdHash groupId = new GroupIdHash(annotationValuesForThisToken, sortPositions, metadataValuesForGroup, metadataValuesHash);
 
+                                    // Count occurrence in this doc
                                     OccurranceCounts occ = occsInDoc.get(groupId);
                                     if (occ == null) {
                                         occ = new OccurranceCounts(1, 1);
@@ -403,6 +401,7 @@ public class HitGroupsTokenFrequencies {
 
                                 }
 
+                                // Merge occurrences in this doc with global occurrences
                                 occsInDoc.forEach((groupId, occ) -> {
                                     occurances.compute(groupId, (__, groupSize) -> {
                                         if (groupSize != null) {

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
@@ -122,23 +122,43 @@ public class HitGroupsTokenFrequencies {
             return new PropInfo(false, index);
         }
 
-        public boolean isDocProperty;
+        private boolean docProperty;
 
-        public int indexInList;
+        private int indexInList;
 
-        private PropInfo(boolean isDocProperty, int indexInList) {
-            this.isDocProperty = isDocProperty;
+        public boolean isDocProperty() {
+            return docProperty;
+        }
+
+        public int getIndexInList() {
+            return indexInList;
+        }
+
+        private PropInfo(boolean docProperty, int indexInList) {
+            this.docProperty = docProperty;
             this.indexInList = indexInList;
         }
     }
 
     /** Info about an annotation we're grouping on. */
     private static final class AnnotInfo {
-        public AnnotationForwardIndex annotationForwardIndex;
+        private AnnotationForwardIndex annotationForwardIndex;
 
-        public MatchSensitivity matchSensitivity;
+        private MatchSensitivity matchSensitivity;
 
-        public Terms terms;
+        private Terms terms;
+
+        public AnnotationForwardIndex getAnnotationForwardIndex() {
+            return annotationForwardIndex;
+        }
+
+        public MatchSensitivity getMatchSensitivity() {
+            return matchSensitivity;
+        }
+
+        public Terms getTerms() {
+            return terms;
+        }
 
         public AnnotInfo(AnnotationForwardIndex annotationForwardIndex, MatchSensitivity matchSensitivity, Terms terms) {
             this.annotationForwardIndex = annotationForwardIndex;
@@ -292,7 +312,7 @@ public class HitGroupsTokenFrequencies {
                     final String lengthTokensFieldName = AnnotatedFieldNameUtil.lengthTokensField(fieldName);
 
                     // Determine all the fields we want to be able to load, so we don't need to load the entire document
-                    final List<String> annotationFINames = hitProperties.stream().map(tr -> tr.annotationForwardIndex.annotation().forwardIndexIdField()).collect(Collectors.toList());
+                    final List<String> annotationFINames = hitProperties.stream().map(tr -> tr.getAnnotationForwardIndex().annotation().forwardIndexIdField()).collect(Collectors.toList());
                     final Set<String> fieldsToLoad = new HashSet<>();
                     fieldsToLoad.add(lengthTokensFieldName);
                     fieldsToLoad.addAll(annotationFINames);
@@ -316,7 +336,7 @@ public class HitGroupsTokenFrequencies {
 
                             try (BlockTimer e = c.child("Read annotations from forward index")) {
                                 for (AnnotInfo annot : hitProperties) {
-                                    final AnnotationForwardIndex afi = annot.annotationForwardIndex;
+                                    final AnnotationForwardIndex afi = annot.getAnnotationForwardIndex();
                                     final String annotationFIName = afi.annotation().forwardIndexIdField();
                                     final int fiid = doc.getField(annotationFIName).numericValue().intValue();
                                     final int[] tokenValues = afi.getDocument(fiid);
@@ -329,7 +349,7 @@ public class HitGroupsTokenFrequencies {
                                     int[] sortValues = new int[docLength];
                                     for (int tokenIndex = 0; tokenIndex < docLength; ++tokenIndex) {
                                         final int termId = tokenValues[tokenIndex];
-                                        sortValues[tokenIndex] = annot.terms.idToSortPosition(termId, annot.matchSensitivity);
+                                        sortValues[tokenIndex] = annot.getTerms().idToSortPosition(termId, annot.getMatchSensitivity());
                                     }
                                     sortValuesPerAnnotation.add(sortValues);
                                 }
@@ -419,15 +439,15 @@ public class HitGroupsTokenFrequencies {
                     // Taking care to preserve the order of the resultant PropertyValues with the order of the input HitProperties
                     int indexInOutput = 0;
                     for (PropInfo p : originalOrderOfUnpackedProperties) {
-                        final int indexInInput = p.indexInList;
-                        if (p.isDocProperty) {
+                        final int indexInInput = p.getIndexInList();
+                        if (p.isDocProperty()) {
                             // is docprop, add PropertyValue as-is
                             groupIdAsList[indexInOutput++] = metadataValues[indexInInput];
                         } else {
                              // is hitprop, convert value to PropertyValue.
                             AnnotInfo annotInfo = hitProperties.get(indexInInput);
-                            Annotation annot = annotInfo.annotationForwardIndex.annotation();
-                            MatchSensitivity sens = annotInfo.matchSensitivity;
+                            Annotation annot = annotInfo.getAnnotationForwardIndex().annotation();
+                            MatchSensitivity sens = annotInfo.getMatchSensitivity();
                             groupIdAsList[indexInOutput++] = new PropertyValueContextWords(index, annot, sens, new int[] {annotationValues[indexInInput]}, false);
                         }
                     }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitGroupsTokenFrequencies.java
@@ -360,7 +360,8 @@ public class HitGroupsTokenFrequencies {
                             int docLength = Integer.parseInt(doc.get(lengthTokensFieldName)) - BlackLabIndex.IGNORE_EXTRA_CLOSING_TOKEN;
                             final DocResult synthesizedDocResult = DocResult.fromDoc(queryInfo, new PropertyValueDoc(new DocImpl(queryInfo.index(), docId)), 0, docLength);
                             final PropertyValue[] metadataValuesForGroup = !docProperties.isEmpty() ? new PropertyValue[docProperties.size()] : null;
-                            for (int i = 0; i < docProperties.size(); ++i) { metadataValuesForGroup[i] = docProperties.get(i).get(synthesizedDocResult); }
+                            for (int i = 0; i < docProperties.size(); ++i)
+                                metadataValuesForGroup[i] = docProperties.get(i).get(synthesizedDocResult);
                             final int metadataValuesHash = Arrays.hashCode(metadataValuesForGroup); // precompute, it's the same for all hits in document
 
                             // now we have all values for all relevant annotations for this document

--- a/mocks/src/main/java/nl/inl/blacklab/mocks/MockTerms.java
+++ b/mocks/src/main/java/nl/inl/blacklab/mocks/MockTerms.java
@@ -1,10 +1,11 @@
 package nl.inl.blacklab.mocks;
 
-import nl.inl.blacklab.forwardindex.Terms;
-import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
+import java.io.File;
+
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 
-import java.io.File;
+import nl.inl.blacklab.forwardindex.Terms;
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 
 public class MockTerms extends Terms {
 


### PR DESCRIPTION
- Move maxHitsToCount check out of inner loop. We accept that we might exceed maxHitsToCount a bit, but that's okay. When we stop because of this limit, the results aren't that useful anyway, it's more about keeping the server available.
- Collect token frequencies per document, then merge (saves synchronization)
- Collect all sort values for a document at once

Certain (partial) grouping requests of our 2.2G corpus can be 2-6 times faster now.