### PR TITLE
Improving  Counting Results

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/exceptions/InterruptedSearch.java
+++ b/engine/src/main/java/nl/inl/blacklab/exceptions/InterruptedSearch.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import nl.inl.blacklab.searches.SearchCacheEntry;
 
+import java.util.concurrent.ExecutionException;
+
 /**
  * Thrown in response to InterruptedException to indicate that a thread was interrupted.
  *
@@ -21,6 +23,10 @@ public class InterruptedSearch extends BlackLabRuntimeException {
     }
 
     public InterruptedSearch(InterruptedException e) {
+        super(DEFAULT_MESSAGE, e);
+    }
+
+    public InterruptedSearch(ExecutionException e) {
         super(DEFAULT_MESSAGE, e);
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/Search.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/Search.java
@@ -4,6 +4,8 @@ import nl.inl.blacklab.exceptions.InvalidQuery;
 import nl.inl.blacklab.search.results.QueryInfo;
 import nl.inl.blacklab.search.results.SearchResult;
 
+import java.util.concurrent.Future;
+
 /**
  * A 'recipe' of search operations.
  *
@@ -121,7 +123,7 @@ public interface Search<R extends SearchResult> {
      *
      * @return the result so far, or null if not supported for this operation
      */
-    default R peek() {
+    default R peek(Future<R> task) {
         return null;
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntryFromFuture.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntryFromFuture.java
@@ -44,7 +44,7 @@ public class SearchCacheEntryFromFuture<R extends SearchResult> extends SearchCa
     public R peek() throws ExecutionException {
         if (isCancelled())
             throw new ExecutionException("Search was cancelled", null);
-        return search.peek();
+        return search.peek(future);
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCount.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCount.java
@@ -3,6 +3,8 @@ package nl.inl.blacklab.searches;
 import nl.inl.blacklab.search.results.QueryInfo;
 import nl.inl.blacklab.search.results.ResultsStats;
 
+import java.util.concurrent.Future;
+
 /**
  * A search operation that yields a count as its result.
  */
@@ -18,6 +20,6 @@ public abstract class SearchCount extends AbstractSearch<ResultsStats> {
      * @return running count
      */
     @Override
-    public abstract ResultsStats peek();
+    public abstract ResultsStats peek(Future<ResultsStats> task);
 
 }

--- a/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
@@ -462,6 +462,6 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
     public T peek() throws ExecutionException {
         if (isCancelled())
             throw new ExecutionException(exceptionThrown);
-        return this.search.peek();
+        return this.search.peek(this);
     }
 }

--- a/test/test/hits.js
+++ b/test/test/hits.js
@@ -127,6 +127,11 @@ function expectHitsJson(pattern, numberOfHits, numberOfDocs, expectedFirstHitJso
 function expectHitsText(pattern, numberOfHits, numberOfDocs, expectedFirstHitText) {
     expectHitsImpl(pattern, numberOfHits, numberOfDocs, undefined, expectedFirstHitText, undefined);
 }
+function expectHitsTextMultipleSearches(pattern, numberOfHits, numberOfDocs, expectedFirstHitText) {
+    for (let i = 0; i < 5; i++) {
+        expectHitsImpl(pattern, numberOfHits, numberOfDocs, undefined, expectedFirstHitText, undefined);
+    }
+}
 
 // Test that a hits search for a pattern returns the correct number of hits and docs,
 // and optionally test that the first hit text matches the specified text.
@@ -228,6 +233,7 @@ expectHitsText('"two|four"', 3, 1, "two");
 expectHitsText('"two"|"four"', 3, 1, "two");
 expectHitsText('[lemma="be" & word="are"]', 7, 2, "are");
 expectHitsText('[lemma="be" & word!="are"]', 35, 3, "'m");
+expectHitsTextMultipleSearches('[lemma="be" & word!="are"]', 35, 3, "'m");
 expectHitsText('<u/> containing "good"', 5, 1, "oh er it 's it 's very good _0 the the er _0 very fresh air and kind people _0");
 
 // Check if docPid, hit start and hit end match


### PR DESCRIPTION
Hey all, we noticed a regression on performance due to some recent changes in `SearchCountFromResults`. This seems to be true mostly for the new `ResultsCache`( thought we might be able to  end up in a similar state with the `BlsCache`).

When peeking at the count, I am proposing to: 
1. Pass the future representing the search task and if it has finished use the results from there.
2. For the cases where the count is still ongoing, use a `CountDownLatch` to mark the end of the search task and avoid waiting unnecessarily.

I am also setting a limit to the time we can wait for the latch, this is will allows to avoid impacting throughput in cases where the searches take a long time to finalize, the maximum time could be made into a setting if need be.


Let me know what you all think about these changes.
