### PR TITLE
Adds small changes to logging and error reporting

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/Response.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/Response.java
@@ -3,6 +3,8 @@ package nl.inl.blacklab.server.requesthandlers;
 import nl.inl.blacklab.server.datastream.DataStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import nl.inl.blacklab.server.exceptions.BlsException;
+
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -46,8 +48,12 @@ public class Response {
     // Highest internal error code so far: 32
 
     public static int internalError(DataStream ds, Exception e, boolean debugMode, String code) {
-        logger.debug("INTERNAL ERROR " + code + ":");
-        e.printStackTrace();
+        if (e.getCause() instanceof BlsException) {
+            BlsException cause = (BlsException) e.getCause();
+            logger.warn("BLACKLAB EXCEPTION " + cause.getBlsErrorCode(), e);
+            return Response.error(ds, cause.getBlsErrorCode(), cause.getMessage(), cause.getHttpStatusCode());
+        }
+        logger.error("INTERNAL ERROR " + code + ":", e);
         ds.internalError(e, debugMode, code);
         return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -3,12 +3,13 @@
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT">
 			<!-- DEFAULT:<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />  -->
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%-20t] %-35c{2} %-5p %m%n" />
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%-20t] %-35c{2.} %-5p rid=%X{requestId} %m%n" />
 		</Console>
 	</Appenders>
 	<Loggers>
 		<Root level="debug">
 			<AppenderRef ref="Console" />
 		</Root>
+		<Logger name="io.netty" level="ERROR"/>
 	</Loggers>
 </Configuration>

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -10,6 +10,5 @@
 		<Root level="debug">
 			<AppenderRef ref="Console" />
 		</Root>
-		<Logger name="io.netty" level="ERROR"/>
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
Hey all

I wanted to share two other small changes we have found useful
1. If an error is coming from an identified Blacklab Exception return more information as part of HTTP response
2. Render the request id in the tomcat logs. Useful when debugging a particular query as it will print out the the request id in all log messages(that contain the request id), thus you can observe the history of a request.