### PR TITLE
Fixes setDefaultThreshold and others

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/config/BLConfigSearch.java
+++ b/engine/src/main/java/nl/inl/blacklab/config/BLConfigSearch.java
@@ -68,7 +68,7 @@ public class BLConfigSearch {
         int maxHitsToCount = getMaxHitsToCount();
         long fiMatchFactor = getFiMatchFactor();
         SearchSettings sett = SearchSettings.get(maxHitsToProcess, maxHitsToCount, fiMatchFactor);
-        ClauseCombinerNfa.setDefaultForwardIndexMatchingThreshold(fiMatchFactor);
+        ClauseCombinerNfa.setNfaThreshold(fiMatchFactor);
         index.setSearchSettings(sett);
     }
 }

--- a/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/ResultsCache.java
@@ -154,10 +154,13 @@ public class ResultsCache implements SearchCache {
                     ThreadContext.remove("requestId");
                     return new CacheEntryWithResults<>(results, System.currentTimeMillis() - startTime);
                 }));
-                CacheEntryWithResults<? extends SearchResult> searchResult = job.get();
-                logger.warn("Internal search time is: {}", searchResult.timeUserWaitedMs());
-                runningJobs.remove(searchWrapper.getSearch());
-                return searchResult.getResults();
+                try {
+                    CacheEntryWithResults<? extends SearchResult> searchResult = job.get();
+                    logger.warn("Internal search time is: {}", searchResult.timeUserWaitedMs());
+                    return searchResult.getResults();
+                } finally {
+                    runningJobs.remove(searchWrapper.getSearch());
+                }
             }
         };
 


### PR DESCRIPTION
Hey @jan-niestadt, would you mind double checking this small fix. I think if we set the setting
`search.fiMatchFactor` we don't actually end up modifying the value?

This PR also contains a fix for leaking future in the ResultsCache