### PR TITLE
set indexer to default config directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,9 @@ services:
         dockerfile: docker/Dockerfile
     command: >-
         /bin/bash -c 
-        "cd /usr/local/lib/blacklab-tools && 
-        java -cp '*' nl.inl.blacklab.tools.IndexTool create /data/${INDEX_NAME} /input ${INDEX_FORMAT}"
+        "cd /usr/local/lib/blacklab-tools &&
+        mkdir -p /data/index && mkdir -p /data/user-index && 
+        java -cp '*' nl.inl.blacklab.tools.IndexTool create /data/index/${INDEX_NAME} /input ${INDEX_FORMAT}"
     volumes:
       - "${BLACKLAB_FORMATS_DIR:-./formats}:/etc/blacklab/formats"
       - "${INDEX_INPUT_DIR:-./input}:/input"


### PR DESCRIPTION
I tried to index in and then start a dockerized BlackLab server following https://github.com/INL/BlackLab#using-blacklab-with-docker . This resulted in 

```
blacklabResponse>
<error>
<code>INTERNAL_ERROR</code>
<message>
<![CDATA[ Configuration error: no readable index locations found. Create /etc/blacklab/blacklab-server.json containing at least the following: { "indexCollections": [ "/dir/containing/indices" ] } ]]>
</message>
</error>
</blacklabResponse>
```

when I tried to access my index. The error message is somewhat confusing and might need to be updated to mention blacklab-server.yaml, but it is not in the scope of this PR.

Currently the dockerized server takes it's config by default from https://github.com/INL/BlackLab/blob/dev/docker/config/blacklab-server.yaml . This PR updates the `docker-compose.yml` to reflect that. This allows users to run dockerized BlackLab out of the box.

Note that using a different configuration file like https://github.com/INL/BlackLab/blob/dev/docker/blacklab-server-FULL-EXAMPLE.yaml will still require a different configuration for the indexer.

