### PR TITLE
A few small changes to the Docker setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     command: >-
         /bin/bash -c 
         "cd /usr/local/lib/blacklab-tools &&
-        mkdir -p /data/index && mkdir -p /data/user-index && 
         java -cp '*' nl.inl.blacklab.tools.IndexTool create /data/index/${INDEX_NAME} /input ${INDEX_FORMAT}"
     volumes:
       - "${BLACKLAB_FORMATS_DIR:-./formats}:/etc/blacklab/formats"
@@ -53,7 +52,7 @@ services:
       - JPDA_ADDRESS=*:5005
       - JPDA_TRANSPORT=dt_socket
     # Create test index. Run Tomcat with JPDA enabled
-    command: "/bin/bash /etc/blacklab/start-server.sh"
+    command: "/bin/bash /etc/blacklab/start-with-test-data.sh"
     ports:
       - "${BLACKLAB_TEST_PORT:-8080}:8080"
       - "5005:5005"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,11 +25,11 @@ COPY ${CONFIG_ROOT}/server.xml /usr/local/tomcat/conf/
 # Copy the configuration file
 COPY ${CONFIG_ROOT}/blacklab-server.yaml /etc/blacklab/
 
-# Copy the starup script
-COPY docker/start-server.sh /etc/blacklab/start-server.sh
+# Copy the startup scripts
+COPY docker/*.sh /etc/blacklab/
 
-# Create directory for formats
-RUN mkdir /etc/blacklab/formats
+# Create directories for formats and data
+RUN mkdir -p /etc/blacklab/formats /data/index /data/user-index
 
 # Copy the WAR file
 COPY --from=builder /app/server/target/blacklab-server-*.war /usr/local/tomcat/webapps/${TOMCAT_APP_NAME}.war

--- a/docker/start-debug-server.sh
+++ b/docker/start-debug-server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script is intended for regular (debug) use of the BlackLab image,
+# other than the integration tests. It will simply start Tomcat in debug mode.
+
+cd /usr/local/tomcat && catalina.sh jpda run

--- a/docker/start-with-test-data.sh
+++ b/docker/start-with-test-data.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script is intended for use with the integration tests.
+# It will remove previous data, index the test data and start Tomcat.
+
 rm -rf /data/index
 rm -rf /data/user-index
 


### PR DESCRIPTION
I'll be using the Docker image for testing the distributed search prototype, and I wanted the option to start with jpda but without the test data.

- Renamed start-server.sh to start-with-test-data.sh (clearer)
- Added start-debug-server.sh to only start Tomcat with jpda, no test data
- Dockerfile will ensure that /data/index and /data/user-index exist (unless you bind-mount /data)

Shouldn't affect the integration tests as far as I can see, but if you see any issues, please let me know.