### PR TITLE
Debug mode: originating ip. Subnets.

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -249,7 +249,7 @@ public class BlackLabServer extends HttpServlet {
         }
 
         // === Create RequestHandler object
-        boolean debugMode = searchManager.config().getDebug().isDebugMode(request.getRemoteAddr());
+        boolean debugMode = searchManager.config().getDebug().isDebugMode(getOriginatingAddress(request));
 
         // The outputType handling is a bit iffy:
         // For some urls the dataType is required to determined the correct RequestHandler to instance (the /docs/ and /hits/)
@@ -338,6 +338,22 @@ public class BlackLabServer extends HttpServlet {
             // This is okay, don't raise the alarm.
             logger.debug("(couldn't send response, client probably cancelled the request)");
         }
+    }
+
+    /**
+     * Get the originating address.
+     *
+     * This is either the "normal" remote address or, in the case of
+     * a reverse proxy setup, the value of the X-Forwarded-For header.
+     *
+     * @param request request
+     * @return originating address
+     */
+    public static String getOriginatingAddress(HttpServletRequest request) {
+        String remoteAddr = request.getHeader("X-Forwarded-For");
+        if (StringUtils.isEmpty(remoteAddr))
+            remoteAddr = request.getRemoteAddr();
+        return remoteAddr;
     }
 
     @Override

--- a/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigDebug.java
+++ b/server/src/main/java/nl/inl/blacklab/server/config/BLSConfigDebug.java
@@ -1,8 +1,9 @@
 package nl.inl.blacklab.server.config;
 
-
 import java.util.Collections;
 import java.util.List;
+
+import nl.inl.blacklab.server.util.BlsUtils;
 
 public class BLSConfigDebug {
     /** Explicit list of debug addresses */
@@ -30,7 +31,7 @@ public class BLSConfigDebug {
         if (alwaysAllowDebugInfo) {
             return true;
         }
-        return addresses.contains(ip);
+        return BlsUtils.wildcardIpsContain(addresses, ip);
     }
 
     public boolean isAlwaysAllowDebugInfo() {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -216,7 +216,7 @@ public abstract class RequestHandler {
                     }
                     if (!debugMode) {
                         return errorObj
-                                .unauthorized("You (" + request.getRemoteAddr() + ") are not authorized to do this.");
+                                .unauthorized("You (" + BlackLabServer.getOriginatingAddress(request) + ") are not authorized to do this.");
                     }
                     requestHandler = new RequestHandlerClearCache(servlet, request, user, indexName, urlResource,
                             urlPathInfo);
@@ -258,7 +258,7 @@ public abstract class RequestHandler {
                     }
                     if (!debugMode) {
                         return errorObj.unauthorized(
-                                "You (" + request.getRemoteAddr() + ") are not authorized to see this information.");
+                                "You (" + BlackLabServer.getOriginatingAddress(request) + ") are not authorized to see this information.");
                     }
                     requestHandler = new RequestHandlerCacheInfo(servlet, request, user, indexName, urlResource,
                             urlPathInfo);
@@ -423,7 +423,7 @@ public abstract class RequestHandler {
         String pathAndQueryString = ServletUtil.getPathAndQueryString(request);
 
         if (!(this instanceof RequestHandlerStaticResponse) && !pathAndQueryString.startsWith("/cache-info")) { // annoying when monitoring
-            logger.info(ServletUtil.shortenIpv6(request.getRemoteAddr()) + " " + user.uniqueIdShort() + " "
+            logger.info(ServletUtil.shortenIpv6(BlackLabServer.getOriginatingAddress(request)) + " " + user.uniqueIdShort() + " "
                     + request.getMethod() + " " + pathAndQueryString);
         }
 

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchParameters.java
@@ -42,6 +42,7 @@ import nl.inl.blacklab.searches.SearchEmpty;
 import nl.inl.blacklab.searches.SearchFacets;
 import nl.inl.blacklab.searches.SearchHitGroups;
 import nl.inl.blacklab.searches.SearchHits;
+import nl.inl.blacklab.server.BlackLabServer;
 import nl.inl.blacklab.server.config.BLSConfigParameters;
 import nl.inl.blacklab.server.datastream.DataStream;
 import nl.inl.blacklab.server.exceptions.BadRequest;
@@ -136,7 +137,7 @@ public class SearchParameters {
                 continue;
             param.put(name, value);
         }
-        param.setDebugMode(searchMan.config().getDebug().isDebugMode(request.getRemoteAddr()));
+        param.setDebugMode(searchMan.config().getDebug().isDebugMode(BlackLabServer.getOriginatingAddress(request)));
         return param;
     }
 

--- a/server/src/main/java/nl/inl/blacklab/server/util/BlsUtils.java
+++ b/server/src/main/java/nl/inl/blacklab/server/util/BlsUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -243,5 +244,19 @@ public class BlsUtils {
         if (sec == 0)
             return min + "m";
         return String.format("%dm%02ds", min, sec);
+    }
+
+    public static boolean wildcardIpMatches(String wildcardIpExpr, String ip) {
+        if (wildcardIpExpr.contains("*") || wildcardIpExpr.contains("?")) {
+            wildcardIpExpr = wildcardIpExpr.replaceAll("\\.", "\\\\.");
+            wildcardIpExpr = wildcardIpExpr.replaceAll("\\*", ".*");
+            wildcardIpExpr = wildcardIpExpr.replaceAll("\\?", ".");
+            return ip.matches(wildcardIpExpr);
+        }
+        return wildcardIpExpr.equals(ip);
+    };
+
+    public static boolean wildcardIpsContain(List<String> addresses, String ip) {
+        return addresses.stream().anyMatch(adr -> wildcardIpMatches(adr, ip));
     }
 }

--- a/server/src/test/java/nl/inl/blacklab/server/util/TestBlsUtils.java
+++ b/server/src/test/java/nl/inl/blacklab/server/util/TestBlsUtils.java
@@ -1,5 +1,7 @@
 package nl.inl.blacklab.server.util;
 
+import java.util.List;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -88,6 +90,24 @@ public class TestBlsUtils {
         Assert.assertEquals("1s", BlsUtils.describeIntervalSec(1));
         Assert.assertEquals("5m", BlsUtils.describeIntervalSec(300));
         Assert.assertEquals("5m01s", BlsUtils.describeIntervalSec(301));
+    }
+
+    @Test
+    public void testWildcardIpMatches() {
+        Assert.assertTrue(BlsUtils.wildcardIpMatches("1.2.3.*", "1.2.3.4"));
+        Assert.assertTrue(BlsUtils.wildcardIpMatches("1.2.*.4", "1.2.3.4"));
+        Assert.assertTrue(BlsUtils.wildcardIpMatches("*.2.3.4", "1.2.3.4"));
+        Assert.assertTrue(BlsUtils.wildcardIpMatches("1.2.3.4", "1.2.3.4"));
+
+        Assert.assertFalse(BlsUtils.wildcardIpMatches("1.2.3.*", "112.3.4"));
+        Assert.assertFalse(BlsUtils.wildcardIpMatches("1.2.3.4", "112.3.4"));
+        Assert.assertFalse(BlsUtils.wildcardIpMatches("1.2.3.4", "1.2.3.5"));
+
+        final String ipv6local = "0:0:0:0:0:0:0:1";
+        Assert.assertTrue(BlsUtils.wildcardIpMatches(ipv6local, ipv6local));
+
+        List<String> adr = List.of("127.0.0.1", ipv6local, "172.16.10.19");
+        Assert.assertTrue(BlsUtils.wildcardIpsContain(adr, ipv6local));
     }
 
 }


### PR DESCRIPTION
We now use the originating ip (`X-Forwarded-For` header if present) to determine debug mode (otherwise BLS behind a proxy always looks like a local request).

It is now also possible to use wildcards `*` and `?` in the `debug.addresses` section of `blacklab-server.yaml` to mark entire subnets as debug addresses, e.g. `172.16.4.*`.

(`debugMode` determines whether you can use `/cache-info` and `/cache-clear`; whether responses are pretty-printed by default; and whether you get stacktraces with error responses, and a few other things)

This change should not affect you if you have set the `debug.alwaysAllowDebugInfo` option to `true`. Otherwise, you may have to reconfigure your `debug.addresses` to include, for example, your internal network.