### PR TITLE
Improve how search/count times are reported

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
@@ -20,20 +20,17 @@ import nl.inl.blacklab.search.results.SearchResult;
  */
 public abstract class AbstractSearch<R extends SearchResult> implements Search<R> {
 
-    private final QueryInfo queryInfo;
-
-    public AbstractSearch(QueryInfo queryInfo) {
-        this.queryInfo = queryInfo;
-    }
-
-    @Override
-    public SearchCacheEntry<R> executeAsync(boolean allowQueue) {
-        return queryInfo.index().cache().getAsync(this, allowQueue);
-    }
-
-    @Override
-    public final R execute(boolean allowQueue) throws InvalidQuery {
-        SearchCacheEntry<R> future = executeAsync(allowQueue);
+    /**
+     * Wait for the result from a search task.
+     *
+     * Will throw InvalidQuery if the query couldn't executed, or an AssertionError in
+     * case of other errors.
+     *
+     * @param future search task
+     * @return result
+     * @param <R> result type
+     */
+    public static <R extends SearchResult> R getResult(SearchCacheEntry<R> future) throws InvalidQuery {
         try {
             return future.get();
         } catch (ExecutionException e) {
@@ -60,8 +57,53 @@ public abstract class AbstractSearch<R extends SearchResult> implements Search<R
         }
     }
 
+    private final QueryInfo queryInfo;
+
+    public AbstractSearch(QueryInfo queryInfo) {
+        this.queryInfo = queryInfo;
+    }
+
     @Override
-    public abstract R executeInternal(Peekable<R> progressReporter) throws InvalidQuery;
+    public SearchCacheEntry<R> executeAsync(boolean allowQueue) {
+        return queryInfo.index().cache().getAsync(this, allowQueue);
+    }
+
+    @Override
+    public final R execute(boolean allowQueue) throws InvalidQuery {
+        SearchCacheEntry<R> future = executeAsync(allowQueue);
+        return getResult(future);
+    }
+
+    /**
+     * Actually execute this search operation.
+     *
+     * @param searchTask represents the search being executed (also the "cache entry"), allows us to
+     *                   report progress (running count) and how long the task (originally) took
+     * @return results of the search operation
+     */
+    @Override
+    public abstract R executeInternal(SearchTask<R> searchTask) throws InvalidQuery;
+
+    public static <R extends SearchResult> R executeChildSearch(SearchTask<?> task, Search<R> childSearch) throws InvalidQuery {
+        // Don't time subtask now, because it could be in the cache.
+        // Instead, pause our timer and ask the subtask to report its original processing time (see below).
+        if (task != null)
+            task.stopTimer();
+        try {
+
+            // Get the subtask results and add its original processing time to our own
+            SearchCacheEntry<R> childsearchEntry = childSearch.executeAsync(false);
+            R result = getResult(childsearchEntry);
+            if (task != null)
+                task.addSubtaskTime(childsearchEntry);
+            return result;
+
+        } finally {
+            // Resume our own timer
+            if (task != null)
+                task.startTimer();
+        }
+    }
 
     @Override
     public QueryInfo queryInfo() {

--- a/engine/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/AbstractSearch.java
@@ -77,12 +77,12 @@ public abstract class AbstractSearch<R extends SearchResult> implements Search<R
     /**
      * Actually execute this search operation.
      *
-     * @param searchTask represents the search being executed (also the "cache entry"), allows us to
+     * @param activeSearch represents the search being executed (also the "cache entry"), allows us to
      *                   report progress (running count) and how long the task (originally) took
      * @return results of the search operation
      */
     @Override
-    public abstract R executeInternal(SearchTask<R> searchTask) throws InvalidQuery;
+    public abstract R executeInternal(ActiveSearch<R> activeSearch) throws InvalidQuery;
 
     /**
      * Execute a child search whose results we need.
@@ -97,7 +97,7 @@ public abstract class AbstractSearch<R extends SearchResult> implements Search<R
      * @return results from the child search
      * @param <R> result type
      */
-    protected static <R extends SearchResult> R executeChildSearch(SearchTask<?> task, Search<R> childSearch) throws InvalidQuery {
+    protected static <R extends SearchResult> R executeChildSearch(ActiveSearch<?> task, Search<R> childSearch) throws InvalidQuery {
         // Don't time subtask now, because it could be in the cache.
         // Instead, pause our timer and ask the subtask to report its original processing time (see below).
         if (task != null)

--- a/engine/src/main/java/nl/inl/blacklab/searches/ActiveSearch.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/ActiveSearch.java
@@ -1,19 +1,19 @@
 package nl.inl.blacklab.searches;
 
-import nl.inl.util.TaskTimer;
+import nl.inl.util.SearchTimer;
 
 /**
- * Most basic interface for a search task ("cache entry").
+ * Most basic interface for a search being (or having been) executed (aka "cache entry").
  *
  * This is passed to the Search.executeInternal() method so it has access
- * to the running task object. This enables it to update the running count
+ * to the active search object. This enables it to update the running count
  * during execution, as well as manage the timer (stopping it before executing
  * a subtask, adding the subtask's processing time, and re-starting it for the
  * rest of the execution)
  *
  * @param <T> type of result this task will yield
  */
-public interface SearchTask<T> {
+public interface ActiveSearch<T> {
     /**
      * Peek at the result.
      * @return null if not supported, a peek at the result otherwise
@@ -24,5 +24,5 @@ public interface SearchTask<T> {
      * Timer instance for this task.
      * @return tasks's timer
      */
-    TaskTimer timer();
+    SearchTimer timer();
 }

--- a/engine/src/main/java/nl/inl/blacklab/searches/Peekable.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/Peekable.java
@@ -1,9 +1,0 @@
-package nl.inl.blacklab.searches;
-
-public interface Peekable<T> {
-    /**
-     * Peek at the result.
-     * @return null if not supported, a peek at the result otherwise
-     */
-    default T peek() { return null; }
-}

--- a/engine/src/main/java/nl/inl/blacklab/searches/Search.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/Search.java
@@ -110,11 +110,11 @@ public interface Search<R extends SearchResult> {
      * executeAsync submits this search to the cache, which then calls this method from a Runnable
      * to run the search.
      *
-     * @param progressReporter where some operations will report on their progress, for example
+     * @param searchTask where some operations will report on their progress, for example
      *                 to be able to monitor the running count while hits are being fetched
      * @return result of the operation
      */
-    R executeInternal(Peekable<R> progressReporter) throws InvalidQuery;
+    R executeInternal(SearchTask<R> searchTask) throws InvalidQuery;
 
     /**
      * Return the peek object, given a cache entry.

--- a/engine/src/main/java/nl/inl/blacklab/searches/Search.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/Search.java
@@ -110,11 +110,11 @@ public interface Search<R extends SearchResult> {
      * executeAsync submits this search to the cache, which then calls this method from a Runnable
      * to run the search.
      *
-     * @param searchTask where some operations will report on their progress, for example
+     * @param activeSearch where some operations will report on their progress, for example
      *                 to be able to monitor the running count while hits are being fetched
      * @return result of the operation
      */
-    R executeInternal(SearchTask<R> searchTask) throws InvalidQuery;
+    R executeInternal(ActiveSearch<R> activeSearch) throws InvalidQuery;
 
     /**
      * Return the peek object, given a cache entry.

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntry.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntry.java
@@ -12,7 +12,7 @@ import nl.inl.blacklab.search.results.SearchResult;
  *
  * @param <R> the type of search result this search will yield
  */
-public abstract class SearchCacheEntry<R extends SearchResult> implements Future<R>, Peekable<R> {
+public abstract class SearchCacheEntry<R extends SearchResult> implements Future<R>, SearchTask<R> {
 
     /** When was our processing timer started? */
     private long timerStart = -1;
@@ -35,16 +35,17 @@ public abstract class SearchCacheEntry<R extends SearchResult> implements Future
     }
 
     /** (Re)start the task's processing timer, adding to its total. */
-    protected void startTimer() {
+    public void startTimer() {
         timerStart = System.currentTimeMillis();
     }
 
     /** Stop the task's processing timer, (temporarily) not keeping track of time elapsed. */
-    protected void stopTimer() {
+    public void stopTimer() {
         processingTime += System.currentTimeMillis() - timerStart;
     }
 
-    protected void addSubtaskTime(SearchCacheEntry subtask) {
+    /** Add the processing time for the subtask to this tasks's processing time. */
+    public void addSubtaskTime(SearchTask<?> subtask) {
         processingTime += subtask.processingTimeMs();
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntry.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCacheEntry.java
@@ -4,7 +4,7 @@ import java.util.concurrent.Future;
 
 import nl.inl.blacklab.exceptions.InterruptedSearch;
 import nl.inl.blacklab.search.results.SearchResult;
-import nl.inl.util.TaskTimer;
+import nl.inl.util.SearchTimer;
 
 /**
  * An entry in BlackLab's search cache.
@@ -13,17 +13,17 @@ import nl.inl.util.TaskTimer;
  *
  * @param <R> the type of search result this search will yield
  */
-public abstract class SearchCacheEntry<R extends SearchResult> implements Future<R>, SearchTask<R> {
+public abstract class SearchCacheEntry<R extends SearchResult> implements Future<R>, ActiveSearch<R> {
 
     /** Keep track of how long this task and subtasks took to (originally) execute. */
-    private TaskTimer taskTimer = new TaskTimer();
+    private SearchTimer searchTimer = new SearchTimer();
 
     /**
      * Get the timer keeping track of how long this search (originally) executed.
      * @return the search's task timer
      */
-    public TaskTimer timer() {
-        return taskTimer;
+    public SearchTimer timer() {
+        return searchTimer;
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFiltered.java
@@ -26,8 +26,8 @@ public class SearchCollocationsFiltered extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(Peekable<TermFrequencyList> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().filter(property, value);
+    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFiltered.java
@@ -26,8 +26,8 @@ public class SearchCollocationsFiltered extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).filter(property, value);
+    public TermFrequencyList executeInternal(ActiveSearch<TermFrequencyList> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFromHits.java
@@ -26,8 +26,8 @@ public class SearchCollocationsFromHits extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(Peekable<TermFrequencyList> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().collocations(annotation, contextSize, sensitivity);
+    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).collocations(annotation, contextSize, sensitivity);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsFromHits.java
@@ -26,8 +26,8 @@ public class SearchCollocationsFromHits extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).collocations(annotation, contextSize, sensitivity);
+    public TermFrequencyList executeInternal(ActiveSearch<TermFrequencyList> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).collocations(annotation, contextSize, sensitivity);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSampled.java
@@ -21,8 +21,8 @@ public class SearchCollocationsSampled extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sample(sampleParameters);
+    public TermFrequencyList executeInternal(ActiveSearch<TermFrequencyList> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSampled.java
@@ -21,8 +21,8 @@ public class SearchCollocationsSampled extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(Peekable<TermFrequencyList> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sample(sampleParameters);
+    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSorted.java
@@ -21,8 +21,8 @@ public class SearchCollocationsSorted extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sort(property);
+    public TermFrequencyList executeInternal(ActiveSearch<TermFrequencyList> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsSorted.java
@@ -21,8 +21,8 @@ public class SearchCollocationsSorted extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(Peekable<TermFrequencyList> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sort(property);
+    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsWindow.java
@@ -23,8 +23,8 @@ public class SearchCollocationsWindow extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).window(first, number);
+    public TermFrequencyList executeInternal(ActiveSearch<TermFrequencyList> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCollocationsWindow.java
@@ -23,8 +23,8 @@ public class SearchCollocationsWindow extends SearchCollocations {
     }
 
     @Override
-    public TermFrequencyList executeInternal(Peekable<TermFrequencyList> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().window(first, number);
+    public TermFrequencyList executeInternal(SearchTask<TermFrequencyList> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCountFromResults.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCountFromResults.java
@@ -33,11 +33,11 @@ public class SearchCountFromResults<T extends Results<?, ?>> extends SearchCount
     }
 
     @Override
-    public ResultsStats executeInternal(SearchTask<ResultsStats> searchTask) throws InvalidQuery {
+    public ResultsStats executeInternal(ActiveSearch<ResultsStats> activeSearch) throws InvalidQuery {
         // Start the search and construct the count object
-        ResultsStats resultCount = new ResultCount(executeChildSearch(searchTask, source), type);
-        if (searchTask != null && searchTask.peek() != null)
-            ((ResultsStatsDelegate) searchTask.peek()).setRealStats(resultCount);
+        ResultsStats resultCount = new ResultCount(executeChildSearch(activeSearch, source), type);
+        if (activeSearch != null && activeSearch.peek() != null)
+            ((ResultsStatsDelegate) activeSearch.peek()).setRealStats(resultCount);
 
         // Gather all the hits.
         // This runs synchronously, so SearchCountFromResults will not be finished until

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchCountFromResults.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchCountFromResults.java
@@ -33,11 +33,11 @@ public class SearchCountFromResults<T extends Results<?, ?>> extends SearchCount
     }
 
     @Override
-    public ResultsStats executeInternal(Peekable<ResultsStats> progressReporter) throws InvalidQuery {
+    public ResultsStats executeInternal(SearchTask<ResultsStats> searchTask) throws InvalidQuery {
         // Start the search and construct the count object
-        ResultsStats resultCount = new ResultCount(source.executeNoQueue(), type);
-        if (progressReporter != null && progressReporter.peek() != null)
-            ((ResultsStatsDelegate) progressReporter.peek()).setRealStats(resultCount);
+        ResultsStats resultCount = new ResultCount(executeChildSearch(searchTask, source), type);
+        if (searchTask != null && searchTask.peek() != null)
+            ((ResultsStatsDelegate) searchTask.peek()).setRealStats(resultCount);
 
         // Gather all the hits.
         // This runs synchronously, so SearchCountFromResults will not be finished until

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFiltered.java
@@ -23,8 +23,8 @@ public class SearchDocGroupsFiltered extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).filter(property, value);
+    public DocGroups executeInternal(ActiveSearch<DocGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFiltered.java
@@ -23,8 +23,8 @@ public class SearchDocGroupsFiltered extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(Peekable<DocGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().filter(property, value);
+    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFromDocs.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFromDocs.java
@@ -24,8 +24,8 @@ public class SearchDocGroupsFromDocs extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).group(property, maxDocs);
+    public DocGroups executeInternal(ActiveSearch<DocGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).group(property, maxDocs);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFromDocs.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsFromDocs.java
@@ -24,8 +24,8 @@ public class SearchDocGroupsFromDocs extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(Peekable<DocGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().group(property, maxDocs);
+    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).group(property, maxDocs);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSampled.java
@@ -19,8 +19,8 @@ public class SearchDocGroupsSampled extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(Peekable<DocGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sample(sampleParameters);
+    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSampled.java
@@ -19,8 +19,8 @@ public class SearchDocGroupsSampled extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sample(sampleParameters);
+    public DocGroups executeInternal(ActiveSearch<DocGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSorted.java
@@ -19,8 +19,8 @@ public class SearchDocGroupsSorted extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(Peekable<DocGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sort(property);
+    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsSorted.java
@@ -19,8 +19,8 @@ public class SearchDocGroupsSorted extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sort(property);
+    public DocGroups executeInternal(ActiveSearch<DocGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsWindow.java
@@ -21,8 +21,8 @@ public class SearchDocGroupsWindow extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).window(first, number);
+    public DocGroups executeInternal(ActiveSearch<DocGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocGroupsWindow.java
@@ -21,8 +21,8 @@ public class SearchDocGroupsWindow extends SearchDocGroups {
     }
 
     @Override
-    public DocGroups executeInternal(Peekable<DocGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().window(first, number);
+    public DocGroups executeInternal(SearchTask<DocGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFiltered.java
@@ -22,8 +22,8 @@ public class SearchDocsFiltered extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().filter(property, value);
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFiltered.java
@@ -22,8 +22,8 @@ public class SearchDocsFiltered extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).filter(property, value);
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromHits.java
@@ -19,8 +19,8 @@ public class SearchDocsFromHits extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().perDocResults(maxHits);
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).perDocResults(maxHits);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromHits.java
@@ -19,8 +19,8 @@ public class SearchDocsFromHits extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).perDocResults(maxHits);
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).perDocResults(maxHits);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromQuery.java
@@ -15,7 +15,7 @@ public class SearchDocsFromQuery extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) {
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) {
         return queryInfo().index().queryDocuments(query);
     }
     

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsFromQuery.java
@@ -15,7 +15,7 @@ public class SearchDocsFromQuery extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) {
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) {
         return queryInfo().index().queryDocuments(query);
     }
     

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSampled.java
@@ -18,8 +18,8 @@ public class SearchDocsSampled extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sample(sampleParameters);
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSampled.java
@@ -18,8 +18,8 @@ public class SearchDocsSampled extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sample(sampleParameters);
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSorted.java
@@ -18,8 +18,8 @@ public class SearchDocsSorted extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sort(property);
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsSorted.java
@@ -18,8 +18,8 @@ public class SearchDocsSorted extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sort(property);
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsWindow.java
@@ -22,8 +22,8 @@ public class SearchDocsWindow extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(Peekable<DocResults> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().window(first, number);
+    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchDocsWindow.java
@@ -22,8 +22,8 @@ public class SearchDocsWindow extends SearchDocs {
     }
 
     @Override
-    public DocResults executeInternal(SearchTask<DocResults> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).window(first, number);
+    public DocResults executeInternal(ActiveSearch<DocResults> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchEmpty.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchEmpty.java
@@ -18,7 +18,7 @@ public class SearchEmpty extends AbstractSearch<SearchResult> {
     }
 
     @Override
-    public SearchResult executeInternal(Peekable<SearchResult> progressReporter) {
+    public SearchResult executeInternal(SearchTask<SearchResult> searchTask) {
         throw new UnsupportedOperationException();
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchEmpty.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchEmpty.java
@@ -18,7 +18,7 @@ public class SearchEmpty extends AbstractSearch<SearchResult> {
     }
 
     @Override
-    public SearchResult executeInternal(SearchTask<SearchResult> searchTask) {
+    public SearchResult executeInternal(ActiveSearch<SearchResult> activeSearch) {
         throw new UnsupportedOperationException();
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchFacets.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchFacets.java
@@ -20,8 +20,8 @@ public class SearchFacets extends AbstractSearch<Facets> {
     }
 
     @Override
-    public Facets executeInternal(Peekable<Facets> progressReporter) throws InvalidQuery {
-        return new Facets(source.executeNoQueue(), properties);
+    public Facets executeInternal(SearchTask<Facets> searchTask) throws InvalidQuery {
+        return new Facets(executeChildSearch(searchTask, source), properties);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchFacets.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchFacets.java
@@ -20,8 +20,8 @@ public class SearchFacets extends AbstractSearch<Facets> {
     }
 
     @Override
-    public Facets executeInternal(SearchTask<Facets> searchTask) throws InvalidQuery {
-        return new Facets(executeChildSearch(searchTask, source), properties);
+    public Facets executeInternal(ActiveSearch<Facets> activeSearch) throws InvalidQuery {
+        return new Facets(executeChildSearch(activeSearch, source), properties);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFiltered.java
@@ -25,8 +25,8 @@ public class SearchHitGroupsFiltered extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).filter(property, value);
+    public HitGroups executeInternal(ActiveSearch<HitGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFiltered.java
@@ -25,8 +25,8 @@ public class SearchHitGroupsFiltered extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(Peekable<HitGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().filter(property, value);
+    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFromHits.java
@@ -50,14 +50,14 @@ public class SearchHitGroupsFromHits extends SearchHitGroups {
      * @throws InvalidQuery if the query is invalid
      */
     @Override
-    public HitGroups executeInternal(Peekable<HitGroups> progressReporter) throws InvalidQuery {
+    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
         if (HitGroupsTokenFrequencies.canUse(mustStoreHits, source, property)) {
             // Any token query, group by hit text or doc metadata! Choose faster path that just "looks up"
             // token frequencies in the forward index(es).
             return HitGroupsTokenFrequencies.get(source, property);
         } else {
             // Just find all the hits and group them.
-            return HitGroups.fromHits(source.executeNoQueue(), property, maxResultsToStorePerGroup);
+            return HitGroups.fromHits(executeChildSearch(searchTask, source), property, maxResultsToStorePerGroup);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFromHits.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsFromHits.java
@@ -50,14 +50,14 @@ public class SearchHitGroupsFromHits extends SearchHitGroups {
      * @throws InvalidQuery if the query is invalid
      */
     @Override
-    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
+    public HitGroups executeInternal(ActiveSearch<HitGroups> activeSearch) throws InvalidQuery {
         if (HitGroupsTokenFrequencies.canUse(mustStoreHits, source, property)) {
             // Any token query, group by hit text or doc metadata! Choose faster path that just "looks up"
             // token frequencies in the forward index(es).
             return HitGroupsTokenFrequencies.get(source, property);
         } else {
             // Just find all the hits and group them.
-            return HitGroups.fromHits(executeChildSearch(searchTask, source), property, maxResultsToStorePerGroup);
+            return HitGroups.fromHits(executeChildSearch(activeSearch, source), property, maxResultsToStorePerGroup);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSampled.java
@@ -21,8 +21,8 @@ public class SearchHitGroupsSampled extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sample(sampleParameters);
+    public HitGroups executeInternal(ActiveSearch<HitGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSampled.java
@@ -21,8 +21,8 @@ public class SearchHitGroupsSampled extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(Peekable<HitGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sample(sampleParameters);
+    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSorted.java
@@ -23,8 +23,8 @@ public class SearchHitGroupsSorted extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sort(property);
+    public HitGroups executeInternal(ActiveSearch<HitGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsSorted.java
@@ -23,8 +23,8 @@ public class SearchHitGroupsSorted extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(Peekable<HitGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sort(property);
+    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsWindow.java
@@ -23,8 +23,8 @@ public class SearchHitGroupsWindow extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(Peekable<HitGroups> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().window(first, number);
+    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitGroupsWindow.java
@@ -23,8 +23,8 @@ public class SearchHitGroupsWindow extends SearchHitGroups {
     }
 
     @Override
-    public HitGroups executeInternal(SearchTask<HitGroups> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).window(first, number);
+    public HitGroups executeInternal(ActiveSearch<HitGroups> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFiltered.java
@@ -22,8 +22,8 @@ public class SearchHitsFiltered extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(Peekable<Hits> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().filter(property, value);
+    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFiltered.java
@@ -22,8 +22,8 @@ public class SearchHitsFiltered extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).filter(property, value);
+    public Hits executeInternal(ActiveSearch<Hits> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).filter(property, value);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFromBLSpanQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFromBLSpanQuery.java
@@ -28,7 +28,7 @@ public class SearchHitsFromBLSpanQuery extends SearchHits {
      * @return result of the operation
      */
     @Override
-    public Hits executeInternal(SearchTask<Hits> searchTask) {
+    public Hits executeInternal(ActiveSearch<Hits> activeSearch) {
         return queryInfo().index().find(spanQuery, searchSettings);
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFromBLSpanQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsFromBLSpanQuery.java
@@ -28,7 +28,7 @@ public class SearchHitsFromBLSpanQuery extends SearchHits {
      * @return result of the operation
      */
     @Override
-    public Hits executeInternal(Peekable<Hits> progressReporter) {
+    public Hits executeInternal(SearchTask<Hits> searchTask) {
         return queryInfo().index().find(spanQuery, searchSettings);
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSampled.java
@@ -19,8 +19,8 @@ public class SearchHitsSampled extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sample(sampleParameters);
+    public Hits executeInternal(ActiveSearch<Hits> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSampled.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSampled.java
@@ -19,8 +19,8 @@ public class SearchHitsSampled extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(Peekable<Hits> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sample(sampleParameters);
+    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sample(sampleParameters);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSorted.java
@@ -19,8 +19,8 @@ public class SearchHitsSorted extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).sort(property);
+    public Hits executeInternal(ActiveSearch<Hits> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSorted.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsSorted.java
@@ -19,8 +19,8 @@ public class SearchHitsSorted extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(Peekable<Hits> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().sort(property);
+    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).sort(property);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsWindow.java
@@ -22,8 +22,8 @@ public class SearchHitsWindow extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(Peekable<Hits> progressReporter) throws InvalidQuery {
-        return source.executeNoQueue().window(first, number);
+    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
+        return executeChildSearch(searchTask, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsWindow.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchHitsWindow.java
@@ -22,8 +22,8 @@ public class SearchHitsWindow extends SearchHits {
     }
 
     @Override
-    public Hits executeInternal(SearchTask<Hits> searchTask) throws InvalidQuery {
-        return executeChildSearch(searchTask, source).window(first, number);
+    public Hits executeInternal(ActiveSearch<Hits> activeSearch) throws InvalidQuery {
+        return executeChildSearch(activeSearch, source).window(first, number);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchTask.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchTask.java
@@ -1,0 +1,30 @@
+package nl.inl.blacklab.searches;
+
+public interface SearchTask<T> {
+    /**
+     * Peek at the result.
+     * @return null if not supported, a peek at the result otherwise
+     */
+    default T peek() { return null; }
+
+    /** Get the total processing time for this task (ms).
+     *
+     * This includes processing time for other tasks it used (e.g. a "sorted hits" task calculates
+     * its processing time by adding the time it took to retrieve all the hits and the time it took
+     * to sort them, even though the task itself only does the actual sorting).
+     *
+     * Processing time is intended to be independent from the cache: it keeps track only of the actual
+     * time processing (originally) took. So even if a request is almost instant, processing time can
+     * be much higher if the original search took that long.
+     */
+    long processingTimeMs();
+
+    /** (Re)start the task's processing timer, adding to its total. */
+    void startTimer();
+
+    /** Stop the task's processing timer, (temporarily) not keeping track of time elapsed. */
+    void stopTimer();
+
+    /** Add the processing time for the subtask to this tasks's processing time. */
+    void addSubtaskTime(SearchTask<?> subtask);
+}

--- a/engine/src/main/java/nl/inl/blacklab/searches/SearchTask.java
+++ b/engine/src/main/java/nl/inl/blacklab/searches/SearchTask.java
@@ -1,5 +1,18 @@
 package nl.inl.blacklab.searches;
 
+import nl.inl.util.TaskTimer;
+
+/**
+ * Most basic interface for a search task ("cache entry").
+ *
+ * This is passed to the Search.executeInternal() method so it has access
+ * to the running task object. This enables it to update the running count
+ * during execution, as well as manage the timer (stopping it before executing
+ * a subtask, adding the subtask's processing time, and re-starting it for the
+ * rest of the execution)
+ *
+ * @param <T> type of result this task will yield
+ */
 public interface SearchTask<T> {
     /**
      * Peek at the result.
@@ -7,24 +20,9 @@ public interface SearchTask<T> {
      */
     default T peek() { return null; }
 
-    /** Get the total processing time for this task (ms).
-     *
-     * This includes processing time for other tasks it used (e.g. a "sorted hits" task calculates
-     * its processing time by adding the time it took to retrieve all the hits and the time it took
-     * to sort them, even though the task itself only does the actual sorting).
-     *
-     * Processing time is intended to be independent from the cache: it keeps track only of the actual
-     * time processing (originally) took. So even if a request is almost instant, processing time can
-     * be much higher if the original search took that long.
+    /**
+     * Timer instance for this task.
+     * @return tasks's timer
      */
-    long processingTimeMs();
-
-    /** (Re)start the task's processing timer, adding to its total. */
-    void startTimer();
-
-    /** Stop the task's processing timer, (temporarily) not keeping track of time elapsed. */
-    void stopTimer();
-
-    /** Add the processing time for the subtask to this tasks's processing time. */
-    void addSubtaskTime(SearchTask<?> subtask);
+    TaskTimer timer();
 }

--- a/engine/src/main/java/nl/inl/util/SearchTimer.java
+++ b/engine/src/main/java/nl/inl/util/SearchTimer.java
@@ -8,8 +8,8 @@ import org.apache.logging.log4j.Logger;
  *
  * Used to keep track of how long a search task (originally) took, including subtasks.
  */
-public class TaskTimer {
-    private static final Logger logger = LogManager.getLogger(TaskTimer.class);
+public class SearchTimer {
+    private static final Logger logger = LogManager.getLogger(SearchTimer.class);
 
     /**
      * When was our processing timer started?

--- a/engine/src/main/java/nl/inl/util/TaskTimer.java
+++ b/engine/src/main/java/nl/inl/util/TaskTimer.java
@@ -1,0 +1,76 @@
+package nl.inl.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Simple pausable timer that we can also manually add time to.
+ *
+ * Used to keep track of how long a search task (originally) took, including subtasks.
+ */
+public class TaskTimer {
+    private static final Logger logger = LogManager.getLogger(TaskTimer.class);
+
+    /**
+     * When was our processing timer started?
+     */
+    private long startTime = -1;
+
+    /**
+     * Is our timer currently running?
+     */
+    private boolean timerRunning = false;
+
+    /**
+     * Total processing time for this task (ms), including that of subtasks.
+     */
+    private long processingTime = 0;
+
+    /**
+     * Get the total processing time for this task (ms).
+     *
+     * If the timer is running, returns the running time.
+     *
+     * This includes processing time for other tasks it used (e.g. a "sorted hits" task calculates
+     * its processing time by adding the time it took to retrieve all the hits and the time it took
+     * to sort them, even though the task itself only does the actual sorting).
+     *
+     * Processing time is intended to be independent from the cache: it keeps track only of the actual
+     * time processing (originally) took. So even if a request is almost instant, processing time can
+     * be much higher if the original search took that long.
+     */
+    public long time() {
+        return timerRunning ? processingTime + (System.currentTimeMillis() - startTime) : processingTime;
+    }
+
+    /**
+     * (Re)start the task's processing timer, adding to its total.
+     */
+    public void start() {
+        if (timerRunning)
+            logger.debug("@@@@@ Timer.start: timer already running!");
+        startTime = System.currentTimeMillis();
+        timerRunning = true;
+    }
+
+    /**
+     * Stop the task's processing timer, (temporarily) not keeping track of time elapsed.
+     */
+    public void stop() {
+        if (timerRunning) {
+            processingTime += System.currentTimeMillis() - startTime;
+            timerRunning = false;
+        } else {
+            logger.debug("@@@@@ Timer.stop: timer wasn't running!");
+        }
+    }
+
+    /**
+     * Add the processing time for the subtask to this tasks's processing time.
+     */
+    public void add(long ms) {
+        if (timerRunning)
+            logger.debug("@@@@@ Timer.add: timer should not be running!");
+        processingTime += ms;
+    }
+}

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/ConcordanceContext.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/ConcordanceContext.java
@@ -9,31 +9,31 @@ import nl.inl.blacklab.search.results.Hit;
 import nl.inl.blacklab.search.results.Hits;
 import nl.inl.blacklab.search.results.Kwics;
 
-public class ContextForHits {
+public class ConcordanceContext {
 
-    public static ContextForHits kwics(Kwics kwics) {
-        return new ContextForHits(kwics, null);
+    public static ConcordanceContext kwics(Kwics kwics) {
+        return new ConcordanceContext(kwics, null);
     }
 
-    public static ContextForHits concordances(Concordances concordances) {
-        return new ContextForHits(null, concordances);
+    public static ConcordanceContext concordances(Concordances concordances) {
+        return new ConcordanceContext(null, concordances);
     }
 
-    public static ContextForHits get(Hits hits, ConcordanceType concordanceType, ContextSize contextSize) {
-        ContextForHits contextForHits;
+    public static ConcordanceContext get(Hits hits, ConcordanceType concordanceType, ContextSize contextSize) {
+        ConcordanceContext concordanceContext;
         if (concordanceType == ConcordanceType.CONTENT_STORE)
-            contextForHits = ContextForHits.concordances(
+            concordanceContext = ConcordanceContext.concordances(
                     hits.concordances(contextSize, ConcordanceType.CONTENT_STORE));
         else
-            contextForHits = ContextForHits.kwics(hits.kwics(contextSize));
-        return contextForHits;
+            concordanceContext = ConcordanceContext.kwics(hits.kwics(contextSize));
+        return concordanceContext;
     }
 
     private Concordances concordances = null;
 
     private Kwics kwics = null;
 
-    private ContextForHits(Kwics kwics, Concordances concordances) {
+    private ConcordanceContext(Kwics kwics, Concordances concordances) {
         this.kwics = kwics;
         this.concordances = concordances;
     }

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/ContextForHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/ContextForHits.java
@@ -1,0 +1,52 @@
+package nl.inl.blacklab.server.requesthandlers;
+
+import nl.inl.blacklab.search.Concordance;
+import nl.inl.blacklab.search.ConcordanceType;
+import nl.inl.blacklab.search.Kwic;
+import nl.inl.blacklab.search.results.Concordances;
+import nl.inl.blacklab.search.results.ContextSize;
+import nl.inl.blacklab.search.results.Hit;
+import nl.inl.blacklab.search.results.Hits;
+import nl.inl.blacklab.search.results.Kwics;
+
+public class ContextForHits {
+
+    public static ContextForHits kwics(Kwics kwics) {
+        return new ContextForHits(kwics, null);
+    }
+
+    public static ContextForHits concordances(Concordances concordances) {
+        return new ContextForHits(null, concordances);
+    }
+
+    public static ContextForHits get(Hits hits, ConcordanceType concordanceType, ContextSize contextSize) {
+        ContextForHits contextForHits;
+        if (concordanceType == ConcordanceType.CONTENT_STORE)
+            contextForHits = ContextForHits.concordances(
+                    hits.concordances(contextSize, ConcordanceType.CONTENT_STORE));
+        else
+            contextForHits = ContextForHits.kwics(hits.kwics(contextSize));
+        return contextForHits;
+    }
+
+    private Concordances concordances = null;
+
+    private Kwics kwics = null;
+
+    private ContextForHits(Kwics kwics, Concordances concordances) {
+        this.kwics = kwics;
+        this.concordances = concordances;
+    }
+
+    public boolean isConcordances() {
+        return concordances != null;
+    }
+
+    public Concordance getConcordance(Hit hit) {
+        return concordances.get(hit);
+    }
+
+    public Kwic getKwic(Hit hit) {
+        return kwics.get(hit);
+    }
+}

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -934,7 +934,7 @@ public abstract class RequestHandler {
         }
     }
 
-    public void datastreamHits(DataStream ds, Hits hits, ContextForHits contextForHits, Map<Integer, Document> luceneDocs) throws BlsException {
+    public void datastreamHits(DataStream ds, Hits hits, ConcordanceContext concordanceContext, Map<Integer, Document> luceneDocs) throws BlsException {
         BlackLabIndex index = hits.index();
 
         ds.startEntry("hits").startList();
@@ -980,9 +980,9 @@ public abstract class RequestHandler {
 
             ContextSize contextSize = searchParam.getContextSettings().size();
             boolean includeContext = contextSize.left() > 0 || contextSize.right() > 0;
-            if (contextForHits.isConcordances()) {
+            if (concordanceContext.isConcordances()) {
                 // Add concordance from original XML
-                Concordance c = contextForHits.getConcordance(hit);
+                Concordance c = concordanceContext.getConcordance(hit);
                 if (includeContext) {
                     ds.startEntry("left").xmlFragment(c.left()).endEntry()
                             .startEntry("match").xmlFragment(c.match()).endEntry()
@@ -992,7 +992,7 @@ public abstract class RequestHandler {
                 }
             } else {
                 // Add KWIC info
-                Kwic c = contextForHits.getKwic(hit);
+                Kwic c = concordanceContext.getKwic(hit);
                 if (includeContext) {
                     ds.startEntry("left").contextList(c.annotations(), annotationsToList, c.left()).endEntry()
                             .startEntry("match").contextList(c.annotations(), annotationsToList, c.match()).endEntry()

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -832,7 +832,7 @@ public abstract class RequestHandler {
         }
 
         // Information about search progress
-        ds.entry("searchTime", timings.getSearchTaskTime());
+        ds.entry("searchTime", timings.getProcessingTime());
         if (timings.getCountTime() != 0)
             ds.entry("countTime", timings.getCountTime());
 

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -803,16 +803,14 @@ public abstract class RequestHandler {
      *
      * @param ds where to output XML/JSON
      * @param searchParam original search parameters
-     * @param searchTime time the search took
-     * @param countTime time the count took
+     * @param timings various timings related to this request
      * @param groups information about groups, if we were grouping
      * @param window our viewing window
      */
     protected <T> void datastreamSummaryCommonFields(
             DataStream ds,
             SearchParameters searchParam,
-            long searchTime,
-            long countTime,
+            SearchTimings timings,
             ResultGroups<T> groups,
             WindowStats window
             ) throws BlsException {
@@ -838,9 +836,9 @@ public abstract class RequestHandler {
         }
 
         // Information about search progress
-        ds.entry("searchTime", searchTime);
-        if (countTime != 0)
-            ds.entry("countTime", countTime);
+        ds.entry("searchTime", timings.getSearchTaskTime());
+        if (timings.getCountTime() != 0)
+            ds.entry("countTime", timings.getCountTime());
 
         // Information about grouping operation
         if (groups != null) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
@@ -124,7 +124,7 @@ public class RequestHandlerDocs extends RequestHandler {
 
         originalHitsSearch = null; // don't use this to report totals, because we've filtered since then
         docResults = group.storedResults();
-        totalTime = 0; // TODO searchGrouped.userWaitTime();
+        totalTime = docGroupFuture.processingTimeMs();
         return doResponse(ds, true, new HashSet<>(this.getAnnotationsToWrite()), this.getMetadataToWrite(), true);
     }
 
@@ -148,7 +148,7 @@ public class RequestHandlerDocs extends RequestHandler {
             totalDocResults.size();
 
         docResults = totalDocResults;
-        totalTime = total.threwException() ? -1 : total.timeUserWaitedMs();
+        totalTime = total.threwException() ? 0 : total.processingTimeMs();
 
         return doResponse(ds, false, new HashSet<>(this.getAnnotationsToWrite()), this.getMetadataToWrite(), waitForTotal);
     }
@@ -172,7 +172,7 @@ public class RequestHandlerDocs extends RequestHandler {
         ResultsStats hitsStats, docsStats;
         hitsStats = originalHitsSearch == null ? null : originalHitsSearch.peek();
         docsStats = searchParam.docsCount().executeAsync().peek();
-        SearchTimings timings = SearchTimings.searchAndCount(search.timeUserWaitedMs(), totalTime);
+        SearchTimings timings = SearchTimings.searchAndCount(search.processingTimeMs(), totalTime);
         datastreamSummaryCommonFields(ds, searchParam, timings, null, window.windowStats());
         boolean countFailed = totalTime < 0;
         if (hitsStats == null)

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
@@ -172,7 +172,8 @@ public class RequestHandlerDocs extends RequestHandler {
         ResultsStats hitsStats, docsStats;
         hitsStats = originalHitsSearch == null ? null : originalHitsSearch.peek();
         docsStats = searchParam.docsCount().executeAsync().peek();
-        datastreamSummaryCommonFields(ds, searchParam, search.timeUserWaitedMs(), totalTime, null, window.windowStats());
+        SearchTimings timings = SearchTimings.searchAndCount(search.timeUserWaitedMs(), totalTime);
+        datastreamSummaryCommonFields(ds, searchParam, timings, null, window.windowStats());
         boolean countFailed = totalTime < 0;
         if (hitsStats == null)
             datastreamNumberOfResultsSummaryDocResults(ds, isViewGroup, docResults, countFailed, null);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocs.java
@@ -124,7 +124,7 @@ public class RequestHandlerDocs extends RequestHandler {
 
         originalHitsSearch = null; // don't use this to report totals, because we've filtered since then
         docResults = group.storedResults();
-        totalTime = docGroupFuture.processingTimeMs();
+        totalTime = docGroupFuture.timer().time();
         return doResponse(ds, true, new HashSet<>(this.getAnnotationsToWrite()), this.getMetadataToWrite(), true);
     }
 
@@ -148,7 +148,7 @@ public class RequestHandlerDocs extends RequestHandler {
             totalDocResults.size();
 
         docResults = totalDocResults;
-        totalTime = total.threwException() ? 0 : total.processingTimeMs();
+        totalTime = total.threwException() ? 0 : total.timer().time();
 
         return doResponse(ds, false, new HashSet<>(this.getAnnotationsToWrite()), this.getMetadataToWrite(), waitForTotal);
     }
@@ -172,7 +172,7 @@ public class RequestHandlerDocs extends RequestHandler {
         ResultsStats hitsStats, docsStats;
         hitsStats = originalHitsSearch == null ? null : originalHitsSearch.peek();
         docsStats = searchParam.docsCount().executeAsync().peek();
-        SearchTimings timings = SearchTimings.searchAndCount(search.processingTimeMs(), totalTime);
+        SearchTimings timings = new SearchTimings(search.timer().time(), totalTime);
         datastreamSummaryCommonFields(ds, searchParam, timings, null, window.windowStats());
         boolean countFailed = totalTime < 0;
         if (hitsStats == null)

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
@@ -80,7 +80,8 @@ public class RequestHandlerDocsGrouped extends RequestHandler {
             subcorpusSize = subcorpus.subcorpusSize();
         }
 
-        datastreamSummaryCommonFields(ds, searchParam, groupSearch.timeUserWaitedMs(), 0, groups, ourWindow);
+        SearchTimings timings = SearchTimings.searchAndCount(groupSearch.timeUserWaitedMs(), 0);
+        datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         if (hitsStats == null)
             datastreamNumberOfResultsSummaryDocResults(ds, false, docResults, false, subcorpusSize);
         else

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
@@ -80,7 +80,7 @@ public class RequestHandlerDocsGrouped extends RequestHandler {
             subcorpusSize = subcorpus.subcorpusSize();
         }
 
-        SearchTimings timings = SearchTimings.searchAndCount(groupSearch.timeUserWaitedMs(), 0);
+        SearchTimings timings = SearchTimings.searchAndCount(groupSearch.processingTimeMs(), 0);
         datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         if (hitsStats == null)
             datastreamNumberOfResultsSummaryDocResults(ds, false, docResults, false, subcorpusSize);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocsGrouped.java
@@ -80,7 +80,7 @@ public class RequestHandlerDocsGrouped extends RequestHandler {
             subcorpusSize = subcorpus.subcorpusSize();
         }
 
-        SearchTimings timings = SearchTimings.searchAndCount(groupSearch.processingTimeMs(), 0);
+        SearchTimings timings = new SearchTimings(groupSearch.timer().time(), 0);
         datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         if (hitsStats == null)
             datastreamNumberOfResultsSummaryDocResults(ds, false, docResults, false, subcorpusSize);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -172,7 +172,7 @@ public class RequestHandlerHits extends RequestHandler {
         // (note that on large indexes, this can actually take significant time)
         long startTimeKwicsMs = System.currentTimeMillis();
         ContextSettings contextSettings = searchParam.getContextSettings();
-        ContextForHits contextForHits = ContextForHits.get(window, contextSettings.concType(), contextSettings.size());
+        ConcordanceContext concordanceContext = ConcordanceContext.get(window, contextSettings.concType(), contextSettings.size());
         long kwicTimeMs = System.currentTimeMillis() - startTimeKwicsMs;
 
         // Search is done; construct the results object
@@ -211,7 +211,7 @@ public class RequestHandlerHits extends RequestHandler {
         ds.endMap().endEntry();
 
         Map<Integer, Document> luceneDocs = new HashMap<>();
-        datastreamHits(ds, window, contextForHits, luceneDocs);
+        datastreamHits(ds, window, concordanceContext, luceneDocs);
         datastreamDocInfos(ds, index, luceneDocs, getMetadataToWrite());
 
         if (searchParam.hasFacets()) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -184,7 +184,8 @@ public class RequestHandlerHits extends RequestHandler {
         long searchTime = (cacheEntryWindow == null ? cacheEntry.timeUserWaitedMs() : cacheEntryWindow.timeUserWaitedMs()) + kwicTimeMs;
         long countTime = cacheEntry.threwException() ? -1 : cacheEntry.timeUserWaitedMs();
         logger.info("Total search time is:{} ms", searchTime);
-        datastreamSummaryCommonFields(ds, searchParam, searchTime, countTime, null, window.windowStats());
+        SearchTimings timings = SearchTimings.searchAndCount(searchTime, countTime);
+        datastreamSummaryCommonFields(ds, searchParam, timings, null, window.windowStats());
         datastreamNumberOfResultsSummaryTotalHits(ds, hitsStats, docsStats, waitForTotal, countTime < 0, null);
         if (includeTokenCount)
             ds.entry("tokensInMatchingDocuments", totalTokens);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHits.java
@@ -172,7 +172,7 @@ public class RequestHandlerHits extends RequestHandler {
         // (note that on large indexes, this can actually take significant time)
         long startTimeKwicsMs = System.currentTimeMillis();
         ContextSettings contextSettings = searchParam.getContextSettings();
-        ContextForHits contextForHits = ContextForHits.get(hits, contextSettings.concType(), contextSettings.size());
+        ContextForHits contextForHits = ContextForHits.get(window, contextSettings.concType(), contextSettings.size());
         long kwicTimeMs = System.currentTimeMillis() - startTimeKwicsMs;
 
         // Search is done; construct the results object
@@ -184,10 +184,10 @@ public class RequestHandlerHits extends RequestHandler {
         ds.startEntry("summary").startMap();
         // Search time should be time user (originally) had to wait for the response to this request.
         // Count time is the time it took (or is taking) to iterate through all the results to count the total.
-        long searchTime = (cacheEntryWindow == null ? cacheEntry.processingTimeMs() : cacheEntryWindow.processingTimeMs()) + kwicTimeMs;
-        long countTime = cacheEntry.threwException() ? -1 : cacheEntry.processingTimeMs();
+        long searchTime = (cacheEntryWindow == null ? cacheEntry.timer().time() : cacheEntryWindow.timer().time()) + kwicTimeMs;
+        long countTime = cacheEntry.threwException() ? -1 : cacheEntry.timer().time();
         logger.info("Total search time is:{} ms", searchTime);
-        SearchTimings timings = SearchTimings.searchAndCount(searchTime, countTime);
+        SearchTimings timings = new SearchTimings(searchTime, countTime);
         datastreamSummaryCommonFields(ds, searchParam, timings, null, window.windowStats());
         datastreamNumberOfResultsSummaryTotalHits(ds, hitsStats, docsStats, waitForTotal, countTime < 0, null);
         if (includeTokenCount)

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -72,7 +72,7 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
         final long actualWindowSize = first + requestedWindowSize > totalResults ? totalResults - first
                 : requestedWindowSize;
         WindowStats ourWindow = new WindowStats(first + requestedWindowSize < totalResults, first, requestedWindowSize, actualWindowSize);
-        SearchTimings timings = SearchTimings.searchAndCount(search.processingTimeMs(), 0);
+        SearchTimings timings = new SearchTimings(search.timer().time(), 0);
         datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         ResultsStats hitsStats = groups.hitsStats();
         ResultsStats docsStats = groups.docsStats();

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -146,8 +146,8 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
                 if (searchParam.includeGroupContents()) {
                     Hits hitsInGroup = group.storedResults();
                     ContextSettings contextSettings = searchParam.getContextSettings();
-                    ContextForHits contextForHits = ContextForHits.get(hitsInGroup, contextSettings.concType(), contextSettings.size());
-                    datastreamHits(ds, hitsInGroup, contextForHits, luceneDocs);
+                    ConcordanceContext concordanceContext = ConcordanceContext.get(hitsInGroup, contextSettings.concType(), contextSettings.size());
+                    datastreamHits(ds, hitsInGroup, concordanceContext, luceneDocs);
                 }
 
                 ds.endMap().endItem();

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -71,7 +71,8 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
         final long actualWindowSize = first + requestedWindowSize > totalResults ? totalResults - first
                 : requestedWindowSize;
         WindowStats ourWindow = new WindowStats(first + requestedWindowSize < totalResults, first, requestedWindowSize, actualWindowSize);
-        datastreamSummaryCommonFields(ds, searchParam, search.timeUserWaitedMs(), 0, groups, ourWindow);
+        SearchTimings timings = SearchTimings.searchAndCount(search.timeUserWaitedMs(), 0);
+        datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         ResultsStats hitsStats = groups.hitsStats();
         ResultsStats docsStats = groups.docsStats();
         if (docsStats == null)

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerHitsGrouped.java
@@ -30,6 +30,7 @@ import nl.inl.blacklab.server.BlackLabServer;
 import nl.inl.blacklab.server.config.DefaultMax;
 import nl.inl.blacklab.server.datastream.DataStream;
 import nl.inl.blacklab.server.exceptions.BlsException;
+import nl.inl.blacklab.server.jobs.ContextSettings;
 import nl.inl.blacklab.server.jobs.User;
 import nl.inl.blacklab.server.jobs.WindowSettings;
 import nl.inl.util.BlockTimer;
@@ -71,7 +72,7 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
         final long actualWindowSize = first + requestedWindowSize > totalResults ? totalResults - first
                 : requestedWindowSize;
         WindowStats ourWindow = new WindowStats(first + requestedWindowSize < totalResults, first, requestedWindowSize, actualWindowSize);
-        SearchTimings timings = SearchTimings.searchAndCount(search.timeUserWaitedMs(), 0);
+        SearchTimings timings = SearchTimings.searchAndCount(search.processingTimeMs(), 0);
         datastreamSummaryCommonFields(ds, searchParam, timings, groups, ourWindow);
         ResultsStats hitsStats = groups.hitsStats();
         ResultsStats docsStats = groups.docsStats();
@@ -144,7 +145,9 @@ public class RequestHandlerHitsGrouped extends RequestHandler {
 
                 if (searchParam.includeGroupContents()) {
                     Hits hitsInGroup = group.storedResults();
-                    datastreamHits(ds, hitsInGroup, luceneDocs, searchParam.getContextSettings());
+                    ContextSettings contextSettings = searchParam.getContextSettings();
+                    ContextForHits contextForHits = ContextForHits.get(hitsInGroup, contextSettings.concType(), contextSettings.size());
+                    datastreamHits(ds, hitsInGroup, contextForHits, luceneDocs);
                 }
 
                 ds.endMap().endItem();

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
@@ -1,0 +1,44 @@
+package nl.inl.blacklab.server.requesthandlers;
+
+/**
+ * Keeps track of various timings we want to report to the client.
+ */
+public class SearchTimings {
+
+    /**
+     * How much time it took to respond to this request.
+     */
+    private long responseTime;
+
+    /**
+     * How much time each required search task originally took to produce this response.
+     */
+    private long searchTaskTime;
+
+    /**
+     * How long it took to count all the results.
+     */
+    private long countTime;
+
+    public SearchTimings(long responseTime, long searchTaskTime, long countTime) {
+        this.responseTime = responseTime;
+        this.searchTaskTime = searchTaskTime;
+        this.countTime = countTime;
+    }
+
+    public static SearchTimings searchAndCount(long searchTime, long countTime) {
+        return new SearchTimings(searchTime, searchTime, countTime);
+    }
+
+    public long getResponseTime() {
+        return responseTime;
+    }
+
+    public long getSearchTaskTime() {
+        return searchTaskTime;
+    }
+
+    public long getCountTime() {
+        return countTime;
+    }
+}

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
@@ -6,11 +6,6 @@ package nl.inl.blacklab.server.requesthandlers;
 public class SearchTimings {
 
     /**
-     * How much time it took to respond to this request.
-     */
-    private long responseTime;
-
-    /**
      * How much time each required search task originally took to produce this response.
      */
     private long searchTaskTime;
@@ -20,18 +15,9 @@ public class SearchTimings {
      */
     private long countTime;
 
-    public SearchTimings(long responseTime, long searchTaskTime, long countTime) {
-        this.responseTime = responseTime;
+    public SearchTimings(long searchTaskTime, long countTime) {
         this.searchTaskTime = searchTaskTime;
         this.countTime = countTime;
-    }
-
-    public static SearchTimings searchAndCount(long searchTime, long countTime) {
-        return new SearchTimings(searchTime, searchTime, countTime);
-    }
-
-    public long getResponseTime() {
-        return responseTime;
     }
 
     public long getSearchTaskTime() {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/SearchTimings.java
@@ -8,20 +8,20 @@ public class SearchTimings {
     /**
      * How much time each required search task originally took to produce this response.
      */
-    private long searchTaskTime;
+    private long processingTime;
 
     /**
      * How long it took to count all the results.
      */
     private long countTime;
 
-    public SearchTimings(long searchTaskTime, long countTime) {
-        this.searchTaskTime = searchTaskTime;
+    public SearchTimings(long processingTime, long countTime) {
+        this.processingTime = processingTime;
         this.countTime = countTime;
     }
 
-    public long getSearchTaskTime() {
-        return searchTaskTime;
+    public long getProcessingTime() {
+        return processingTime;
     }
 
     public long getCountTime() {

--- a/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
+++ b/server/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
@@ -132,7 +132,7 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
     public void executeSearch() {
         // keep track of processing time, taking child searches into account
         // (child searches already in cache will add their original processing time)
-        startTimer();
+        timer().start();
         try {
             result = search.executeInternal(this);
         } catch (Throwable e) {
@@ -153,7 +153,7 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
         } finally {
 
             // Stop keeping track of processing time for this task.
-            stopTimer();
+            timer().stop();
 
             // Record the time the task was done, for e.g. cache management.
             doneTime = now();
@@ -384,7 +384,7 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
         if (!StringUtils.isEmpty(reason))
             stats.put("cancelReason", reason);
         stats.put("numberOfStoredHits", numberOfStoredHits());
-        stats.put("processingTime", processingTimeMs() / 1000.0);
+        stats.put("processingTime", timer().time() / 1000.0);
         stats.put("userWaitTime", timeUserWaitedMs() / 1000.0);
         stats.put("notAccessedFor", timeSinceLastAccessMs() / 1000.0);
 


### PR DESCRIPTION
Before, search and count time were heavily dependent on the contents of the cache. Also, polling the running count gave a search time of basically 0, which was not a useful thing to show to users (see #307).

We want to have each executing search task keep track of the total processing time required to produce its results. This PR does that. It's still not perfect: the state of the OS disk cache still heavily influences the speed of searches (unavoidable), and paging through a list of results produces pretty much the same search time for each page, when the last page actually took a lot more processing to produce (but fetching hits often happens in the background and is therefore not measured). But it's probably a lot better.

Notable changes:
- Awkwardly named interface `Peekable` was renamed to `ActiveSearch`, since that is what it represents (the instantiation of a `Search` request, or a search being or having been executed)
- `ActiveSearch` has a `timer()` method that returns a `SearchTimer` object. This is used in `Search.executeInternal()` to keep track of processing time (including the (original) processing time of child searches), using the new `AbstractSearch.executeChildSearch()` method.
- The `timeUserWaitedMs()` method is now only used to make caching decisions, and is never reported to the user. So it's not an issue that `SearchCacheEntryFromFuture` does not implement this method.
- KWIC construction is now correctly timed in `RequestHandlerHits`, using the new `ConcordanceContext` class to pass either `Kwics` or `Concordances` to `datastreamHits`.