### PR TITLE
Refactor Indexer/BlackLabIndexWriter instantiation. IndexTool option --integrate-external-files

### DIFF
--- a/core/src/test/java/nl/inl/blacklab/Example.java
+++ b/core/src/test/java/nl/inl/blacklab/Example.java
@@ -14,6 +14,7 @@ import nl.inl.blacklab.queryParser.corpusql.CorpusQueryLanguageParser;
 import nl.inl.blacklab.resultproperty.HitPropertyHitText;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndex;
+import nl.inl.blacklab.search.BlackLabIndexWriter;
 import nl.inl.blacklab.search.Concordance;
 import nl.inl.blacklab.search.ConcordanceType;
 import nl.inl.blacklab.search.lucene.BLSpanQuery;
@@ -77,7 +78,8 @@ public class Example {
         // Create an index and add our test documents.
         Indexer indexer = null;
         try {
-            indexer = Indexer.createNewIndex(indexDir, "exampleformat");
+            BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, true, "exampleformat", null);
+            indexer = Indexer.openIndex(indexWriter, "exampleformat");
             for (int i = 0; i < testData.length; i++) {
                 indexer.index("test" + (i + 1), testData[i].getBytes(StandardCharsets.UTF_8));
             }

--- a/core/src/test/java/nl/inl/blacklab/Example.java
+++ b/core/src/test/java/nl/inl/blacklab/Example.java
@@ -78,7 +78,8 @@ public class Example {
         // Create an index and add our test documents.
         Indexer indexer = null;
         try {
-            BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, true, "exampleformat", null);
+            BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, true,
+                    "exampleformat", null);
             indexer = Indexer.openIndex(indexWriter, "exampleformat");
             for (int i = 0; i < testData.length; i++) {
                 indexer.index("test" + (i + 1), testData[i].getBytes(StandardCharsets.UTF_8));

--- a/core/src/test/java/nl/inl/blacklab/Example.java
+++ b/core/src/test/java/nl/inl/blacklab/Example.java
@@ -78,7 +78,7 @@ public class Example {
         // Create an index and add our test documents.
         Indexer indexer = null;
         try {
-            BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, true,
+            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true,
                     "exampleformat", null);
             indexer = Indexer.openIndex(indexWriter, "exampleformat");
             for (int i = 0; i < testData.length; i++) {

--- a/core/src/test/java/nl/inl/blacklab/Example.java
+++ b/core/src/test/java/nl/inl/blacklab/Example.java
@@ -80,7 +80,7 @@ public class Example {
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true,
                     "exampleformat", null);
-            indexer = Indexer.openIndex(indexWriter, "exampleformat");
+            indexer = Indexer.get(indexWriter, "exampleformat");
             for (int i = 0; i < testData.length; i++) {
                 indexer.index("test" + (i + 1), testData[i].getBytes(StandardCharsets.UTF_8));
             }

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -140,8 +140,9 @@ public class TestIndex {
         DocumentFormats.registerFormat(testFormat, DocIndexerExample.class);
         try {
             BlackLabEngine engine = BlackLab.implicitInstance();
-            BlackLabIndexWriter indexWriter = engine.openForWriting(indexDir, true, (File)null, indexType);
-            Indexer indexer = Indexer.openIndex(indexWriter, testFormat); //.createNewIndex(indexDir, testFormat);
+            BlackLabIndexWriter indexWriter;
+            indexWriter = BlackLabIndexWriter.open(indexDir, true, testFormat, null, indexType);
+            Indexer indexer = Indexer.openIndex(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {
                 // Index each of our test "documents".
@@ -152,7 +153,7 @@ public class TestIndex {
                     // Delete the first doc, to test deletion.
                     // (close and re-open to be sure the document was written to disk first)
                     indexer.close();
-                    indexWriter = BlackLabIndexWriter.open(indexDir, false, null, null);
+                    indexWriter = BlackLabIndexWriter.open(indexDir, false, null, null, indexType);
                     indexer = Indexer.openIndex(indexWriter);
                     String luceneField = indexer.indexWriter().annotatedField("contents").annotation("word").sensitivity(MatchSensitivity.INSENSITIVE).luceneField();
                     indexer.indexWriter().delete(new TermQuery(new Term(luceneField, "dog")));

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -21,7 +21,6 @@ import nl.inl.blacklab.queryParser.corpusql.CorpusQueryLanguageParser;
 import nl.inl.blacklab.resultproperty.HitProperty;
 import nl.inl.blacklab.resultproperty.PropertyValue;
 import nl.inl.blacklab.search.BlackLab;
-import nl.inl.blacklab.search.BlackLabEngine;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.BlackLabIndex.IndexType;
 import nl.inl.blacklab.search.BlackLabIndexWriter;
@@ -139,9 +138,8 @@ public class TestIndex {
         // Instantiate the BlackLab indexer, supplying our DocIndexer class
         DocumentFormats.registerFormat(testFormat, DocIndexerExample.class);
         try {
-            BlackLabEngine engine = BlackLab.implicitInstance();
             BlackLabIndexWriter indexWriter;
-            indexWriter = BlackLabIndexWriter.open(indexDir, true, testFormat, null, indexType);
+            indexWriter = BlackLab.openForWriting(indexDir, true, testFormat, null, indexType);
             Indexer indexer = Indexer.openIndex(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {
@@ -153,7 +151,7 @@ public class TestIndex {
                     // Delete the first doc, to test deletion.
                     // (close and re-open to be sure the document was written to disk first)
                     indexer.close();
-                    indexWriter = BlackLabIndexWriter.open(indexDir, false, null, null, indexType);
+                    indexWriter = BlackLab.openForWriting(indexDir, false, null, null, indexType);
                     indexer = Indexer.openIndex(indexWriter);
                     String luceneField = indexer.indexWriter().annotatedField("contents").annotation("word").sensitivity(MatchSensitivity.INSENSITIVE).luceneField();
                     indexer.indexWriter().delete(new TermQuery(new Term(luceneField, "dog")));

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -139,7 +139,7 @@ public class TestIndex {
         DocumentFormats.registerFormat(testFormat, DocIndexerExample.class);
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true, testFormat, null, indexType);
-            Indexer indexer = Indexer.openIndex(indexWriter);
+            Indexer indexer = Indexer.get(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {
                 // Index each of our test "documents".
@@ -151,7 +151,7 @@ public class TestIndex {
                     // (close and re-open to be sure the document was written to disk first)
                     indexer.close();
                     indexWriter = BlackLab.openForWriting(indexDir, false, null, null, indexType);
-                    indexer = Indexer.openIndex(indexWriter);
+                    indexer = Indexer.get(indexWriter);
                     String luceneField = indexer.indexWriter().annotatedField("contents").annotation("word").sensitivity(MatchSensitivity.INSENSITIVE).luceneField();
                     indexer.indexWriter().delete(new TermQuery(new Term(luceneField, "dog")));
                 }

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -138,8 +138,7 @@ public class TestIndex {
         // Instantiate the BlackLab indexer, supplying our DocIndexer class
         DocumentFormats.registerFormat(testFormat, DocIndexerExample.class);
         try {
-            BlackLabIndexWriter indexWriter;
-            indexWriter = BlackLab.openForWriting(indexDir, true, testFormat, null, indexType);
+            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true, testFormat, null, indexType);
             Indexer indexer = Indexer.openIndex(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -152,7 +152,8 @@ public class TestIndex {
                     // Delete the first doc, to test deletion.
                     // (close and re-open to be sure the document was written to disk first)
                     indexer.close();
-                    indexer = Indexer.openIndex(indexDir);
+                    indexWriter = BlackLabIndexWriter.open(indexDir, false, null, null);
+                    indexer = Indexer.openIndex(indexWriter);
                     String luceneField = indexer.indexWriter().annotatedField("contents").annotation("word").sensitivity(MatchSensitivity.INSENSITIVE).luceneField();
                     indexer.indexWriter().delete(new TermQuery(new Term(luceneField, "dog")));
                 }

--- a/engine/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocumentFormats.java
@@ -200,4 +200,21 @@ public class DocumentFormats {
         DocIndexerFactory fac = getFactory(formatIdentifier);
         return fac != null ? fac.get(formatIdentifier, indexer, documentName, b, cs) : null;
     }
+
+    /**
+     * Get the format configuration matching the given format identifier, if it exists.
+     *
+     * @param formatIdentifier format identifier
+     * @return the format configuration, or null if not found
+     */
+    public static ConfigInputFormat getConfigInputFormat(String formatIdentifier) {
+        ConfigInputFormat format = null;
+        for (Format desc : getFormats()) {
+            if (desc.getId().equals(formatIdentifier) && desc.getConfig() != null) {
+                format = desc.getConfig();
+                break;
+            }
+        }
+        return format;
+    }
 }

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -18,35 +18,79 @@ import nl.inl.blacklab.search.BlackLabIndexWriter;
 
 public interface Indexer {
 
-    @Deprecated
-    static Indexer createNewIndex(File directory) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, true);
+    /**
+     * Create an Indexer for an existing index.
+     *
+     * The default index format from the index metadata will be used.
+     *
+     * @param writer index to write to
+     * @return the indexer
+     * @throws DocumentFormatNotFound if the default format isn't supported
+     */
+    static Indexer openIndex(BlackLabIndexWriter writer) throws DocumentFormatNotFound {
+        return new IndexerImpl(writer, null);
     }
 
-    static Indexer createNewIndex(File directory, String formatIdentifier) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, true, formatIdentifier, null);
-    }
-
-    static Indexer openIndex(File directory) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, false);
-    }
-
-    @Deprecated
-    static Indexer openIndex(File directory, String formatIdentifier) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, false, formatIdentifier, null);
-    }
-
+    /**
+     * Create an Indexer.
+     *
+     * Will try to use the specified format, or fall back on the index's
+     * default format (if set).
+     *
+     * @param writer index to write to
+     * @param formatIdentifier format to use, or null for the index default
+     * @return the indexer
+     * @throws DocumentFormatNotFound if the format isn't supported
+     */
     static Indexer openIndex(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
         return new IndexerImpl(writer, formatIdentifier);
     }
 
+    /**
+     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
+     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     */
     @Deprecated
-    static Indexer openIndex(File directory, boolean createNewIndex, String formatIdentifier) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, createNewIndex, formatIdentifier, null);
+    static Indexer createNewIndex(File directory, String formatIdentifier) throws DocumentFormatNotFound, ErrorOpeningIndex {
+        return openIndex(directory, true, formatIdentifier, null);
     }
 
+    /**
+     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
+     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     */
+    @Deprecated
+    static Indexer openIndex(File directory) throws DocumentFormatNotFound, ErrorOpeningIndex {
+        return openIndex(directory, false, null, null);
+    }
+
+    /**
+     * Open index
+     *
+     * @param directory the main BlackLab index directory
+     * @param create if true, creates a new index; otherwise, appends to existing
+     *            index. When creating a new index, a formatIdentifier or an
+     *            indexTemplateFile containing a valid "documentFormat" value should
+     *            also be supplied. Otherwise adding new data to the index isn't
+     *            possible, as we can't construct a DocIndexer to do the actual
+     *            indexing without a valid formatIdentifier.
+     * @param formatIdentifier (optional) determines how this Indexer will index any
+     *            new data added to it. If omitted, when opening an existing index,
+     *            the formatIdentifier in its metadata (as "documentFormat") is used
+     *            instead. When creating a new index, this format will be stored as
+     *            the default for that index, unless another default is already set
+     *            by the indexTemplateFile (as "documentFormat"), it will still be
+     *            used by this Indexer however.
+     * @param indexTemplateFile (optional, legacy) JSON file to use as template for index structure /
+     *            metadata (if creating new index)
+     * @throws DocumentFormatNotFound if no formatIdentifier was specified and
+     *             autodetection failed
+     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
+     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     */
+    @Deprecated
     static Indexer openIndex(File directory, boolean createNewIndex, String formatIdentifier, File indexTemplateFile) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(directory, createNewIndex, formatIdentifier, indexTemplateFile);
+        return new IndexerImpl(BlackLabIndexWriter.open(directory, createNewIndex, formatIdentifier, indexTemplateFile), formatIdentifier);
     }
 
     Charset DEFAULT_INPUT_ENCODING = StandardCharsets.UTF_8;

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -66,26 +66,6 @@ public interface Indexer {
     }
 
     /**
-     * Open index
-     *
-     * @param directory the main BlackLab index directory
-     * @param createNewIndex if true, creates a new index; otherwise, appends to existing
-     *            index. When creating a new index, a formatIdentifier or an
-     *            indexTemplateFile containing a valid "documentFormat" value should
-     *            also be supplied. Otherwise adding new data to the index isn't
-     *            possible, as we can't construct a DocIndexer to do the actual
-     *            indexing without a valid formatIdentifier.
-     * @param formatIdentifier (optional) determines how this Indexer will index any
-     *            new data added to it. If omitted, when opening an existing index,
-     *            the formatIdentifier in its metadata (as "documentFormat") is used
-     *            instead. When creating a new index, this format will be stored as
-     *            the default for that index, unless another default is already set
-     *            by the indexTemplateFile (as "documentFormat"), it will still be
-     *            used by this Indexer however.
-     * @param indexTemplateFile (optional, legacy) JSON file to use as template for index structure /
-     *            metadata (if creating new index)
-     * @throws DocumentFormatNotFound if no formatIdentifier was specified and
-     *             autodetection failed
      * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
      *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -68,7 +68,7 @@ public interface Indexer {
      * Open index
      *
      * @param directory the main BlackLab index directory
-     * @param create if true, creates a new index; otherwise, appends to existing
+     * @param createNewIndex if true, creates a new index; otherwise, appends to existing
      *            index. When creating a new index, a formatIdentifier or an
      *            indexTemplateFile containing a valid "documentFormat" value should
      *            also be supplied. Otherwise adding new data to the index isn't
@@ -90,7 +90,9 @@ public interface Indexer {
      */
     @Deprecated
     static Indexer openIndex(File directory, boolean createNewIndex, String formatIdentifier, File indexTemplateFile) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        return new IndexerImpl(BlackLabIndexWriter.open(directory, createNewIndex, formatIdentifier, indexTemplateFile), formatIdentifier);
+        BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(directory, createNewIndex, formatIdentifier,
+                indexTemplateFile);
+        return new IndexerImpl(indexWriter, formatIdentifier);
     }
 
     Charset DEFAULT_INPUT_ENCODING = StandardCharsets.UTF_8;

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.Term;
 
 import nl.inl.blacklab.exceptions.DocumentFormatNotFound;
 import nl.inl.blacklab.exceptions.ErrorOpeningIndex;
+import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndexWriter;
 
 public interface Indexer {
@@ -86,11 +87,11 @@ public interface Indexer {
      * @throws DocumentFormatNotFound if no formatIdentifier was specified and
      *             autodetection failed
      * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
-     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
     static Indexer openIndex(File directory, boolean createNewIndex, String formatIdentifier, File indexTemplateFile) throws DocumentFormatNotFound, ErrorOpeningIndex {
-        BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(directory, createNewIndex, formatIdentifier,
+        BlackLabIndexWriter indexWriter = BlackLab.openForWriting(directory, createNewIndex, formatIdentifier,
                 indexTemplateFile);
         return new IndexerImpl(indexWriter, formatIdentifier);
     }

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -28,7 +28,7 @@ public interface Indexer {
      * @return the indexer
      * @throws DocumentFormatNotFound if the default format isn't supported
      */
-    static Indexer openIndex(BlackLabIndexWriter writer) throws DocumentFormatNotFound {
+    static Indexer get(BlackLabIndexWriter writer) throws DocumentFormatNotFound {
         return new IndexerImpl(writer, null);
     }
 
@@ -43,13 +43,13 @@ public interface Indexer {
      * @return the indexer
      * @throws DocumentFormatNotFound if the format isn't supported
      */
-    static Indexer openIndex(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
+    static Indexer get(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
         return new IndexerImpl(writer, formatIdentifier);
     }
 
     /**
-     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
-     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
+     *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
     static Indexer createNewIndex(File directory, String formatIdentifier) throws DocumentFormatNotFound, ErrorOpeningIndex {
@@ -57,8 +57,8 @@ public interface Indexer {
     }
 
     /**
-     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
-     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
+     *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
     static Indexer openIndex(File directory) throws DocumentFormatNotFound, ErrorOpeningIndex {
@@ -86,7 +86,7 @@ public interface Indexer {
      *            metadata (if creating new index)
      * @throws DocumentFormatNotFound if no formatIdentifier was specified and
      *             autodetection failed
-     * @deprecated use {@link #openIndex(BlackLabIndexWriter, String)} with
+     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
      *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated

--- a/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -220,7 +220,9 @@ class IndexerImpl implements DocWriter, Indexer {
     @Deprecated
     IndexerImpl(File directory, boolean create, String formatIdentifier, File indexTemplateFile)
             throws DocumentFormatNotFound, ErrorOpeningIndex {
-        init(BlackLabIndexWriter.open(directory, create, formatIdentifier, indexTemplateFile), formatIdentifier);
+        BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(directory, create, formatIdentifier,
+                indexTemplateFile);
+        init(indexWriter, formatIdentifier);
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -29,11 +29,8 @@ import nl.inl.blacklab.exceptions.MalformedInputFile;
 import nl.inl.blacklab.exceptions.PluginException;
 import nl.inl.blacklab.forwardindex.ForwardIndex;
 import nl.inl.blacklab.forwardindex.ForwardIndexExternal;
-import nl.inl.blacklab.index.DocIndexerFactory.Format;
 import nl.inl.blacklab.index.annotated.AnnotatedFieldWriter;
 import nl.inl.blacklab.index.annotated.AnnotationWriter;
-import nl.inl.blacklab.indexers.config.ConfigInputFormat;
-import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndexWriter;
 import nl.inl.blacklab.search.ContentAccessor;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
@@ -201,22 +198,6 @@ class IndexerImpl implements DocWriter, Indexer {
      *
      * @param directory the main BlackLab index directory
      * @param create if true, creates a new index; otherwise, appends to existing
-     *            index
-     * @throws DocumentFormatNotFound if autodetection of the document format
-     *             failed
-     * @throws ErrorOpeningIndex if we couldn't open the index
-     */
-    @Deprecated
-    IndexerImpl(File directory, boolean create)
-            throws DocumentFormatNotFound, ErrorOpeningIndex {
-        init(directory, create, null, null);
-    }
-
-    /**
-     * Construct Indexer
-     *
-     * @param directory the main BlackLab index directory
-     * @param create if true, creates a new index; otherwise, appends to existing
      *            index. When creating a new index, a formatIdentifier or an
      *            indexTemplateFile containing a valid "documentFormat" value should
      *            also be supplied. Otherwise adding new data to the index isn't
@@ -233,42 +214,13 @@ class IndexerImpl implements DocWriter, Indexer {
      *            metadata (if creating new index)
      * @throws DocumentFormatNotFound if no formatIdentifier was specified and
      *             autodetection failed
+     * @deprecated use {@link #Indexer(BlackLabIndexWriter, String, File)} with
+     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
      */
+    @Deprecated
     IndexerImpl(File directory, boolean create, String formatIdentifier, File indexTemplateFile)
             throws DocumentFormatNotFound, ErrorOpeningIndex {
-        init(directory, create, formatIdentifier, indexTemplateFile);
-    }
-
-    protected void init(File directory, boolean create, String formatIdentifier, File indexTemplateFile)
-            throws DocumentFormatNotFound, ErrorOpeningIndex {
-
-        if (create) {
-            if (indexTemplateFile == null) {
-                // Create index from format configuration (modern)
-                // (or a legacy DocIndexer, but no index template file, so the defaults will be used)
-                createIndex(directory, formatIdentifier);
-            } else {
-                // Create index from index template file (legacy)
-                createIndexFromTemplate(directory, formatIdentifier, indexTemplateFile);
-            }
-        } else {
-            // opening an existing index
-            this.indexWriter = BlackLab.openForWriting(directory, false);
-            String defaultFormatIdentifier = this.indexWriter.metadata().documentFormat();
-
-            if (DocumentFormats.isSupported(formatIdentifier))
-                this.formatIdentifier = formatIdentifier;
-            else if (DocumentFormats.isSupported(defaultFormatIdentifier))
-                this.formatIdentifier = defaultFormatIdentifier;
-            else {
-                indexWriter.close();
-                throw new DocumentFormatNotFound(
-                        "Could not determine documentFormat for index " + directory + " (" + formatIdentifier
-                                + "): " + formatError(formatIdentifier));
-            }
-        }
-
-        initMetadataFieldTypes();
+        init(BlackLabIndexWriter.open(directory, create, formatIdentifier, indexTemplateFile), formatIdentifier);
     }
 
     /**
@@ -279,24 +231,53 @@ class IndexerImpl implements DocWriter, Indexer {
      *      If omitted, uses the default formatIdentifier stored in the indexMetadata. If that is missing too, throws DocumentFormatNotFound.
      */
     IndexerImpl(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
-        if (writer == null) {
-            throw new BlackLabRuntimeException("writer == null");
+        init(writer, formatIdentifier);
+    }
+
+    private void init(BlackLabIndexWriter indexWriter, String formatIdentifier) throws DocumentFormatNotFound {
+        if (indexWriter == null) {
+            throw new BlackLabRuntimeException("indexWriter == null");
         }
 
-        this.indexWriter = writer;
+        this.indexWriter = indexWriter;
 
-        if (!DocumentFormats.isSupported(formatIdentifier)) {
-            formatIdentifier = writer.metadata().documentFormat();
-            if (!DocumentFormats.isSupported(formatIdentifier)) {
-                throw new DocumentFormatNotFound(
-                        "Could not determine documentFormat for index " + writer.name() + " (" + formatIdentifier
-                                + "): " + formatError(formatIdentifier));
-            }
+        // Make sure we have a supported format, and make sure a default format is recorded in the metadata.
+        try {
+            this.formatIdentifier = determineFormat(indexWriter.indexDirectory(), formatIdentifier, indexWriter.metadata().documentFormat());
+            setMetadataDocumentFormatIfMissing(indexWriter, formatIdentifier);
+        } catch (DocumentFormatNotFound e) {
+            indexWriter.close();
+            throw e;
         }
-        this.formatIdentifier = formatIdentifier;
-        setMetadataDocumentFormatIfMissing(formatIdentifier);
 
         initMetadataFieldTypes();
+    }
+
+    /**
+     * Determine what format to use, the specified or the default one.
+     *
+     * Will return a supported format, preferring the specified one to the
+     * default, or throw an exception.
+     *
+     * @param directory index directory (for exception message)
+     * @param formatIdentifier specified format
+     * @param fallbackFormat default to fall back if the specified format is not supported
+     * @return chosen format
+     * @throws DocumentFormatNotFound if neither format is supported
+     */
+    private String determineFormat(File directory, String formatIdentifier, String fallbackFormat)
+            throws DocumentFormatNotFound {
+        if (!DocumentFormats.isSupported(formatIdentifier)) {
+            // Specified format not found; use index default
+            if (fallbackFormat == null || !DocumentFormats.isSupported(fallbackFormat)) {
+                // Index default doesn't work either, error
+                throw new DocumentFormatNotFound(
+                        "Could not determine documentFormat for index " + directory + " (" + formatIdentifier
+                                + (fallbackFormat == null ? "" : " / " + fallbackFormat) + "): " + formatError(formatIdentifier));
+            }
+            formatIdentifier = fallbackFormat;
+        }
+        return formatIdentifier;
     }
 
     private void initMetadataFieldTypes() {
@@ -332,57 +313,7 @@ class IndexerImpl implements DocWriter, Indexer {
         return formatError;
     }
 
-    private void createIndex(File directory, String formatIdentifier) throws ErrorOpeningIndex, DocumentFormatNotFound {
-        if (!DocumentFormats.isSupported(formatIdentifier)) {
-            throw new DocumentFormatNotFound(
-                    "Cannot create new index in " + directory + " with format " + formatIdentifier + ": " +
-                            formatError(formatIdentifier));
-        }
-        this.formatIdentifier = formatIdentifier;
-
-        // No indexTemplateFile, but maybe the formatIdentifier is backed by a ConfigInputFormat (instead of
-        // some other DocIndexer implementation)
-        // this ConfigInputFormat could then still be used as a minimal template to setup the index
-        // (if there's no ConfigInputFormat, that's okay too, a default index template will be used instead)
-        ConfigInputFormat format = null;
-        for (Format desc : DocumentFormats.getFormats()) {
-            if (desc.getId().equals(formatIdentifier) && desc.getConfig() != null) {
-                format = desc.getConfig();
-                break;
-            }
-        }
-
-        // template might still be null, in that case a default will be created
-        indexWriter = BlackLab.openForWriting(directory, true, format);
-
-        setMetadataDocumentFormatIfMissing(formatIdentifier); // only necessary if not a config-based format?
-    }
-
-    private void createIndexFromTemplate(File directory, String formatIdentifier, File indexTemplateFile)
-            throws ErrorOpeningIndex, DocumentFormatNotFound {
-        indexWriter = BlackLab.openForWriting(directory, true, indexTemplateFile);
-
-        // Read back the formatIdentifier that was provided through the indexTemplateFile now that the index
-        // has written it (might be null)
-
-        if (DocumentFormats.isSupported(formatIdentifier)) {
-            this.formatIdentifier = formatIdentifier;
-            setMetadataDocumentFormatIfMissing(formatIdentifier);
-        } else {
-            String defaultFormatIdentifier = indexWriter.metadata().documentFormat();
-            if (DocumentFormats.isSupported(defaultFormatIdentifier)) {
-                this.formatIdentifier = defaultFormatIdentifier;
-            } else {
-                // TODO we should delete the newly created index here as it failed, how do we clean up files properly?
-                indexWriter.close();
-                throw new DocumentFormatNotFound(
-                        "Cannot create new index in " + directory + " with format " + formatIdentifier + ": " +
-                                formatError(formatIdentifier));
-            }
-        }
-    }
-
-    private void setMetadataDocumentFormatIfMissing(String formatIdentifier) {
+    private static void setMetadataDocumentFormatIfMissing(BlackLabIndexWriter indexWriter, String formatIdentifier) {
         String defaultFormatIdentifier = indexWriter.metadata().documentFormat();
         if (defaultFormatIdentifier == null || defaultFormatIdentifier.isEmpty()) {
             // indexTemplateFile didn't provide a default formatIdentifier,

--- a/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/IndexerImpl.java
@@ -31,6 +31,7 @@ import nl.inl.blacklab.forwardindex.ForwardIndex;
 import nl.inl.blacklab.forwardindex.ForwardIndexExternal;
 import nl.inl.blacklab.index.annotated.AnnotatedFieldWriter;
 import nl.inl.blacklab.index.annotated.AnnotationWriter;
+import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndexWriter;
 import nl.inl.blacklab.search.ContentAccessor;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
@@ -214,13 +215,13 @@ class IndexerImpl implements DocWriter, Indexer {
      *            metadata (if creating new index)
      * @throws DocumentFormatNotFound if no formatIdentifier was specified and
      *             autodetection failed
-     * @deprecated use {@link #Indexer(BlackLabIndexWriter, String, File)} with
-     *   {@link BlackLabIndexWriter#open(File, boolean, String, File)} instead
+     * @deprecated use {@link IndexerImpl(BlackLabIndexWriter, String, File)} with
+     *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
     IndexerImpl(File directory, boolean create, String formatIdentifier, File indexTemplateFile)
             throws DocumentFormatNotFound, ErrorOpeningIndex {
-        BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(directory, create, formatIdentifier,
+        BlackLabIndexWriter indexWriter = BlackLab.openForWriting(directory, create, formatIdentifier,
                 indexTemplateFile);
         init(indexWriter, formatIdentifier);
     }
@@ -246,7 +247,7 @@ class IndexerImpl implements DocWriter, Indexer {
         // Make sure we have a supported format, and make sure a default format is recorded in the metadata.
         try {
             this.formatIdentifier = determineFormat(indexWriter.indexDirectory(), formatIdentifier, indexWriter.metadata().documentFormat());
-            setMetadataDocumentFormatIfMissing(indexWriter, formatIdentifier);
+            BlackLabIndexWriter.setMetadataDocumentFormatIfMissing(indexWriter, formatIdentifier);
         } catch (DocumentFormatNotFound e) {
             indexWriter.close();
             throw e;
@@ -313,16 +314,6 @@ class IndexerImpl implements DocWriter, Indexer {
                 formatError =  "Unknown formatIdentifier '" + formatIdentifier + "'";
         }
         return formatError;
-    }
-
-    private static void setMetadataDocumentFormatIfMissing(BlackLabIndexWriter indexWriter, String formatIdentifier) {
-        String defaultFormatIdentifier = indexWriter.metadata().documentFormat();
-        if (defaultFormatIdentifier == null || defaultFormatIdentifier.isEmpty()) {
-            // indexTemplateFile didn't provide a default formatIdentifier,
-            // overwrite it with our provided formatIdentifier
-            indexWriter.metadata().setDocumentFormat(formatIdentifier);
-            indexWriter.metadata().save();
-        }
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
@@ -35,6 +35,9 @@ import nl.inl.blacklab.search.indexmetadata.IndexMetadataImpl;
  */
 public abstract class DocIndexerConfig extends DocIndexerBase {
 
+    /** What annotations have we warned about using special default sensitivity? */
+    private static Set<String> warnSensitivity = new HashSet<>();
+
     protected static String replaceDollarRefs(String pattern, List<String> replacements) {
         if (pattern != null) {
             int i = 1;
@@ -94,9 +97,6 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
 
     protected final Map<String, Collection<String>> sortedMetadataValues = new HashMap<>();
 
-    /** What annotations have we warned about using special default sensitivity? */
-    Set<String> warnSensitivity = new HashSet<>();
-
     public void setConfigInputFormat(ConfigInputFormat config) {
         this.config = config;
     }
@@ -110,13 +110,16 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
                 // Historic behaviour: if no sensitivity is given, "word" and "lemma" annotations will
                 // get SensitivitySetting.SENSITIVE_AND_INSENSITIVE; all others get SensitivitySetting.ONLY_INSENSITIVE.
                 // Warn users about this so they can make their config files explicit before this special case is removed.
-                if (!warnSensitivity.contains(name)) {
-                    warnSensitivity.add(name);
-                    logger.warn("Configuration " + config.getName()
-                            + " relies on special default sensitivity 'sensitive_insensitive' for annotation " + name
-                            + "; this behaviour "
-                            + "is deprecated. Please update your config to explicitly declare the sensitivity setting for this annotation. In a future version, all annotations "
-                            + "without explicit sensitivity will default to 'insensitive'.");
+                synchronized (warnSensitivity) {
+                    if (!warnSensitivity.contains(name)) {
+                        warnSensitivity.add(name);
+                        logger.warn("Configuration " + config.getName()
+                                + " relies on special default sensitivity 'sensitive_insensitive' for annotation "
+                                + name
+                                + "; this behaviour "
+                                + "is deprecated. Please update your config to explicitly declare the sensitivity setting for this annotation. In a future version, all annotations "
+                                + "without explicit sensitivity will default to 'insensitive'.");
+                    }
                 }
             }
             return sensitivity;

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLab.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLab.java
@@ -24,6 +24,7 @@ import nl.inl.blacklab.index.DownloadCache;
 import nl.inl.blacklab.index.PluginManager;
 import nl.inl.blacklab.index.ZipHandleManager;
 import nl.inl.blacklab.indexers.config.ConfigInputFormat;
+import nl.inl.blacklab.search.BlackLabIndex.IndexType;
 import nl.inl.util.FileUtil;
 
 /**
@@ -140,7 +141,52 @@ public final class BlackLab {
      */
     public static BlackLabIndexWriter openForWriting(File indexDir, boolean createNewIndex, ConfigInputFormat config)
             throws ErrorOpeningIndex {
-        return BlackLab.implicitInstance().openForWriting(indexDir, createNewIndex, config);
+        return implicitInstance().openForWriting(indexDir, createNewIndex, config);
+    }
+
+    /**
+     * Open an index for writing ("index mode": adding/deleting documents).
+     *
+     * @param directory the index directory
+     * @param create if true, create a new index even if one existed there
+     * @param formatIdentifier default format to use
+     * @param indexTemplateFile (optional, legacy) index template file
+     * @return index writer
+     * @throws ErrorOpeningIndex if the index couldn't be opened
+     */
+    public static BlackLabIndexWriter openForWriting(File directory, boolean create, String formatIdentifier) throws ErrorOpeningIndex {
+        return openForWriting(directory, create, formatIdentifier, null, null);
+    }
+
+    /**
+     * Open an index for writing ("index mode": adding/deleting documents).
+     *
+     * @param directory the index directory
+     * @param create if true, create a new index even if one existed there
+     * @param formatIdentifier default format to use
+     * @param indexTemplateFile (optional, legacy) index template file
+     * @return index writer
+     * @throws ErrorOpeningIndex if the index couldn't be opened
+     */
+    public static BlackLabIndexWriter openForWriting(File directory, boolean create, String formatIdentifier,
+            File indexTemplateFile) throws ErrorOpeningIndex {
+        return openForWriting(directory, create, formatIdentifier, indexTemplateFile, null);
+    }
+
+    /**
+     * Open an index for writing ("index mode": adding/deleting documents).
+     *
+     * @param directory the index directory
+     * @param create if true, create a new index even if one existed there
+     * @param formatIdentifier default format to use
+     * @param indexTemplateFile (optional, legacy) index template file
+     * @param indexType index format to use: classic with external files or new integrated
+     * @return index writer
+     * @throws ErrorOpeningIndex if the index couldn't be opened
+     */
+    public static BlackLabIndexWriter openForWriting(File directory, boolean create, String formatIdentifier,
+            File indexTemplateFile, IndexType indexType) throws ErrorOpeningIndex {
+        return implicitInstance().openForWriting(directory, create, formatIdentifier, indexTemplateFile, indexType);
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexWriter.java
@@ -24,7 +24,24 @@ public interface BlackLabIndexWriter extends BlackLabIndex {
      */
     static BlackLabIndexWriter open(File directory, boolean create, String formatIdentifier,
             File indexTemplateFile) throws ErrorOpeningIndex {
+        return open(directory, create, formatIdentifier, indexTemplateFile, null);
+    }
+
+    /**
+     * Create or open an index.
+     *
+     * @param directory index directory
+     * @param create force creating a new index even if one already exists?
+     * @param formatIdentifier default document format to use
+     * @param indexTemplateFile optional file to use as template for index (legacy)
+     * @param indexType index format to use for creating index: classic with external files or integrated
+     * @return the index writer
+     * @throws ErrorOpeningIndex if the index couldn't be opened
+     */
+    static BlackLabIndexWriter open(File directory, boolean create, String formatIdentifier,
+            File indexTemplateFile, IndexType indexType) throws ErrorOpeningIndex {
         BlackLabIndexWriter indexWriter;
+        BlackLabEngine engine = BlackLab.implicitInstance();
         if (create) {
             if (indexTemplateFile == null) {
                 // Create index from format configuration (modern)
@@ -36,11 +53,13 @@ public interface BlackLabIndexWriter extends BlackLabIndex {
                 ConfigInputFormat format = DocumentFormats.getConfigInputFormat(formatIdentifier);
 
                 // template might still be null, in that case a default will be created
-                indexWriter = BlackLab.openForWriting(directory, true, format);
+                indexWriter = engine.openForWriting(directory, true, format, indexType);
             } else {
                 // Create index from index template file (legacy)
-                indexWriter = BlackLab.openForWriting(directory, true, indexTemplateFile);
+                indexWriter = engine.openForWriting(directory, true, indexTemplateFile, indexType);
             }
+            // Record the default format in the index
+            indexWriter.metadata().setDocumentFormat(formatIdentifier);
         } else {
             // opening an existing index
             indexWriter = BlackLab.openForWriting(directory, false);

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexWriter.java
@@ -1,11 +1,52 @@
 package nl.inl.blacklab.search;
 
+import java.io.File;
+
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.Query;
 
+import nl.inl.blacklab.exceptions.ErrorOpeningIndex;
+import nl.inl.blacklab.index.DocumentFormats;
+import nl.inl.blacklab.indexers.config.ConfigInputFormat;
 import nl.inl.blacklab.search.indexmetadata.IndexMetadataWriter;
 
 public interface BlackLabIndexWriter extends BlackLabIndex {
+
+    /**
+     * Create or open an index.
+     *
+     * @param directory index directory
+     * @param create force creating a new index even if one already exists?
+     * @param formatIdentifier default document format to use
+     * @param indexTemplateFile optional file to use as template for index (legacy)
+     * @return the index writer
+     * @throws ErrorOpeningIndex if the index couldn't be opened
+     */
+    static BlackLabIndexWriter open(File directory, boolean create, String formatIdentifier,
+            File indexTemplateFile) throws ErrorOpeningIndex {
+        BlackLabIndexWriter indexWriter;
+        if (create) {
+            if (indexTemplateFile == null) {
+                // Create index from format configuration (modern)
+                // (or a legacy DocIndexer, but no index template file, so the defaults will be used)
+                // No indexTemplateFile, but maybe the formatIdentifier is backed by a ConfigInputFormat (instead of
+                // some other DocIndexer implementation)
+                // this ConfigInputFormat could then still be used as a minimal template to setup the index
+                // (if there's no ConfigInputFormat, that's okay too, a default index template will be used instead)
+                ConfigInputFormat format = DocumentFormats.getConfigInputFormat(formatIdentifier);
+
+                // template might still be null, in that case a default will be created
+                indexWriter = BlackLab.openForWriting(directory, true, format);
+            } else {
+                // Create index from index template file (legacy)
+                indexWriter = BlackLab.openForWriting(directory, true, indexTemplateFile);
+            }
+        } else {
+            // opening an existing index
+            indexWriter = BlackLab.openForWriting(directory, false);
+        }
+        return indexWriter;
+    }
 
     /**
      * Call this to roll back any changes made to the index this session. Calling

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataImpl.java
@@ -211,7 +211,6 @@ public class IndexMetadataImpl implements IndexMetadataWriter {
         }
         saveAsJson = false;
         if (createNewIndex && config != null) {
-
             // Create an index metadata file from this config.
             ConfigCorpus corpusConfig = config.getCorpusConfig();
             ObjectMapper mapper = Json.getJsonObjectMapper();
@@ -239,6 +238,10 @@ public class IndexMetadataImpl implements IndexMetadataWriter {
 
             addFieldInfoFromConfig(metadata, annotated, metaGroups, annotGroups, config);
             extractFromJson(jsonRoot, null, true);
+
+            if (config.getName() != null)
+                setDocumentFormat(config.getName());
+
             save();
         } else {
             // Read existing metadata or create empty new one

--- a/server/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/server/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -23,6 +23,7 @@ import nl.inl.blacklab.index.IndexListener;
 import nl.inl.blacklab.index.Indexer;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndex;
+import nl.inl.blacklab.search.BlackLabIndexWriter;
 import nl.inl.blacklab.search.indexmetadata.IndexMetadata;
 import nl.inl.blacklab.server.exceptions.BlsException;
 import nl.inl.blacklab.server.exceptions.IllegalIndexName;
@@ -277,7 +278,9 @@ public class Index {
         cleanupClosedIndexerOrThrow();
         close(); // Close any BlackLabIndex that is still in search mode
         try {
-            this.indexer = Indexer.openIndex(searchMan.blackLabInstance().openForWriting(this.dir, false), null);
+            BlackLabIndexWriter indexWriter = searchMan.blackLabInstance()
+                    .openForWriting(this.dir, false);
+            this.indexer = Indexer.openIndex(indexWriter);
             indexer.setNumberOfThreadsToUse(BlackLab.config().getIndexing().getNumberOfThreads());
         } catch (Exception e) {
             throw new InternalServerError("Could not open index '" + id + "'", "INTERR_OPENING_INDEXWRITER", e);

--- a/server/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/server/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -280,7 +280,7 @@ public class Index {
         try {
             BlackLabIndexWriter indexWriter = searchMan.blackLabInstance()
                     .openForWriting(this.dir, false);
-            this.indexer = Indexer.openIndex(indexWriter);
+            this.indexer = Indexer.get(indexWriter);
             indexer.setNumberOfThreadsToUse(BlackLab.config().getIndexing().getNumberOfThreads());
         } catch (Exception e) {
             throw new InternalServerError("Could not open index '" + id + "'", "INTERR_OPENING_INDEXWRITER", e);

--- a/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -62,8 +62,7 @@ public class IndexTool {
         String deleteQuery = null;
         int numberOfThreadsToUse = BlackLab.config().getIndexing().getNumberOfThreads();
         List<File> linkedFileDirs = new ArrayList<>();
-        IndexType indexType = BlackLab.isFeatureEnabled(BlackLab.FEATURE_INTEGRATE_EXTERNAL_FILES) ?
-                IndexType.INTEGRATED : IndexType.EXTERNAL_FILES;
+        IndexType indexType = null; // null means "use default"
         for (int i = 0; i < args.length; i++) {
             String arg = args[i].trim();
             if (arg.startsWith("---")) {
@@ -276,7 +275,7 @@ public class IndexTool {
         Indexer indexer = null;
         try {
             BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, forceCreateNew,
-                    formatIdentifier, indexTemplateFile);
+                    formatIdentifier, indexTemplateFile, indexType);
             indexer = Indexer.openIndex(indexWriter, formatIdentifier);
             //indexer = Indexer.openIndex(indexDir, forceCreateNew, formatIdentifier, indexTemplateFile);
         } catch (DocumentFormatNotFound e1) {

--- a/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -274,7 +274,7 @@ public class IndexTool {
         }
         Indexer indexer = null;
         try {
-            BlackLabIndexWriter indexWriter = BlackLabIndexWriter.open(indexDir, forceCreateNew,
+            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, forceCreateNew,
                     formatIdentifier, indexTemplateFile, indexType);
             indexer = Indexer.openIndex(indexWriter, formatIdentifier);
             //indexer = Indexer.openIndex(indexDir, forceCreateNew, formatIdentifier, indexTemplateFile);

--- a/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -276,7 +276,7 @@ public class IndexTool {
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, forceCreateNew,
                     formatIdentifier, indexTemplateFile, indexType);
-            indexer = Indexer.openIndex(indexWriter, formatIdentifier);
+            indexer = Indexer.get(indexWriter, formatIdentifier);
             //indexer = Indexer.openIndex(indexDir, forceCreateNew, formatIdentifier, indexTemplateFile);
         } catch (DocumentFormatNotFound e1) {
             // Maybe formatIdentifier isn't a format name but the path to a format file?


### PR DESCRIPTION
Instead of letting the Indexer create or open the index, let the client do that and pass the resulting BlackLabIndexWriter to the Indexer. This is more flexible and will make testing easier.

This proved a little tricky because Indexer did some additional things that didn't normally happen when opening an index, such as making sure the documentFormat is set in the metadata. But it should work now.

The entire reason for the above change was the desire for an option in the IndexTool to specify the index format, external or integrated. That should work now as well.