### PR TITLE
adds null pointer check for capture group when omitting empty

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/CapturedGroupsImpl.java
@@ -92,7 +92,7 @@ public class CapturedGroupsImpl implements CapturedGroups {
             return null;
         Map<String, Span> result = new TreeMap<>(); // TreeMap to maintain group ordering
         for (int i = 0; i < names.size(); i++) {
-            if (!omitEmpty || groups[i].length() > 0)
+            if (groups[i] != null && (!omitEmpty || groups[i].length() > 0))
                 result.put(names.get(i), groups[i]);
         }
         return Collections.unmodifiableMap(result);


### PR DESCRIPTION
Hey all, we found a null pointer exception when using the new flag. The below fixes the problem we observe.

I took a 2nd (and third look) at possible places we could be reading elements of the `groups` array and could not find other references where we weren't checking for null.

Double-checking those references read would be helpful.

Thanks all.

