### PR TITLE
Integrated format: index metadata improvements

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,7 +29,6 @@ Integrating with Solr will involve the following steps.
 
 ### Metadata
 
-- [ ] QueryTool: enter command `filter *:*`, then command `docs`. The index metadata document is not skipped. ideally, there should be a guarantee that DocResults cannot include the metadata document.
 - [ ] metadata may change during indexing after all? no more undeclared metadata field warning? OTOH, changing metadata as documents are added to the index would be tricky in distributed env... You should probably check for metadata document updates semi-regularly, and keep more critical information in field attributes.
 
 Where we take the metadata document into account:

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,7 +29,6 @@ Integrating with Solr will involve the following steps.
 
 ### Metadata
 
-- [ ] unit tests should also test fetching document metadata. Give TestIndex some metadata and write a simple test for it.
 - [ ] QueryTool: enter command `filter *:*`, then command `docs`. The index metadata document is not skipped. ideally, there should be a guarantee that DocResults cannot include the metadata document.
 - [ ] metadata may change during indexing after all? no more undeclared metadata field warning? OTOH, changing metadata as documents are added to the index would be tricky in distributed env... You should probably check for metadata document updates semi-regularly, and keep more critical information in field attributes.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,13 +29,9 @@ Integrating with Solr will involve the following steps.
 
 ### Metadata
 
-- [ ] custom should be freezable?
 - [ ] unit tests should also test fetching document metadata. Give TestIndex some metadata and write a simple test for it.
-- [x] Store metadata in "special" document. Preferably, don't treat it as a special document, just a document in the index that doesn't have a value for the contents field.
-    - [ ] metadata may change during indexing after all? no more undeclared metadata field warning?
-          OTOH, changing metadata as documents are added to the index would be tricky in distributed env...
-    - [ ] QueryTool: enter command `filter *:*`, then command `docs`. The index metadata document is not skipped.
-          ideally, there should be a guarantee that DocResults cannot include the metadata document.
+- [ ] QueryTool: enter command `filter *:*`, then command `docs`. The index metadata document is not skipped. ideally, there should be a guarantee that DocResults cannot include the metadata document.
+- [ ] metadata may change during indexing after all? no more undeclared metadata field warning? OTOH, changing metadata as documents are added to the index would be tricky in distributed env... You should probably check for metadata document updates semi-regularly, and keep more critical information in field attributes.
 
 Where we take the metadata document into account:
 - whenever we iterate over all documents to do something (BlackLabIndex.forEachDocument explicitly skips metadata document)

--- a/core/src/test/java/nl/inl/blacklab/perdocument/TestDocResults.java
+++ b/core/src/test/java/nl/inl/blacklab/perdocument/TestDocResults.java
@@ -8,6 +8,7 @@ import nl.inl.blacklab.search.results.DocResult;
 import nl.inl.blacklab.search.results.DocResults;
 import nl.inl.blacklab.search.results.Hits;
 import nl.inl.blacklab.search.results.Results;
+import nl.inl.blacklab.testutil.TestIndex;
 
 public class TestDocResults {
 

--- a/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
@@ -1,9 +1,13 @@
 package nl.inl.blacklab.search;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.junit.AfterClass;
@@ -23,6 +27,8 @@ import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 import nl.inl.blacklab.search.lucene.BLSpanTermQuery;
 import nl.inl.blacklab.search.lucene.SpanQueryFiltered;
+import nl.inl.blacklab.search.results.DocResult;
+import nl.inl.blacklab.search.results.DocResults;
 import nl.inl.blacklab.search.results.Hits;
 import nl.inl.blacklab.testutil.TestIndex;
 
@@ -452,6 +458,25 @@ public class TestSearches {
         Assert.assertEquals(1, group.length);
         Assert.assertEquals(2, group[0].start());
         Assert.assertEquals(3, group[0].end());
+    }
+
+    @Test
+    public void testDocResults() {
+        DocResults allDocs = testIndex.index().queryDocuments(new MatchAllDocsQuery());
+
+        // Check that the number is correct (e.g. metadata document is not matched)
+        Assert.assertEquals(4, allDocs.size());
+
+        // Check that all pids are there
+        Set<String> pids = new HashSet<>();
+        Set<String> titles = new HashSet<>();
+        for (DocResult d: allDocs) {
+            Document doc = testIndex.index().luceneDoc(d.docId());
+            pids.add(doc.get("pid"));
+            titles.add(doc.get("title"));
+        }
+        Assert.assertEquals(Set.of("0", "1", "2", "3"), pids);
+        Assert.assertEquals(Set.of("Pangram", "Learning words", "Star Wars", "Bastardized Shakespeare"), titles);
     }
 
 }

--- a/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -78,6 +79,14 @@ public class TestSearches {
         expected = List.of("May [the] Force");
         int docId = testIndex.getDocIdForDocNumber(2);
         Assert.assertEquals(expected, testIndex.findConc(" 'the' ", new SingleDocIdFilter(docId)));
+    }
+
+    @Test
+    public void testSimpleTitleFilter() {
+        expected = List.of("May [the] Force");
+        // metadata is tokenized and lowercased by default
+        Query filter = new TermQuery(new Term("title", "star"));
+        Assert.assertEquals(expected, testIndex.findConc(" 'the' ", filter));
     }
 
     @Test

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -73,7 +73,7 @@ public class TestIndex {
             // Note that "The|DOH|ZZZ" will be indexed as multiple values at the same token position.
             // All values will be searchable in the reverse index, but only the first will be stored in the
             // forward index.
-            "<doc pid='0'><s><entity>"
+            "<doc pid='0' title='Pangram'><s><entity>"
                 + "<w l='the'   p='art'>The|DOH|ZZZ</w> "
                 + "<w l='quick' p='adj'>quick</w> "
                 + "<w l='brown' p='adj'>brown</w> "
@@ -88,7 +88,7 @@ public class TestIndex {
             // This is intentional, to test this case.
             // It is not the last doc, because we need to make
             // sure that doesn't mess up docs indexed after this one.
-            "<doc pid='1'> <w l='noot'>noot</w> "
+            "<doc pid='1' title='Learning words'> <w l='noot'>noot</w> "
                     + "<w l='mier'>mier</w> "
                     + "<w l='aap'>aap</w> "
                     + "<w l='mier'>mier</w> "
@@ -102,14 +102,14 @@ public class TestIndex {
                     + "<w l='aap'>aap</w> "
                     + "</doc>",
 
-            "<doc pid='2'> <s><w l='may' p='vrb'>May</w> "
+            "<doc pid='2' title='Star Wars'> <s><w l='may' p='vrb'>May</w> "
                     + "<entity><w l='the' p='art'>the</w> "
                     + "<w l='force' p='nou'>Force</w></entity> "
                     + "<w l='be' p='vrb'>be</w> "
                     + "<w l='with' p='pre'>with</w> "
                     + "<w l='you' p='pro'>you</w>" + ".</s></doc>",
 
-            "<doc pid='3'> <s><w l='to' p='pre'>To</w> "
+            "<doc pid='3' title='Bastardized Shakespeare'> <s><w l='to' p='pre'>To</w> "
                     + "<w l='find' p='vrb'>find</w> "
                     + "<w l='or' p='con'>or</w> "
                     + "<w l='be' p='adv'>not</w> "

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
@@ -284,9 +284,11 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
     }
 
     @Override
-    synchronized public void freeze() {
-        super.freeze();
-        this.annots.values().forEach(AnnotationImpl::freeze);
+    public boolean freeze() {
+        boolean b = super.freeze();
+        if (b)
+            this.annots.values().forEach(AnnotationImpl::freeze);
+        return b;
     }
     
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationImpl.java
@@ -69,7 +69,7 @@ public class AnnotationImpl implements Annotation, Freezable {
     private MatchSensitivity offsetsMatchSensitivity;
 
     @XmlTransient
-    private boolean frozen = false;
+    private FreezeStatus frozen = new FreezeStatus();
     
     /** Names of our subannotations, if we have any */
     private final Set<String> subannotations = new HashSet<>();
@@ -287,13 +287,13 @@ public class AnnotationImpl implements Annotation, Freezable {
     }
     
     @Override
-    public void freeze() {
-        this.frozen = true;
+    public boolean freeze() {
+        return frozen.freeze();
     }
     
     @Override
     public boolean isFrozen() {
-        return this.frozen;
+        return frozen.isFrozen();
     }
 
     @Override public boolean equals(Object o) {
@@ -351,7 +351,8 @@ public class AnnotationImpl implements Annotation, Freezable {
             sensitivitiesMap.put(s, new AnnotationSensitivityImpl(this, s));
         }
         offsetsSensitivity = sensitivitiesMap.get(offsetsMatchSensitivity);
-        frozen = !index.indexMode();
+        if (!index.indexMode())
+            freeze();
     }
 
     public boolean isSubannotation() {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomPropsMap.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomPropsMap.java
@@ -56,16 +56,12 @@ public class CustomPropsMap implements CustomProps {
     public CustomPropsMap() { }
 
     public CustomPropsMap(Map<String, Object> props) {
-        putAll(props);
+        customFields.putAll(props);
     }
 
     @Override
     public Object get(String key) {
         return customFields.get(key);
-    }
-
-    public void clear() {
-        customFields.clear();
     }
 
     public void put(String key, Object value) {
@@ -74,14 +70,6 @@ public class CustomPropsMap implements CustomProps {
         } else {
             customFields.put(key, value);
         }
-    }
-
-    public void putAll(CustomProps props) {
-        putAll(props.asMap());
-    }
-
-    public void putAll(Map<String, Object> props) {
-        customFields.putAll(props);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/FieldImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/FieldImpl.java
@@ -26,7 +26,7 @@ public abstract class FieldImpl implements Field, Freezable {
      * Doing so anyway will throw an exception.
      */
     @XmlTransient
-    private boolean frozen;
+    private FreezeStatus frozen = new FreezeStatus();
 
     // For JAXB deserialization
     @SuppressWarnings("unused")
@@ -137,13 +137,13 @@ public abstract class FieldImpl implements Field, Freezable {
     }
 
     @Override
-    public synchronized void freeze() {
-        this.frozen = true;
+    public boolean freeze() {
+        return frozen.freeze();
     }
 
     @Override
-    public synchronized boolean isFrozen() {
-        return this.frozen;
+    public boolean isFrozen() {
+        return frozen.isFrozen();
     }
 
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/Freezable.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/Freezable.java
@@ -6,8 +6,40 @@ package nl.inl.blacklab.search.indexmetadata;
  * A frozen object may not be modified.
  */
 public interface Freezable {
-    
-    void freeze();
+
+    /** Can be used as a delegate to easily implement Freezable */
+    class FreezeStatus implements Freezable {
+        boolean frozen;
+
+        public FreezeStatus() {
+            this(false);
+        }
+
+        public FreezeStatus(boolean frozen) {
+            this.frozen = frozen;
+        }
+
+        public synchronized boolean isFrozen() {
+            return frozen;
+        }
+
+        @Override
+        public synchronized boolean freeze() {
+            if (!frozen) {
+                // apply freeze now
+                frozen = true;
+                return true;
+            }
+            // was already frozen
+            return false;
+        }
+    }
+
+    /**
+     * Freeze if not already frozen
+     * @return true if freeze was applied, false if it was already frozen
+     */
+    boolean freeze();
     
     boolean isFrozen();
     

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataAbstract.java
@@ -136,7 +136,7 @@ public abstract class IndexMetadataAbstract implements IndexMetadataWriter {
     protected final AnnotatedFieldsImpl annotatedFields = new AnnotatedFieldsImpl();
 
     /** Is this instance frozen, that is, are all mutations disallowed? */
-    private boolean frozen;
+    private FreezeStatus frozen = new FreezeStatus();
 
     public IndexMetadataAbstract(BlackLabIndex index) {
         this.index = index;
@@ -1130,15 +1130,18 @@ public abstract class IndexMetadataAbstract implements IndexMetadataWriter {
     }
 
     @Override
-    public void freeze() {
-        this.frozen = true;
-        annotatedFields.freeze();
-        metadataFields.freeze();
+    public boolean freeze() {
+        boolean b = frozen.freeze();
+        if (b) {
+            annotatedFields.freeze();
+            metadataFields.freeze();
+        }
+        return b;
     }
 
     @Override
     public boolean isFrozen() {
-        return this.frozen;
+        return frozen.isFrozen();
     }
 
     protected void detectMainAnnotation(IndexReader reader) {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
@@ -61,7 +61,7 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
 
     /** Is the object frozen, not allowing any modifications? */
     @XmlTransient
-    private boolean frozen = false;
+    private FreezeStatus frozen = new FreezeStatus();
 
     /** If we try to get() a missing field, should we throw or return a default config?
      *  Should eventually be eliminated when we can enforce all metadatafields to be declared.
@@ -279,7 +279,7 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
     @Override
     public void setSpecialField(String specialFieldType, String fieldName) {
         ensureNotFrozen();
-        if (specialFieldType.equals("pid"))
+        if (specialFieldType.equals("pid")) // TODO: get rid of this special case?
             setPidField(fieldName);
         else
             topLevelCustom.put(specialFieldType + "Field", fieldName);
@@ -296,16 +296,19 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
     }
 
     @Override
-    public void freeze() {
-        this.frozen = true;
-        for (MetadataFieldImpl field: metadataFieldInfos.values()) {
-            field.freeze();
+    public boolean freeze() {
+        boolean b = frozen.freeze();
+        if (b) {
+            for (MetadataFieldImpl field: metadataFieldInfos.values()) {
+                field.freeze();
+            }
         }
+        return b;
     }
 
     @Override
-    public synchronized boolean isFrozen() {
-        return this.frozen;
+    public boolean isFrozen() {
+        return frozen.isFrozen();
     }
 
     @Override

--- a/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
+++ b/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
@@ -18,7 +18,7 @@ public class MockIndexMetadata implements IndexMetadata {
     
     private final List<AnnotatedField> fields;
     
-    private boolean frozen;
+    private FreezeStatus frozen = new FreezeStatus();
 
     public MockIndexMetadata() {
         List<Annotation> annot = Arrays.asList(new MockAnnotation("word"), new MockAnnotation("lemma"), new MockAnnotation("pos"));
@@ -138,13 +138,13 @@ public class MockIndexMetadata implements IndexMetadata {
     }
 
     @Override
-    public void freeze() {
-        this.frozen = true;
+    public boolean freeze() {
+        return frozen.freeze();
     }
 
     @Override
     public boolean isFrozen() {
-        return this.frozen;
+        return frozen.isFrozen();
     }
 
 }


### PR DESCRIPTION
- AnnotatedFieldsImpl implements Freezable
- FreezeStatus is a consistent way to implement Freezable, with synchronized methods for threadsafety
- Also freeze custom properties in metadata
- Skip metadata document in DocResults when querying all documents (`*:*` / MatchAllDocsQuery)