### PR TITLE
Fixes leak when writing the TOC file

### DIFF
--- a/content-store/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlock.java
+++ b/content-store/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlock.java
@@ -255,7 +255,7 @@ public abstract class ContentStoreFixedBlock extends ContentStoreDirAbstract {
         }
     }
 
-    protected abstract void mapToc(boolean writable) throws IOException;
+    protected abstract void mapToc(boolean writable, boolean growBuffer) throws IOException;
 
     /**
      * Read the table of contents from the file
@@ -263,7 +263,7 @@ public abstract class ContentStoreFixedBlock extends ContentStoreDirAbstract {
     protected synchronized void readToc() {
         toc.clear();
         try {
-            mapToc(false);
+            mapToc(false, false);
             try {
                 ((Buffer)tocFileBuffer).position(0);
                 int n = tocFileBuffer.getInt();

--- a/content-store/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
+++ b/content-store/src/main/java/nl/inl/blacklab/contentstore/ContentStoreFixedBlockReader.java
@@ -61,7 +61,7 @@ public class ContentStoreFixedBlockReader extends ContentStoreFixedBlock {
     }
 
     @Override
-    protected synchronized void mapToc(boolean writable) throws IOException {
+    protected synchronized void mapToc(boolean writable, boolean growBuffer) throws IOException {
         if (writable)
             throw new UnsupportedOperationException("writable == true, but not in index mode");
         tocRaf = new RandomAccessFile(tocFile, "r");


### PR DESCRIPTION
On sustained index close operations the buffer backing the `toc` file increments with no bounds, until the file can no longer be memory mapped

The following PR only increments the buffer when there is not enough room to serialize the toc.

Curious about your thoughts on this fix @jan-niestadt 