### PR TITLE
Fix metadataFieldGroups and annotationGroups not (de)serializing correctly anymore.

### DIFF
--- a/core/src/main/resources/formats/testformat.blf.yaml
+++ b/core/src/main/resources/formats/testformat.blf.yaml
@@ -76,3 +76,14 @@ corpusConfig:
           - title
     - name: Other fields group
       addRemainingFields: true
+
+  annotationGroups:
+      contents:
+        - name: Basic
+          annotations:
+            - word
+            - lemma
+        - name: Advanced
+          annotations:
+            - pos
+          addRemainingAnnotations: true

--- a/core/src/main/resources/formats/testformat.blf.yaml
+++ b/core/src/main/resources/formats/testformat.blf.yaml
@@ -68,3 +68,11 @@ metadata:
     valuePath: "@pid"
   - name: title
     valuePath: "@title"
+
+corpusConfig:
+  metadataFieldGroups:
+    - name: Title group
+      fields:
+          - title
+    - name: Other fields group
+      addRemainingFields: true

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -177,7 +177,7 @@ public class AnnotationWriter {
         boolean offsets = includeOffsets && isMainSensitivity;
 
         // Main sensitivity of main annotation may get content store
-        boolean contentStore = false; // @@@ WIP  isMainAnnotation && isMainSensitivity && field().hasContentStore();
+        boolean contentStore = false; // Content store has its own field, e.g. contents#cs
         return BLAnnotFieldTypes.get(offsets, hasForwardIndex, contentStore);
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldNameUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldNameUtil.java
@@ -51,39 +51,28 @@ public final class AnnotatedFieldNameUtil {
      * String used to separate the base field name (say, contents) and the field
      * annotation (pos, lemma, etc.)
      */
-    static final String ANNOT_SEP;
+    static final String ANNOT_SEP = "%";
 
     /**
      * String used to separate the field/annotation name (say, contents_lemma) and the
      * alternative (e.g. "s" for case-sensitive)
      */
-    static final String SENSITIVITY_SEP;
+    static final String SENSITIVITY_SEP = "@";
 
     /**
      * String used to separate the field/annotation name (say, contents_lemma) and the
      * alternative (e.g. "s" for case-sensitive)
      */
-    static final String BOOKKEEPING_SEP;
+    static final String BOOKKEEPING_SEP = "#";
 
     /** Length of SENSITIVITY_SEP */
-    static final int SENSITIVITY_SEP_LEN;
+    static final int SENSITIVITY_SEP_LEN = SENSITIVITY_SEP.length();
 
     /** Length of ANNOT_SEP */
-    static final int ANNOT_SEP_LEN;
+    static final int ANNOT_SEP_LEN = ANNOT_SEP.length();
 
     /** Length of BOOKKEEPING_SEP */
-    static final int BOOKKEEPING_SEP_LEN;
-
-    static {
-        // Lucene doesn't have any restrictions on characters in field names;
-        // use the short, symbolic ones.
-        ANNOT_SEP = "%";
-        SENSITIVITY_SEP = "@";
-        BOOKKEEPING_SEP = "#";
-        SENSITIVITY_SEP_LEN = SENSITIVITY_SEP.length();
-        ANNOT_SEP_LEN = ANNOT_SEP.length();
-        BOOKKEEPING_SEP_LEN = BOOKKEEPING_SEP.length();
-    }
+    static final int BOOKKEEPING_SEP_LEN = BOOKKEEPING_SEP.length();
 
     /**
      * What are the names of the bookkeeping subfields (i.e. content id, forward

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationGroup.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationGroup.java
@@ -3,7 +3,9 @@ package nl.inl.blacklab.search.indexmetadata;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -52,6 +54,21 @@ public class AnnotationGroup implements Iterable<String> {
 
     public Stream<String> stream() {
         return annotations.stream();
+    }
+
+    public Map<String, Object> toCustom() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("groupName", groupName);
+        result.put("annotations", annotations);
+        result.put("addRemainingAnnotations", addRemainingAnnotations);
+        return result;
+    }
+
+    public static AnnotationGroup fromCustom(String fieldName, Map<String, Object> serialized) {
+        String groupName = (String)serialized.getOrDefault("groupName", "UNKNOWN");
+        List<String> annotations = (List<String>)serialized.getOrDefault("annotations", Collections.emptyList());
+        boolean addRemainingAnnotations = (Boolean)serialized.getOrDefault("addRemainingAnnotations", false);
+        return new AnnotationGroup(fieldName, groupName, annotations, addRemainingAnnotations);
     }
 
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationGroups.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotationGroups.java
@@ -3,13 +3,11 @@ package nl.inl.blacklab.search.indexmetadata;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-
 /** Groups of annotations for a single field */
-@XmlAccessorType(XmlAccessType.FIELD)
 public class AnnotationGroups implements Iterable<AnnotationGroup> {
     
     private final String fieldName;
@@ -41,5 +39,17 @@ public class AnnotationGroups implements Iterable<AnnotationGroup> {
     public AnnotationGroup get(String name) {
         return groups.stream().filter(g -> g.groupName().equals(name)).findFirst().orElse(null);
     }
-    
+
+    public List<Map<String, Object>> toCustom() {
+        return groups.stream()
+                .map(AnnotationGroup::toCustom)
+                .collect(Collectors.toList());
+    }
+
+    public static AnnotationGroups fromCustom(String fieldName, List<Map<String, Object>> serialized) {
+        List<AnnotationGroup> groups = serialized.stream()
+                .map(g -> AnnotationGroup.fromCustom(fieldName, g))
+                .collect(Collectors.toList());
+        return new AnnotationGroups(fieldName, groups);
+    }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomProps.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomProps.java
@@ -2,6 +2,7 @@ package nl.inl.blacklab.search.indexmetadata;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Interface for getting custom metadata properties (not used by BlackLab itself)

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomPropsMap.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/CustomPropsMap.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -75,5 +76,14 @@ public class CustomPropsMap implements CustomProps {
     @Override
     public Map<String, Object> asMap() {
         return Collections.unmodifiableMap(customFields);
+    }
+
+    <T> T computeIfAbsent(String key, Function<String, T> mappingFunction) {
+        T value = (T)get(key);
+        if (value == null) {
+            value = mappingFunction.apply(key);
+            put(key, value);
+        }
+        return value;
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataIntegrated.java
@@ -374,7 +374,6 @@ public class IndexMetadataIntegrated implements IndexMetadataWriter {
                     g.isAddRemainingFields());
             groups.put(group.name(), group);
         }
-        custom.put("metadataFieldGroups", groups); // @@@custom
         metadataFields.setMetadataGroups(groups);
 
         // Annotation groups
@@ -407,7 +406,7 @@ public class IndexMetadataIntegrated implements IndexMetadataWriter {
         versionInfo.populateWithDefaults();
         metadataFields.clearSpecialFields();
         custom.put("annotationGroups", new LinkedHashMap<>());
-        custom.put("metadataFieldGroups", new LinkedHashMap<>()); // @@@custom
+        custom.put("metadataFieldGroups", new LinkedHashMap<>());
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataIntegrated.java
@@ -374,7 +374,7 @@ public class IndexMetadataIntegrated implements IndexMetadataWriter {
                     g.isAddRemainingFields());
             groups.put(group.name(), group);
         }
-        custom.put("metadataFieldGroups", groups);
+        custom.put("metadataFieldGroups", groups); // @@@custom
         metadataFields.setMetadataGroups(groups);
 
         // Annotation groups
@@ -407,7 +407,7 @@ public class IndexMetadataIntegrated implements IndexMetadataWriter {
         versionInfo.populateWithDefaults();
         metadataFields.clearSpecialFields();
         custom.put("annotationGroups", new LinkedHashMap<>());
-        custom.put("metadataFieldGroups", new LinkedHashMap<>());
+        custom.put("metadataFieldGroups", new LinkedHashMap<>()); // @@@custom
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroup.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroup.java
@@ -1,5 +1,6 @@
 package nl.inl.blacklab.search.indexmetadata;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroupImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroupImpl.java
@@ -1,8 +1,11 @@
 package nl.inl.blacklab.search.indexmetadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -52,5 +55,21 @@ public class MetadataFieldGroupImpl implements MetadataFieldGroup {
     @Override
     public Stream<String> stream() {
         return fieldNamesInGroup.stream();
+    }
+
+    public Map<String, Object> toCustom() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("name", name);
+        result.put("fieldNamesInGroup", fieldNamesInGroup);
+        result.put("addRemainingFields", addRemainingFields);
+        return result;
+    }
+
+    public static MetadataFieldGroupImpl fromCustom(Map<String, Object> customStruct) {
+        String name = (String)customStruct.getOrDefault("name", "UNKNOWN");
+        List<String> fieldNames = (List<String>)customStruct.getOrDefault("fieldNames",
+                Collections.emptyList());
+        boolean addRemainingFields = (Boolean)customStruct.getOrDefault("addRemainingFields", false);
+        return new MetadataFieldGroupImpl(name, fieldNames, addRemainingFields);
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroupImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldGroupImpl.java
@@ -67,7 +67,7 @@ public class MetadataFieldGroupImpl implements MetadataFieldGroup {
 
     public static MetadataFieldGroupImpl fromCustom(Map<String, Object> customStruct) {
         String name = (String)customStruct.getOrDefault("name", "UNKNOWN");
-        List<String> fieldNames = (List<String>)customStruct.getOrDefault("fieldNames",
+        List<String> fieldNames = (List<String>)customStruct.getOrDefault("fieldNamesInGroup",
                 Collections.emptyList());
         boolean addRemainingFields = (Boolean)customStruct.getOrDefault("addRemainingFields", false);
         return new MetadataFieldGroupImpl(name, fieldNames, addRemainingFields);

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
@@ -1,12 +1,12 @@
 package nl.inl.blacklab.search.indexmetadata;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -163,14 +163,12 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
 
     @Override
     public Map<String, ? extends MetadataFieldGroup> groups() {
-
-        //@@@@@@@@@@@@@@@@@
         List<Map<String, Object>> metadataFieldGroups = (List<Map<String, Object>>)topLevelCustom
-                .get("metadataFieldGroups", Collections.emptyMap());
-        Map<String, ? extends MetadataFieldGroup> result = metadataFieldGroups.stream()
+                .get("metadataFieldGroups", new ArrayList<Map<String, Object>>());
+        Map<String, MetadataFieldGroupImpl> result = metadataFieldGroups.stream()
                 .map( MetadataFieldGroupImpl::fromCustom)
-                .collect(Collectors.toMap());
-        //return Collections.unmodifiableMap(metadataFieldGroups);
+                .collect(Collectors.toMap(MetadataFieldGroupImpl::name, Function.identity()));
+        return result;
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -162,9 +163,14 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
 
     @Override
     public Map<String, ? extends MetadataFieldGroup> groups() {
-        Map<String, MetadataFieldGroup> metadataFieldGroups = topLevelCustom.get("metadataFieldGroups",
-                Collections.emptyMap());
-        return Collections.unmodifiableMap(metadataFieldGroups);
+
+        //@@@@@@@@@@@@@@@@@
+        List<Map<String, Object>> metadataFieldGroups = (List<Map<String, Object>>)topLevelCustom
+                .get("metadataFieldGroups", Collections.emptyMap());
+        Map<String, ? extends MetadataFieldGroup> result = metadataFieldGroups.stream()
+                .map( MetadataFieldGroupImpl::fromCustom)
+                .collect(Collectors.toMap());
+        //return Collections.unmodifiableMap(metadataFieldGroups);
     }
 
     @Override
@@ -237,7 +243,10 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
     public void setMetadataGroups(Map<String, MetadataFieldGroupImpl> metadataGroups) {
         if (!groups().equals(metadataGroups)) {
             ensureNotFrozen();
-            topLevelCustom.put("metadataFieldGroups", metadataGroups); // @@@custom
+            List<Map<String, Object>> metaGroupsCustom = metadataGroups.entrySet().stream()
+                    .map( e -> e.getValue().toCustom())
+                    .collect(Collectors.toList());
+            topLevelCustom.put("metadataFieldGroups", metaGroupsCustom);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
@@ -237,7 +237,7 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
     public void setMetadataGroups(Map<String, MetadataFieldGroupImpl> metadataGroups) {
         if (!groups().equals(metadataGroups)) {
             ensureNotFrozen();
-            topLevelCustom.put("metadataFieldGroups", metadataGroups);
+            topLevelCustom.put("metadataFieldGroups", metadataGroups); // @@@custom
         }
     }
 

--- a/engine/src/main/java/nl/inl/util/SearchTimer.java
+++ b/engine/src/main/java/nl/inl/util/SearchTimer.java
@@ -48,7 +48,7 @@ public class SearchTimer {
      */
     public void start() {
         if (timerRunning)
-            logger.debug("@@@@@ Timer.start: timer already running!");
+            logger.debug("### Timer.start: timer already running!");
         startTime = System.currentTimeMillis();
         timerRunning = true;
     }
@@ -61,7 +61,7 @@ public class SearchTimer {
             processingTime += System.currentTimeMillis() - startTime;
             timerRunning = false;
         } else {
-            logger.debug("@@@@@ Timer.stop: timer wasn't running!");
+            logger.debug("### Timer.stop: timer wasn't running!");
         }
     }
 
@@ -70,7 +70,7 @@ public class SearchTimer {
      */
     public void add(long ms) {
         if (timerRunning)
-            logger.debug("@@@@@ Timer.add: timer should not be running!");
+            logger.debug("### Timer.add: timer should not be running!");
         processingTime += ms;
     }
 }

--- a/test/data/saved-responses/docs/document metadata.json
+++ b/test/data/saved-responses/docs/document metadata.json
@@ -13,7 +13,21 @@
     "lengthInTokens": 334,
     "mayView": true
   },
-  "metadataFieldGroups": [],
+  "metadataFieldGroups": [
+    {
+      "name": "Other fields group",
+      "fields": [
+        "fromInputFile",
+        "pid"
+      ]
+    },
+    {
+      "name": "Title group",
+      "fields": [
+        "title"
+      ]
+    }
+  ],
   "docFields": {
     "pidField": "pid",
     "titleField": "title"

--- a/test/data/saved-responses/indices/expected-index-metadata.json
+++ b/test/data/saved-responses/indices/expected-index-metadata.json
@@ -136,6 +136,37 @@
       "valueListComplete": true
     }
   },
-  "metadataFieldGroups": [],
-  "annotationGroups": {}
+  "metadataFieldGroups": [
+    {
+      "fields": [
+        "fromInputFile",
+        "pid"
+      ],
+      "name": "Other fields group"
+    },
+    {
+      "fields": [
+        "title"
+      ],
+      "name": "Title group"
+    }
+  ],
+
+  "annotationGroups": {
+    "contents": [
+      {
+        "annotations": [
+          "word",
+          "lemma"
+        ],
+        "name": "Basic"
+      },
+      {
+        "annotations": [
+          "pos"
+        ],
+        "name": "Advanced"
+      }
+    ]
+  }
 }

--- a/test/data/saved-responses/info/corpus.json
+++ b/test/data/saved-responses/info/corpus.json
@@ -142,6 +142,36 @@
       "valueListComplete": true
     }
   },
-  "metadataFieldGroups": [],
-  "annotationGroups": {}
+  "metadataFieldGroups": [
+    {
+      "name": "Other fields group",
+      "fields": [
+        "fromInputFile",
+        "pid"
+      ]
+    },
+    {
+      "name": "Title group",
+      "fields": [
+        "title"
+      ]
+    }
+  ],
+  "annotationGroups": {
+    "contents": [
+      {
+        "name": "Basic",
+        "annotations": [
+          "word",
+          "lemma"
+        ]
+      },
+      {
+        "name": "Advanced",
+        "annotations": [
+          "pos"
+        ]
+      }
+    ]
+  }
 }

--- a/test/data/voice-tei.blf.yaml
+++ b/test/data/voice-tei.blf.yaml
@@ -75,6 +75,25 @@ corpusConfig:
   # Allow us to retrieve document content
   contentViewable: true
 
+  metadataFieldGroups:
+    - name: Title group
+      fields:
+        - title
+    - name: Other fields group
+      addRemainingFields: true
+
+  annotationGroups:
+    contents:
+      - name: Basic
+        annotations:
+          - word
+          - lemma
+      - name: Advanced
+        annotations:
+          - pos
+        addRemainingAnnotations: true
+
+
 # FoLiA's native metadata
 metadata:
   containerPath: .


### PR DESCRIPTION
Because these are now considered custom properties, the way the are (de)serialized changed, and there were no proper tests for them. This should fix that.