### PR TITLE
Abstract how BlacklabIndex and IndexReader relate (Solr)

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLab.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLab.java
@@ -236,8 +236,8 @@ public final class BlackLab {
      * @param reader index reader that was opened using BlackLab
      * @return BlackLab index object
      */
-    public static synchronized BlackLabIndex indexFromReader(IndexReader reader) {
-        return BlackLabEngine.indexFromReader(reader);
+    public static synchronized BlackLabIndex indexFromReader(IndexReader reader, boolean wrapIfNotFound) {
+        return BlackLabEngine.indexFromReader(reader, wrapIfNotFound);
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
@@ -217,6 +217,7 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
                 indexMetadata.freeze();
 
             finishOpeningIndex(indexDir, indexMode, createNewIndex);
+
         } catch (IndexFormatTooNewException|IndexFormatTooOldException e) {
             throw new IndexVersionMismatch(e);
         } catch (IOException e) {
@@ -242,14 +243,19 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
         if (indexMode) {
             if (traceIndexOpening())
                 logger.debug("  Opening IndexWriter...");
-            indexWriter = openIndexWriter(indexLocation, createNewIndex, null);
+            IndexWriter luceneIndexWriter = openIndexWriter(indexLocation, createNewIndex, null);
+            indexWriter = indexObjectFactory().indexWriterProxy(luceneIndexWriter);
             if (traceIndexOpening())
                 logger.debug("  Opening corresponding IndexReader...");
-            reader = DirectoryReader.open(indexWriter, false, false);
+            reader = DirectoryReader.open(luceneIndexWriter, false, false);
         } else {
             reader = openIndexForReading(indexLocation, traceIndexOpening());
         }
         shouldCloseIndex = true; // we're opening the IndexReader, so we're responsible for closing it.
+    }
+
+    public BLIndexObjectFactory indexObjectFactory() {
+        return blackLab.indexObjectFactory();
     }
 
     protected abstract IndexMetadataWriter getIndexMetadata(boolean createNewIndex, ConfigInputFormat config)

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
@@ -156,6 +156,7 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
     /** Was this index closed? */
     private boolean closed;
 
+
     // Constructors
     //---------------------------------------------------------------
 
@@ -223,10 +224,6 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
         } catch (IOException e) {
             throw new ErrorOpeningIndex("Could not open index: " + indexDir, e);
         }
-    }
-
-    public BLIndexObjectFactory indexObjectFactory() {
-        return blackLab.indexObjectFactory();
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
@@ -237,13 +237,17 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
      */
     private void openIndex(boolean createNewIndex) throws IOException, IndexVersionMismatch {
         checkCanOpenIndex(indexMode, createNewIndex);
+        if (traceIndexOpening())
+            logger.debug("Constructing BlackLabIndex...");
         if (indexMode) {
-            indexWriter = openIndexWriter(indexLocation, createNewIndex, traceIndexOpening());
+            if (traceIndexOpening())
+                logger.debug("  Opening IndexWriter...");
+            indexWriter = openIndexWriter(indexLocation, createNewIndex, null);
             if (traceIndexOpening())
                 logger.debug("  Opening corresponding IndexReader...");
             reader = DirectoryReader.open(indexWriter, false, false);
         } else {
-            reader = openIndexForReaading(indexLocation, traceIndexOpening());
+            reader = openIndexForReading(indexLocation, traceIndexOpening());
         }
         shouldCloseIndex = true; // we're opening the IndexReader, so we're responsible for closing it.
     }
@@ -413,9 +417,7 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
         // subclass can override this
     }
 
-    private static DirectoryReader openIndexForReaading(File indexLocation, boolean trace) throws IOException, IndexVersionMismatch {
-        if (trace)
-            logger.debug("Constructing BlackLabIndex...");
+    private static DirectoryReader openIndexForReading(File indexLocation, boolean trace) throws IOException, IndexVersionMismatch {
         // Open Lucene index
         if (trace)
             logger.debug("  Following symlinks...");
@@ -433,14 +435,6 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter {
                 throw new IndexVersionMismatch("Error opening index, Codec not available; wrong BlackLab version?", e);
             throw e;
         }
-    }
-
-    private IndexWriter openIndexWriter(File indexLocation, boolean createNewIndex, boolean trace) throws IOException {
-        if (trace)
-            logger.debug("Constructing BlackLabIndex...");
-        if (trace)
-            logger.debug("  Opening IndexWriter...");
-        return openIndexWriter(indexLocation, createNewIndex, null);
     }
 
     protected void finishOpeningIndex(File indexDir, boolean indexMode, boolean createNewIndex)

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
@@ -43,12 +43,12 @@ public class BlackLabIndexExternal extends BlackLabIndexAbstract {
 
     BlackLabIndexExternal(BlackLabEngine blackLab, File indexDir, boolean indexMode, boolean createNewIndex,
             ConfigInputFormat config) throws ErrorOpeningIndex {
-        super(blackLab, indexDir, indexMode, createNewIndex, config);
+        super(blackLab, null, indexDir, indexMode, createNewIndex, config, null);
     }
 
     BlackLabIndexExternal(BlackLabEngine blackLab, File indexDir, boolean indexMode, boolean createNewIndex,
             File indexTemplateFile) throws ErrorOpeningIndex {
-        super(blackLab, indexDir, indexMode, createNewIndex, indexTemplateFile);
+        super(blackLab, null, indexDir, indexMode, createNewIndex, null, indexTemplateFile);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexIntegrated.java
@@ -118,24 +118,10 @@ public class BlackLabIndexIntegrated extends BlackLabIndexAbstract {
     /** A list of stored fields that doesn't include content store fields. */
     private Set<String> allExceptContentStoreFields;
 
-    BlackLabIndexIntegrated(BlackLabEngine blackLab, File indexDir, boolean indexMode, boolean createNewIndex,
+    BlackLabIndexIntegrated(BlackLabEngine blackLab, IndexReader reader, File indexDir, boolean indexMode, boolean createNewIndex,
             ConfigInputFormat config) throws ErrorOpeningIndex {
-        super(blackLab, indexDir, indexMode, createNewIndex, config);
-        init();
-    }
+        super(blackLab, reader, indexDir, indexMode, createNewIndex, config, null);
 
-    BlackLabIndexIntegrated(BlackLabEngine blackLab, File indexDir, boolean indexMode, boolean createNewIndex,
-            File indexTemplateFile) throws ErrorOpeningIndex {
-        super(blackLab, indexDir, indexMode, createNewIndex, indexTemplateFile);
-        init();
-    }
-
-    public BlackLabIndexIntegrated(BlackLabEngine engine, IndexReader reader) throws ErrorOpeningIndex {
-        super(engine, reader);
-        init();
-    }
-
-    private void init() {
         // Determine the list of all fields in the index, but skip fields that
         // represent a content store as they contain very large values (i.e. the
         // whole input document) we don't generally want returned when requesting
@@ -156,12 +142,9 @@ public class BlackLabIndexIntegrated extends BlackLabIndexAbstract {
     }
 
     protected IndexMetadataWriter getIndexMetadata(boolean createNewIndex, File indexTemplateFile) {
-        if (!createNewIndex)
-            return IndexMetadataIntegrated.deserializeFromJsonJaxb(this);
         if (indexTemplateFile != null)
-            throw new UnsupportedOperationException(
-                    "Template file not supported for integrated index format! Please see the IndexTool documentation for how use the classic index format.");
-        return IndexMetadataIntegrated.create(this, null);
+            throw new IllegalArgumentException("Template file not supported for integrated index format! Please see the IndexTool documentation for how use the classic index format.");
+        return getIndexMetadata(createNewIndex, (ConfigInputFormat)null);
     }
 
     public ForwardIndex createForwardIndex(AnnotatedField field) {

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexIntegrated.java
@@ -10,6 +10,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanClause;
@@ -126,6 +127,11 @@ public class BlackLabIndexIntegrated extends BlackLabIndexAbstract {
     BlackLabIndexIntegrated(BlackLabEngine blackLab, File indexDir, boolean indexMode, boolean createNewIndex,
             File indexTemplateFile) throws ErrorOpeningIndex {
         super(blackLab, indexDir, indexMode, createNewIndex, indexTemplateFile);
+        init();
+    }
+
+    public BlackLabIndexIntegrated(BlackLabEngine engine, IndexReader reader) throws ErrorOpeningIndex {
+        super(engine, reader);
         init();
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQuerySequence.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQuerySequence.java
@@ -280,7 +280,7 @@ public class SpanQuerySequence extends BLSpanQueryAbstract {
     @Override
     public BLSpanQuery optimize(IndexReader reader) throws IOException {
         super.optimize(reader);
-        BlackLabIndex index = BlackLab.indexFromReader(reader);
+        BlackLabIndex index = BlackLab.indexFromReader(reader, true);
         boolean canDoNfaMatching = false;
         if (index instanceof BlackLabIndexAbstract) {
             canDoNfaMatching = ((BlackLabIndexAbstract)index).canDoNfaMatching();
@@ -323,7 +323,7 @@ public class SpanQuerySequence extends BLSpanQueryAbstract {
 
     @Override
     public BLSpanQuery rewrite(IndexReader reader) throws IOException {
-        BlackLabIndex index = BlackLab.indexFromReader(reader);
+        BlackLabIndex index = BlackLab.indexFromReader(reader, true);
         boolean canDoNfaMatching = false;
         if (index instanceof BlackLabIndexAbstract) {
             canDoNfaMatching = ((BlackLabIndexAbstract)index).canDoNfaMatching();

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/optimize/ClauseCombinerNfa.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/optimize/ClauseCombinerNfa.java
@@ -257,7 +257,7 @@ public class ClauseCombinerNfa extends ClauseCombiner {
                 return ((SpanQueryFiSeq) left).appendNfa(right);
             }
             // New FISEQ.
-            ForwardIndexAccessor fiAccessor = BlackLab.indexFromReader(reader).forwardIndexAccessor(right.getField());
+            ForwardIndexAccessor fiAccessor = BlackLab.indexFromReader(reader, true).forwardIndexAccessor(right.getField());
             NfaTwoWay nfaTwoWay = right.getNfaTwoWay(fiAccessor, SpanQueryFiSeq.DIR_TO_RIGHT);
             return new SpanQueryFiSeq(left, SpanQueryFiSeq.END_OF_ANCHOR, nfaTwoWay, right, SpanQueryFiSeq.DIR_TO_RIGHT, fiAccessor);
         }
@@ -268,7 +268,7 @@ public class ClauseCombinerNfa extends ClauseCombiner {
             return ((SpanQueryFiSeq) right).appendNfa(left);
         }
         // New FISEQ.
-        ForwardIndexAccessor fiAccessor = BlackLab.indexFromReader(reader).forwardIndexAccessor(left.getField());
+        ForwardIndexAccessor fiAccessor = BlackLab.indexFromReader(reader, true).forwardIndexAccessor(left.getField());
         NfaTwoWay nfaTwoWay = left.getNfaTwoWay(fiAccessor, SpanQueryFiSeq.DIR_TO_LEFT);
         return new SpanQueryFiSeq(right, SpanQueryFiSeq.START_OF_ANCHOR, nfaTwoWay, left, SpanQueryFiSeq.DIR_TO_LEFT, fiAccessor);
 


### PR DESCRIPTION
BlackLabIndex used to be in charge of opening IndexReader, but this doesn't work with Solr, which manages its own IndexReaders. This allows us to instantiate a BlackLabIndex from an IndexReader instance when needed (and when none exists yet).

A future challenge is how to finalize BlackLabIndex (Solr doesn't tell us when it opens or closes IndexReaders). In the long term, the goal is for BlackLabIndex to no longer hold resources (such as global term ids) but to only keep that kind of state in the per-segment codec classes.