### PR TITLE
DocIndexerExample: an example of low-level custom indexing

### DIFF
--- a/core/src/test/java/nl/inl/blacklab/IndexAndTestExample.java
+++ b/core/src/test/java/nl/inl/blacklab/IndexAndTestExample.java
@@ -28,7 +28,7 @@ import nl.inl.util.FileUtil;
 /**
  * Simple test program to demonstrate index & search functionality.
  */
-public class Example {
+public class IndexAndTestExample {
 
     /**
      * The BlackLab index object.

--- a/core/src/test/java/nl/inl/blacklab/search/TestIndexFormats.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestIndexFormats.java
@@ -24,6 +24,7 @@ import nl.inl.blacklab.forwardindex.AnnotationForwardIndex;
 import nl.inl.blacklab.forwardindex.Terms;
 import nl.inl.blacklab.index.annotated.AnnotationSensitivities;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.blacklab.search.indexmetadata.FieldType;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
@@ -190,7 +191,8 @@ public class TestIndexFormats {
         AnnotatedField field = index.metadata().annotatedFields().get("contents");
         Assert.assertTrue(field.hasXmlTags());
         Assert.assertTrue(field.hasContentStore());
-        Set<String> expectedAnnotations = new HashSet<>(Arrays.asList("word", "lemma", "pos", "starttag", "punct"));
+        Set<String> expectedAnnotations = new HashSet<>(Arrays.asList("word", "lemma", "pos",
+                AnnotatedFieldNameUtil.TAGS_ANNOT_NAME, AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME));
         Set<String> actualAnnotations = field.annotations().stream().map(Annotation::name).collect(Collectors.toSet());
         Assert.assertEquals(expectedAnnotations, actualAnnotations);
         Assert.assertEquals("word", field.mainAnnotation().name());

--- a/core/src/test/java/nl/inl/blacklab/search/TestKwic.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestKwic.java
@@ -10,11 +10,12 @@ import org.junit.Test;
 import nl.inl.blacklab.mocks.MockAnnotatedField;
 import nl.inl.blacklab.mocks.MockAnnotation;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
 
 public class TestKwic {
 
-    static final List<String> PROPS = Arrays.asList("punct", "lemma", "pos", "word");
+    static final List<String> PROPS = Arrays.asList(AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME, "lemma", "pos", "word");
     
     static final List<Annotation> ANNOTS = PROPS.stream().map(MockAnnotation::new).collect(Collectors.toList());
     

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -169,7 +169,7 @@ public class TestIndex {
 
     public static final int[] DOC_LENGTHS_TOKENS = { 9, 12, 6, 10 };
 
-    final static String testFormat = "testformat";
+    final static String TEST_FORMAT_NAME = "testformat";
 
     /**
      * The BlackLab index object.
@@ -201,7 +201,7 @@ public class TestIndex {
 
         // Instantiate the BlackLab indexer, supplying our DocIndexer class
         try {
-            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true, testFormat, null, indexType);
+            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true, TEST_FORMAT_NAME, null, indexType);
             Indexer indexer = Indexer.get(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {

--- a/engine/src/main/java/nl/inl/blacklab/analysis/PayloadUtils.java
+++ b/engine/src/main/java/nl/inl/blacklab/analysis/PayloadUtils.java
@@ -1,9 +1,20 @@
 package nl.inl.blacklab.analysis;
 
+import java.nio.ByteBuffer;
+
 import org.apache.lucene.util.BytesRef;
 
 /**
  * Utilities for dealing with payloads in BlackLab.
+ *
+ * Specifically:
+ * <ul>
+ * <li>a payload is stored in the "starttag" annotation to indicate the end position
+ * of a span</li>
+ * <li>while indexing, payloads are used to distinguish between "primary values" (that are
+ * recorded in the forward index) and "secondary values" (that are not). These indicators will stripped
+ * before writing to the Lucene index, however, leaving the original payload.</li>
+ * </ul>
  */
 public class PayloadUtils {
 
@@ -155,5 +166,21 @@ public class PayloadUtils {
             System.arraycopy(bytesRef.bytes, bytesRef.offset, bytes, 0, bytesRef.length);
         }
         return bytes;
+    }
+
+    /**
+     * Get the payload to store with the span start tag.
+     *
+     * Spans are stored in the "starttag" annotation, at the token position of the start tag.
+     * The payload gives the token position of the end tag.
+     *
+     * @param endPosition end position (exclusive), or the first token after the span
+     * @param isPrimaryValue if true, resulting payload will indicate if that this is a primary value. Pass false if
+     *                       this is not a primary value, or if primary value status should not be recorded in the
+     *                       payload (i.e. because there is no forward index)
+     * @return payload to store
+     */
+    public static BytesRef tagEndPositionPayload(int endPosition) {
+        return new BytesRef(ByteBuffer.allocate(4).putInt(endPosition).array());
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexerPlainTextBasic.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexerPlainTextBasic.java
@@ -49,7 +49,8 @@ public class DocIndexerPlainTextBasic extends DocIndexerLegacy {
                 needsPrimaryValuePayloads);
         annotMain = contentsField.mainAnnotation();
         String propName = AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME;
-        annotPunct = contentsField.addAnnotation(null, propName, getSensitivitySetting(propName), false);
+        annotPunct = contentsField.addAnnotation(propName, getSensitivitySetting(propName),
+                false, false);
         IndexMetadataWriter indexMetadata = indexer.indexWriter().metadata();
         indexMetadata.registerAnnotatedField(contentsField);
     }
@@ -105,7 +106,7 @@ public class DocIndexerPlainTextBasic extends DocIndexerLegacy {
     }
 
     public AnnotationWriter addAnnotation(String propName, AnnotationSensitivities sensitivity) {
-        return contentsField.addAnnotation(null, propName, sensitivity);
+        return contentsField.addAnnotation(propName, sensitivity, false);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
@@ -378,11 +378,12 @@ public abstract class DocIndexerXmlHandlers extends DocIndexerLegacy {
 
     @SuppressWarnings("deprecation")
     protected AnnotationWriter addAnnotation(String propName, boolean includePayloads) {
-        return contentsField.addAnnotation(null, propName, getSensitivitySetting(propName), includePayloads);
+        return contentsField.addAnnotation(propName, getSensitivitySetting(propName), includePayloads,
+                false);
     }
 
     public AnnotationWriter addAnnotation(String propName, AnnotationSensitivities sensitivity) {
-        return contentsField.addAnnotation(null, propName, sensitivity);
+        return contentsField.addAnnotation(propName, sensitivity, false);
     }
 
     public DocIndexerXmlHandlers(DocWriter docWriter, String fileName, Reader reader) {

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotatedFieldWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotatedFieldWriter.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 
 import nl.inl.blacklab.index.BLInputDocument;
-import nl.inl.blacklab.indexers.config.ConfigAnnotation;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldImpl;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
@@ -64,7 +63,10 @@ public class AnnotatedFieldWriter {
     }
 
     /**
-     * Construct a AnnotatedFieldWriter object with a main annotation
+     * Construct a AnnotatedFieldWriter object with a main annotation.
+     *
+     * NOTE: right now, the main annotation will always have a forward index.
+     * Maybe make this configurable?
      *
      * @param name field name
      * @param mainAnnotationName main annotation name (e.g. "word")
@@ -93,21 +95,22 @@ public class AnnotatedFieldWriter {
         return start.size();
     }
 
-    public AnnotationWriter addAnnotation(ConfigAnnotation annot, String name, AnnotationSensitivities sensitivity, boolean includePayloads) {
+    public AnnotationWriter addAnnotation(String name, AnnotationSensitivities sensitivity, boolean includePayloads,
+            boolean createForwardIndex) {
         if (!AnnotatedFieldNameUtil.isValidXmlElementName(name))
             logger.warn("Annotation name '" + name
                     + "' is discouraged (field/annotation names should be valid XML element names)");
         AnnotationWriter p = new AnnotationWriter(this, name, sensitivity, false, includePayloads,
                 needsPrimaryValuePayloads);
-        if (noForwardIndexAnnotations.contains(name) || annot != null && !annot.createForwardIndex()) {
+        if (noForwardIndexAnnotations.contains(name) || !createForwardIndex) {
             p.setHasForwardIndex(false);
         }
         annotations.put(name, p);
         return p;
     }
 
-    public AnnotationWriter addAnnotation(ConfigAnnotation annot, String name, AnnotationSensitivities sensitivity) {
-        return addAnnotation(annot, name, sensitivity, false);
+    public AnnotationWriter addAnnotation(String name, AnnotationSensitivities sensitivity, boolean createForwardIndex) {
+        return addAnnotation(name, sensitivity, false, createForwardIndex);
     }
 
     public void addStartChar(int startChar) {

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -218,9 +218,10 @@ public class AnnotationWriter {
      * Add a value to the annotation.
      *
      * @param value value to add
+     * @return position of the token added
      */
-    final public void addValue(String value) {
-        addValue(value, 1);
+    final public int addValue(String value) {
+        return addValue(value, 1, null);
     }
 
     /**
@@ -228,35 +229,22 @@ public class AnnotationWriter {
      *
      * @param value the value to add
      * @param increment number of tokens distance from the last token added
+     * @return position of the token added
      */
-    public void addValue(String value, int increment) {
-        if (value.length() > MAXIMUM_VALUE_LENGTH) {
-            // Let's keep a sane maximum value length.
-            // (Lucene's is 32766, but we don't want to go that far)
-            value = value.substring(0, MAXIMUM_VALUE_LENGTH);
-        }
+    public int addValue(String value, int increment) {
+        return addValue(value, increment, null);
+    }
 
-        // Make sure we don't keep duplicates of strings in memory, but re-use earlier instances.
-        value = value.intern();
-
-        // Special case: if previous value was the empty string and position increment is 0,
-        // replace the previous value. This is convenient to keep all the annotations synched
-        // up while indexing (by adding an empty string if we don't have a value for a
-        // annotation), while still being able to add a value to this position later (for example,
-        // when we encounter an XML close tag.
-        int lastIndex = values.size() - 1;
-        if (lastIndex >= 0 && values.get(lastIndex).length() == 0) {
-            // Change the last value and its position increment
-            values.set(lastIndex, value);
-            if (increment > 0)
-                increments.set(lastIndex, increments.get(lastIndex) + increment);
-            lastValuePosition += increment; // keep track of position of last token
-            return;
-        }
-
-        values.add(value);
-        increments.add(increment);
-        lastValuePosition += increment; // keep track of position of last token
+    /**
+     * Add a value to the annotation.
+     *
+     * @param value the value to add
+     * @param increment number of tokens distance from the last token added
+     * @param payload payload to store (or null if none)
+     * @return position of the token added
+     */
+    public int addValue(String value, int increment, BytesRef payload) {
+        return addValueAtPosition(value, lastValuePosition + increment, payload);
     }
 
     /**
@@ -269,9 +257,10 @@ public class AnnotationWriter {
      *
      * @param value the value to add
      * @param position the position to put it at
+     * @param payload payload (or null if none)
      * @return new position of the last token, in case it changed.
      */
-    public int addValueAtPosition(String value, int position) {
+    public int addValueAtPosition(String value, int position, BytesRef payload) {
         if (value.length() > MAXIMUM_VALUE_LENGTH) {
             // Let's keep a sane maximum value length.
             // (Lucene's is 32766, but we don't want to go that far)
@@ -282,8 +271,31 @@ public class AnnotationWriter {
         value = value.intern();
 
         if (position >= lastValuePosition) {
-            // Beyond the last position; regular addValue()
-            addValue(value, position - lastValuePosition);
+            // Beyond the last position; just add at the end.
+            int increment = position - lastValuePosition;
+
+            // Special case: if previous value was the empty string, there was no payload and position increment is 0,
+            // replace the previous value. This is convenient to keep all the annotations synched
+            // up while indexing (by adding an empty string if we don't have a value for a
+            // annotation), while still being able to add a value to this position later (for example,
+            // when we encounter an XML close tag.
+            int lastIndex = values.size() - 1;
+            if (lastIndex >= 0 && values.get(lastIndex).length() == 0 && (!hasPayload() || payloads.get(lastIndex) == null)) {
+                // Change the last value and its position increment
+                values.set(lastIndex, value);
+                if (hasPayload())
+                    payloads.set(lastIndex, payload);
+                if (increment > 0)
+                    increments.set(lastIndex, increments.get(lastIndex) + increment);
+            } else {
+                // Just add the new value
+                values.add(value);
+                if (hasPayload())
+                    payloads.add(payload);
+                increments.add(increment);
+            }
+            lastValuePosition += increment; // keep track of position of last token
+
         } else {
             // Before the last position.
             // Find the index where the value should be inserted.
@@ -292,7 +304,7 @@ public class AnnotationWriter {
                 if (curPos <= position) {
                     // Value should be inserted after this index.
                     int n = i + 1;
-                    insertValueAtPosition(value, position, n, curPos);
+                    insertValueAtIndex(n, value, position - curPos, payload);
                     break;
                 }
                 curPos -= increments.get(i); // go to previous value position
@@ -300,7 +312,7 @@ public class AnnotationWriter {
             if (curPos == -1) {
                 // Value should be inserted at the first position.
                 int n = 0;
-                insertValueAtPosition(value, position, n, curPos);
+                insertValueAtIndex(n, value, position - curPos, payload);
             }
         }
 
@@ -310,20 +322,25 @@ public class AnnotationWriter {
     /**
      * Add a value at a specific token position.
      *
-     * @param value value to add
-     * @param valuePosition token position of this value
-     * @param index index in the arrays where this value goes
-     * @param previousPosition token position of the previous value in the arrays (to calculate positionIncrement)
+     * @param index             index in the arrays where this value goes
+     * @param value             value to add
+     * @param positionIncrement position increment to store (and also adjust next position increment)
+     * @param payload           payload to add (or null if no payload)
      */
-    private void insertValueAtPosition(String value, int valuePosition, int index, int previousPosition) {
+    private void insertValueAtIndex(int index, String value, int positionIncrement, BytesRef payload) {
         values.add(index, value);
-        int positionIncrement = valuePosition - previousPosition;
         increments.addAtIndex(index, positionIncrement);
+        if (hasPayload())
+            payloads.add(index, payload);
+        // Do we need to adjust the position increment of the next value?
         if (increments.size() > index + 1 && positionIncrement > 0) {
             // Inserted value wasn't the last value, so the
             // increment for the value after this is now wrong;
             // correct it.
-            increments.set(index + 1, increments.get(index + 1) - positionIncrement);
+            int newPosIncr = increments.get(index + 1) - positionIncrement;
+            if (newPosIncr < 0)
+                throw new RuntimeException("ERROR insertValueAtPosition(value, index, posIncr): Next token got a negative posIncrement!");
+            increments.set(index + 1, newPosIncr);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -300,20 +300,16 @@ public class AnnotationWriter {
             // Before the last position.
             // Find the index where the value should be inserted.
             int curPos = this.lastValuePosition;
+            int n = 0; // if we go through the whole loop without breaking out, value should go at position 0
             for (int i = values.size() - 1; i >= 0; i--) {
                 if (curPos <= position) {
                     // Value should be inserted after this index.
-                    int n = i + 1;
-                    insertValueAtIndex(n, value, position - curPos, payload);
+                    n = i + 1;
                     break;
                 }
                 curPos -= increments.get(i); // go to previous value position
             }
-            if (curPos == -1) {
-                // Value should be inserted at the first position.
-                int n = 0;
-                insertValueAtIndex(n, value, position - curPos, payload);
-            }
+            insertValueAtIndex(n, value, position - curPos, payload);
         }
 
         return lastValuePosition;

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigMetadataField.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigMetadataField.java
@@ -92,7 +92,7 @@ public class ConfigMetadataField {
         cp.setAnalyzer(analyzer);
         cp.displayValues.putAll(displayValues);
         cp.displayOrder.addAll(displayOrder);
-        cp.setsortValues(sortValues);
+        cp.setSortValues(sortValues);
         return cp;
     }
 
@@ -226,7 +226,7 @@ public class ConfigMetadataField {
         displayOrder.addAll(fields);
     }
 
-    public void setsortValues(boolean sortValues) {
+    public void setSortValues(boolean sortValues) {
         this.sortValues = sortValues;
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
@@ -124,25 +124,27 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
                     needsPrimaryValuePayloads);
             addAnnotatedField(fieldWriter);
 
-            AnnotationWriter annotStartTag = fieldWriter.addAnnotation(null, AnnotatedFieldNameUtil.TAGS_ANNOT_NAME,
-                    AnnotationSensitivities.ONLY_SENSITIVE, true);
+            AnnotationWriter annotStartTag = fieldWriter.addAnnotation(AnnotatedFieldNameUtil.TAGS_ANNOT_NAME,
+                    AnnotationSensitivities.ONLY_SENSITIVE, true, false);
             annotStartTag.setHasForwardIndex(false);
 
             // Create properties for the other annotations
             for (int i = 1; i < annotations.size(); i++) {
                 ConfigAnnotation annot = annotations.get(i);
                 if (!annot.isForEach())
-                    fieldWriter.addAnnotation(annot, annot.getName(), annot.getSensitivitySetting(), false);
+                    fieldWriter.addAnnotation(annot.getName(), annot.getSensitivitySetting(), false,
+                            annot.createForwardIndex());
             }
             for (ConfigStandoffAnnotations standoff : af.getStandoffAnnotations()) {
                 for (ConfigAnnotation annot : standoff.getAnnotations().values()) {
-                    fieldWriter.addAnnotation(annot, annot.getName(), annot.getSensitivitySetting(), false);
+                    fieldWriter.addAnnotation(annot.getName(), annot.getSensitivitySetting(), false,
+                            annot.createForwardIndex());
                 }
             }
             if (!fieldWriter.hasAnnotation(AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME)) {
                 // Hasn't been created yet. Create it now.
-                fieldWriter.addAnnotation(null, AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME,
-                        AnnotationSensitivities.ONLY_INSENSITIVE, false);
+                fieldWriter.addAnnotation(AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME,
+                        AnnotationSensitivities.ONLY_INSENSITIVE, false, false);
             }
             if (getDocWriter() != null) {
                 IndexMetadataWriter indexMetadata = getDocWriter().indexWriter().metadata();

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerConfig.java
@@ -26,7 +26,6 @@ import nl.inl.blacklab.index.annotated.AnnotationWriter;
 import nl.inl.blacklab.indexers.preprocess.DocIndexerConvertAndTag;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
-import nl.inl.blacklab.search.indexmetadata.IndexMetadataWriter;
 
 /**
  * A DocIndexer configured using a ConfigInputFormat structure.
@@ -122,7 +121,6 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
             AnnotatedFieldWriter fieldWriter = new AnnotatedFieldWriter(af.getName(),
                     mainAnnotation.getName(), mainAnnotation.getSensitivitySetting(), false,
                     needsPrimaryValuePayloads);
-            addAnnotatedField(fieldWriter);
 
             AnnotationWriter annotStartTag = fieldWriter.addAnnotation(AnnotatedFieldNameUtil.TAGS_ANNOT_NAME,
                     AnnotationSensitivities.ONLY_SENSITIVE, true, false);
@@ -144,13 +142,9 @@ public abstract class DocIndexerConfig extends DocIndexerBase {
             if (!fieldWriter.hasAnnotation(AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME)) {
                 // Hasn't been created yet. Create it now.
                 fieldWriter.addAnnotation(AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME,
-                        AnnotationSensitivities.ONLY_INSENSITIVE, false, false);
+                        AnnotationSensitivities.ONLY_INSENSITIVE, false, true);
             }
-            if (getDocWriter() != null) {
-                IndexMetadataWriter indexMetadata = getDocWriter().indexWriter().metadata();
-                indexMetadata.registerAnnotatedField(fieldWriter);
-            }
-
+            addAnnotatedField(fieldWriter);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
@@ -23,28 +23,24 @@ import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.FieldType;
 
 /**
- * A toy DocIndexer that demonstrates advanced custom format support.
+ * An educational DocIndexer to learn how to implement your own.
  *
- * You probably don't want to use this for real indexing, just to learn
- * how custom indexing can be done.
- *
- * Note that for most XML or TSV formats, you don't even need to write your
- * own DocIndexer; you should just write a .blf.yaml configuration file.
- * But if your input data doesn't fit this setup, implementing your own
- * DocIndexer will give you the flexibility you need.
+ * If your input data cannot easily be described using the standard
+ * .blf.yaml configuration files, you might need to implement your own
+ * DocIndexer class. This shows how to do that.
  *
  * This example is designed to explain the most basic building blocks of
  * indexing data in BlackLab, not to be practical or robust. It covers only
- * the most important features.
+ * the most important features. If something is unclear, please ask.
  *
- * Input files are a sort of "assembly language" for BlackLab indexing.
- * Files should contain one instruction per line, each instruction being
- * an uppercase word followed by 0 or more parameter(s), whitespace-separated.
- * Anything after a hash symbol is ignored.
+ * The input files that this DocIndexer can process are a sort of "assembly
+ * language" for BlackLab indexing. They contain one instruction per line,
+ * each instruction being an uppercase word followed by 0 or more parameter(s),
+ * whitespace-separated. Anything after a hash symbol is ignored.
  *
- * Also see example.txt in the resources dir.
+ * Below is a small example. For a larger excample, see example/example.txt in
+ * the resources dir.
  *
- * Example:
  * <code>
  * # Add document
  * DOC_START                     # begin a new document

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
@@ -1,0 +1,317 @@
+package nl.inl.blacklab.indexers.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+
+import nl.inl.blacklab.exceptions.MalformedInputFile;
+import nl.inl.blacklab.exceptions.PluginException;
+import nl.inl.blacklab.index.annotated.AnnotatedFieldWriter;
+import nl.inl.blacklab.index.annotated.AnnotationSensitivities;
+import nl.inl.blacklab.search.BlackLabIndexWriter;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
+import nl.inl.blacklab.search.indexmetadata.FieldType;
+
+/**
+ * A toy DocIndexer that demonstrates advanced custom format support.
+ *
+ * Note that for most XML or TSV formats, you should just use a .blf.yaml
+ * configuration file, but if your format doesn't fit this setup, implementing
+ * your own DocIndexer will give the most flexibility.
+ *
+ * The example format is designed to show the most basic building blocks
+ * of indexing, not to be practical or robust. It covers only some of the possibilities.
+ * It contains one instruction per line. Each instruction is
+ * a uppercase word followed by 0 or more parameter(s), whitespace-separated.
+ * Anything after a hash symbol is ignored.
+ *
+ * Also see example.txt in the resources dir.
+ *
+ * Example:
+ * <code>
+ * # Add document
+ * DOC_START                     # begin a new document
+ *   # Add metadata
+ *   MVALUE author Pete Puck
+ *   MVALUE title This is a test.
+ *
+ *   # Add annotation values
+ *   AVAL_START contents
+ *     VAL word The
+ *     VAL lemma the
+ *     POS_ADD 1                 # Go to next token position
+ *     VAL word quick
+ *     VAL lemma quick
+ *     POS_ADD 1                 # Go to next token position
+ *     VAL word brown
+ *     VAL lemma brown
+ *     POS_ADD 1                 # Go to next token position
+ *     VAL word fox
+ *     VAL lemma fox
+ *     SPAN named-entity 0 4     # Add span according to token positions
+ *                               # (note that start is inclusive, end exclusive)
+ *     VAL word jumps
+ *     VAL lemma jump
+ *   AVAL_END
+ *
+ * DOC_END                       # end document and add to index
+ * </code>
+ *
+ */
+public class DocIndexerExample extends DocIndexerBase {
+
+    private BufferedReader reader;
+
+    /** Are we inside a document? */
+    private boolean inDoc = false;
+
+    /** Name of annotated field we're processing or null if not in annotated field part */
+    private String currentAnnotatedField = null;
+
+    /** What position increment should the next annotation values get? */
+    private int posIncr;
+
+    /** Character position within the input file. */
+    private int characterPosition = 0;
+
+    public DocIndexerExample() {
+
+        // Create our index structure: annotated and metadata fields.
+        createSimpleAnnotatedField("contents", List.of("word", "lemma"));
+        createMetadataField("pid", FieldType.UNTOKENIZED);
+        createMetadataField("author", FieldType.UNTOKENIZED);
+        createMetadataField("title", FieldType.TOKENIZED);
+    }
+
+    /**
+     * Create a simple annotated field.
+     *
+     * All of the given annotations get a forward index and will be indexed
+     * accent/case insensitively only. A special annotation for spans ("tags")
+     * will also be created.
+     *
+     * @param name annotated field name
+     * @param annotations annotations on this field
+     */
+    private void createSimpleAnnotatedField(String name, List<String> annotations) {
+        BlackLabIndexWriter indexWriter = getDocWriter().indexWriter();
+        // Configure an annotated field "contents".
+        // Add two annotations, "word" and "lemma". First one added will be the main annotation.
+        ConfigAnnotatedField field = new ConfigAnnotatedField();
+        field.setName(name);
+        for (String annotationName: annotations) {
+            addAnnotationToFieldConfig(field, annotationName,
+                    AnnotationSensitivities.ONLY_INSENSITIVE,
+                    true);
+        }
+        // Add a special annotation where we can index arbitrary spans.
+        addAnnotationToFieldConfig(field, AnnotatedFieldNameUtil.TAGS_ANNOT_NAME,
+                AnnotationSensitivities.ONLY_SENSITIVE, false);
+
+        // Add the field to the index metadata
+        getDocWriter().indexWriter().annotatedFields().addFromConfig(field);
+
+        // Create and add AnnotatedFieldWriter so we can index this field
+        addAnnotatedField(createAnnotatedFieldWriter(field));
+    }
+
+    private static ConfigAnnotation addAnnotationToFieldConfig(ConfigAnnotatedField config, String name,
+            AnnotationSensitivities sensitivities, boolean forwardIndex) {
+        ConfigAnnotation annot = new ConfigAnnotation();
+        annot.setName(name);
+        annot.setSensitivity(sensitivities);
+        annot.setForwardIndex(forwardIndex);
+        config.addAnnotation(annot);
+        return annot;
+    }
+
+    private AnnotatedFieldWriter createAnnotatedFieldWriter(ConfigAnnotatedField fieldContents) {
+        BlackLabIndexWriter indexWriter = getDocWriter().indexWriter();
+        // Add the configured field to our index metadata
+        indexWriter.annotatedFields().addFromConfig(fieldContents);
+
+        // Create a AnnotatedFieldWriter for this field so we can index it
+        Collection<ConfigAnnotation> annots = fieldContents.getAnnotations().values();
+        Iterator<ConfigAnnotation> annotIt = annots.iterator();
+        ConfigAnnotation mainAnnotation = annotIt.next();
+        AnnotatedFieldWriter contents = new AnnotatedFieldWriter(fieldContents.getName(),
+                mainAnnotation.getName(), mainAnnotation.getSensitivitySetting(),
+                false,
+                indexWriter.needsPrimaryValuePayloads());
+        while (annotIt.hasNext()) {
+            ConfigAnnotation annot = annotIt.next();
+            boolean includePayloads = annot.getName() == AnnotatedFieldNameUtil.TAGS_ANNOT_NAME;
+            contents.addAnnotation(annot.getName(), annot.getSensitivitySetting(), includePayloads, annot.createForwardIndex());
+        }
+        return contents;
+    }
+
+    private ConfigMetadataField createMetadataField(String name, FieldType type) {
+        ConfigMetadataField metaPidConfig = new ConfigMetadataField();
+        metaPidConfig.setName(name);
+        metaPidConfig.setType(type);
+        getDocWriter().indexWriter().metadata().metadataFields().addFromConfig(metaPidConfig);
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void index() throws IOException, MalformedInputFile, PluginException {
+        // Execute the commands one line at a time.
+        while (true) {
+            String line = reader.readLine();
+            if (line == null)
+                break;
+
+            // Try to keep track of character position, for highlighting.
+            // Assumes lines end with only a newline. May not be accurate.
+            characterPosition += line.length() + 1;
+
+            // Execute the command on this line, if any.
+            processLine(line);
+        }
+    }
+
+    private void processLine(String line) {
+        // Remove comments and leading/trailing whitespace
+        line = line.replaceAll("^\\s*(\\S.*\\S)\\s*(#.*)?$", "$1");
+        if (line.isEmpty())
+            return;
+
+        String[] parts = line.split("\\s+", -1);
+        String command = parts[0];
+        String[] parameters = Arrays.copyOfRange(parts, 1, Integer.MAX_VALUE);
+        executeCommand(command, parameters);
+    }
+
+    private void executeCommand(String command, String[] parameters) {
+        if (currentAnnotatedField != null) {
+            executeValueCommand(command, parameters);
+        } else if (inDoc) {
+            execDocCommand(command, parameters);
+        } else {
+            // Top-level. Look for documents.
+            switch (command) {
+            case "DOC_START":
+                // Start a document.
+                inDoc = true;
+            default:
+                throw new RuntimeException("Command " + command + " cannot appear at top level");
+            }
+        }
+    }
+
+    /**
+     * Handle command inside a AVAL (annotated field values) block.
+     *
+     * @param command command to handle
+     * @param parameters parameters
+     */
+    private void executeValueCommand(String command, String[] parameters) {
+        switch (command) {
+        case "VAL":
+            // Add annotation value at current position.
+            String annotationName = parameters[0];
+            String value = parameters[1];
+            annotation(annotationName, value, posIncr, null);
+            break;
+        case "POS_ADD":
+            // Increase current position.
+            posIncr = Integer.parseInt(parameters[0]);
+            break;
+        case "SPAN":
+            // Add a named span, e.g. <p>, <s>, <named-entity>, etc.
+            // at the specified token positions.
+            String spanType = parameters[0];
+            int spanStart = Integer.parseInt(parameters[1]);
+            int spanEnd = Integer.parseInt(parameters[2]);
+            //@@@@
+            //annotation(AnnotatedFieldNameUtil.TAGS_ANNOT_NAME, )
+            // PAYLOAD
+        case "AVAL_END":
+            // End the annotated field value block.
+            currentAnnotatedField = null;
+            break;
+        default:
+            throw new RuntimeException("Command " + command + " cannot appear inside annotated field block");
+        }
+    }
+
+    /**
+     * Handle command inside a DOC (document) block.
+     *
+     * @param command command to handle
+     * @param parameters parameters
+     */
+    private void execDocCommand(String command, String[] parameters) {
+        switch (command) {
+        case "MVALUE":
+            // Gives a document metadata value.
+            String name = parameters[0];
+            String value = parameters[1];
+            addMetadataField(name, value);
+            break;
+        case "AVAL_START":
+            // Starts an annotated field values block.
+            currentAnnotatedField = parameters[0];
+            setCurrentAnnotatedFieldName(currentAnnotatedField);
+            break;
+        case "DOC_END":
+            // Ends document.
+            inDoc = false;
+            break;
+        default:
+            throw new RuntimeException("Command " + command + " cannot appear inside document");
+        }
+    }
+
+    @Override
+    protected int getCharacterPosition() {
+        // This should ideally keep track of character position within the input document, to be used
+        // for highlighting in BlackLab later. If you don't use BlackLab's highlighting, you don't need this.
+        return characterPosition;
+    }
+
+    @Override
+    public void indexSpecificDocument(String documentExpr) {
+        // Used with linked documents to index part of a linked document.
+        // For example, if you're indexing a document A that links to a document B that contains metadata
+        // for many documents, you only want to index the metadata for document A in document B. The
+        // document expression indicates how to find that metadata inside document B. For XML, this would probably
+        // be an XPath expression.
+        // If this doesn't fit your needs, it is of course always fine to ignore this and write your own code
+        // to handle your linked resources.
+    }
+
+    @Override
+    protected void storeDocument() {
+        // If you want to store your input documents in the BlackLab index for easy retrieval and highlighting
+        // later, you should uncomment the next line.
+        //storeWholeDocument(document);
+    }
+
+    /**
+     * Sets document to be indexed.
+     *
+     * NOTE: there are other setDocument methods that you can override. In some
+     * cases, depending on how you process your data, you can optimize indexing by
+     * implementing another method. For example, DocIndexerXpath uses the byte array
+     * because that's what VTD-XML expects.
+     *
+     * @param reader document to index
+     */
+    @Override
+    public void setDocument(Reader reader) {
+        this.reader = IOUtils.toBufferedReader(reader);
+    }
+
+}

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
@@ -274,12 +274,11 @@ public class DocIndexerExample extends DocIndexerBase {
             if (!inWord) {
                 // Signal that we're starting a new token position.
                 beginWord();
-                inWord = true; // make sure we call endWord() later
+                inWord = true; // remember to call endWord() later
             }
             String annotationName = parameters[0];
             String value = parameters[1];
             annotation(annotationName, value, -1, List.of(currentTokenPosition));
-//            posIncr = 0; // reset so next value can be added at the same position
             break;
 
         case "ADVANCE":
@@ -295,7 +294,7 @@ public class DocIndexerExample extends DocIndexerBase {
             break;
 
         case "SPAN":
-            // Add a named span, e.g. <p>, <s>, <named-entity>, etc.
+            // Add a named span, e.g. <p/>, <s/>, <entity/>, etc.
             // at the specified token positions.
             // CAUTION: right now, we can only add spans at positions that we have already
             //   indexed values for! So add the spans either while or after indexing values,
@@ -306,6 +305,7 @@ public class DocIndexerExample extends DocIndexerBase {
             int spanStart = Integer.parseInt(parameters[1]);
             int spanEnd = Integer.parseInt(parameters[2]);   // end position (exclusive)
             tagsAnnotation().addValueAtPosition(spanType, spanStart, PayloadUtils.tagEndPositionPayload(spanEnd));
+            // Add the span's attributes, if any
             for (int i = 3; i < parameters.length; i += 2) {
                 String attName = parameters[i];
                 String attValue = parameters[i + 1];
@@ -333,7 +333,7 @@ public class DocIndexerExample extends DocIndexerBase {
         super.endWord();
 
         // Make sure that all annotations are at the same token position.
-        // (if not all annotations have a value at all positions, they could desynchronize, causing problems)
+        // (we don't want annotations to run out of synch)
         for (AnnotationWriter aw: getAnnotatedField(currentAnnotatedField).annotationWriters()) {
             while (aw.lastValuePosition() < currentTokenPosition) {
                 aw.addValue("");
@@ -342,7 +342,7 @@ public class DocIndexerExample extends DocIndexerBase {
     }
 
     /**
-     * Handle command inside a DOC (document) block.
+     * Handle command inside a document block.
      *
      * @param command command to handle
      * @param parameters parameters

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerExample.java
@@ -151,12 +151,8 @@ public class DocIndexerExample extends DocIndexerBase {
         addAnnotationToFieldConfig(field, AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME,
                 AnnotationSensitivities.ONLY_SENSITIVE, true);
 
-        // Add the field to the index metadata
-        getDocWriter().indexWriter().annotatedFields().addFromConfig(field);
-
         // Create and add AnnotatedFieldWriter so we can index this field
-        AnnotatedFieldWriter fieldWriter = createAnnotatedFieldWriter(field);
-        addAnnotatedField(fieldWriter);
+        createAnnotatedFieldWriter(field);
     }
 
     private static ConfigAnnotation addAnnotationToFieldConfig(ConfigAnnotatedField config, String name,
@@ -169,7 +165,7 @@ public class DocIndexerExample extends DocIndexerBase {
         return annot;
     }
 
-    private AnnotatedFieldWriter createAnnotatedFieldWriter(ConfigAnnotatedField fieldContents) {
+    private void createAnnotatedFieldWriter(ConfigAnnotatedField fieldContents) {
         BlackLabIndexWriter indexWriter = getDocWriter().indexWriter();
         // Add the configured field to our index metadata
         indexWriter.annotatedFields().addFromConfig(fieldContents);
@@ -187,7 +183,7 @@ public class DocIndexerExample extends DocIndexerBase {
             boolean includePayloads = annot.getName() == AnnotatedFieldNameUtil.TAGS_ANNOT_NAME;
             contents.addAnnotation(annot.getName(), annot.getSensitivitySetting(), includePayloads, annot.createForwardIndex());
         }
-        return contents;
+        addAnnotatedField(contents);
     }
 
     private ConfigMetadataField createMetadataField(String name, FieldType type) {

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
@@ -653,7 +653,7 @@ public class InputFormatReader extends YamlJsonReader {
                     f.addDisplayValues(values);
                     break;
                 case "sortValues":
-                    f.setsortValues(YamlJsonReader.bool(e));
+                    f.setSortValues(YamlJsonReader.bool(e));
                     break;
                 default:
                     throw new InvalidInputFormatConfig(

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
@@ -208,8 +208,6 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
             ensureNotFrozen();
             pd = new AnnotationImpl(this, name);
             putAnnotation(pd);
-            if (name.equals(AnnotatedFieldNameUtil.TAGS_ANNOT_NAME))
-                xmlTags = true;
         }
         return pd;
     }
@@ -217,6 +215,8 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
     synchronized void putAnnotation(AnnotationImpl annotDesc) {
         ensureNotFrozen();
         annots.put(annotDesc.name(), annotDesc);
+        if (annotDesc.name().equals(AnnotatedFieldNameUtil.TAGS_ANNOT_NAME))
+            xmlTags = true;
     }
 
     synchronized void detectMainAnnotation(IndexReader reader) {
@@ -229,7 +229,6 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
                 throw new IllegalArgumentException("Main annotation '" + mainAnnotationName + "' (from index metadata) not found!");
             mainAnnotation = annots.get(mainAnnotationName);
             mainAnnotationName = null;
-            //return;
         }
         
         if (annots.isEmpty())

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldNameUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldNameUtil.java
@@ -83,7 +83,27 @@ public final class AnnotatedFieldNameUtil {
         // Historic behaviour: if no sensitivity is given, "word" and "lemma" annotations will
         // get SensitivitySetting.SENSITIVE_AND_INSENSITIVE; all others get SensitivitySetting.ONLY_INSENSITIVE.
         // We warn users if their configuration relies on this, so we can eventually remove it.
-        return name.equals("lemma") || name.equals("word");
+        return name.equals("lemma") || name.equals(DEFAULT_MAIN_ANNOT_NAME);
+    }
+
+    /**
+     * What value do we index for attributes to tags (spans)?
+     *
+     * For example, a tag <s id="123"> ... </s> would be indexed in annotations "starttag"
+     * with two tokens at the same position: "s" and "@iid__123".
+     *
+     * FIXME: this means that currently, we cannot distinguish between attributes for
+     *   different start tags occurring at the same token position! We should change the index
+     *   format to at least include tag name with each attribute, but this will break index
+     *   compatibility. We'll probably do this as part of a larger update to how document
+     *   structure is indexed (for syntactic search features).
+     *
+     * @param name attribute name
+     * @param value attribute value
+     * @return value to index for this attribute
+     */
+    public static String tagAttributeIndexValue(String name, String value) {
+        return "@" + name.toLowerCase() + "__" + value.toLowerCase();
     }
 
     public enum BookkeepFieldType {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFields.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFields.java
@@ -3,6 +3,8 @@ package nl.inl.blacklab.search.indexmetadata;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import nl.inl.blacklab.indexers.config.ConfigAnnotatedField;
+
 /** Annotated fields on a BlackLab index */
 public interface AnnotatedFields extends Iterable<AnnotatedField> {
 
@@ -47,4 +49,5 @@ public interface AnnotatedFields extends Iterable<AnnotatedField> {
 
     AnnotationGroups annotationGroups(String fieldName);
 
+    void addFromConfig(ConfigAnnotatedField config);
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsImpl.java
@@ -76,8 +76,11 @@ class MetadataFieldsImpl implements MetadataFieldsWriter, Freezable {
     @XmlTransient
     private final Map<String, MetadataFieldImpl> implicitFields = new ConcurrentHashMap<>();
 
-    void addFromConfig(ConfigMetadataField f) {
-        put(f.getName(), MetadataFieldImpl.fromConfig(f, this));
+    @Override
+    public MetadataFieldImpl addFromConfig(ConfigMetadataField f) {
+        MetadataFieldImpl fieldDesc = MetadataFieldImpl.fromConfig(f, this);
+        put(f.getName(), fieldDesc);
+        return fieldDesc;
     }
 
     public MetadataFieldValues.Factory getMetadataFieldValuesFactory() {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/MetadataFieldsWriter.java
@@ -2,6 +2,8 @@ package nl.inl.blacklab.search.indexmetadata;
 
 import java.util.Map;
 
+import nl.inl.blacklab.indexers.config.ConfigMetadataField;
+
 /**
  * Interface for MetadataFields objects while indexing.
  */
@@ -33,4 +35,5 @@ public interface MetadataFieldsWriter extends MetadataFields {
 
     void resetForIndexing();
 
+    MetadataFieldImpl addFromConfig(ConfigMetadataField metaPidConfig);
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryTags.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryTags.java
@@ -57,7 +57,7 @@ public class SpanQueryTags extends BLSpanQuery {
         // Construct attribute filters
         List<BLSpanQuery> attrFilters = new ArrayList<>();
         for (Map.Entry<String, String> e : attr.entrySet()) {
-            String value = "@" + e.getKey() + "__" + e.getValue();
+            String value = AnnotatedFieldNameUtil.tagAttributeIndexValue(e.getKey(), e.getValue());
             attrFilters.add(new BLSpanTermQuery(queryInfo, new Term(startTagFieldName, value)));
         }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Concordances.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Concordances.java
@@ -29,7 +29,7 @@ public class Concordances {
      * null, because Kwics will be used internally. This is only used when making
      * concordances from the content store (the old default).
      */
-    private final Map<Hit, Concordance> concordances;
+    private Map<Hit, Concordance> concordances = null;
     
     Kwics kwics = null;
 
@@ -40,10 +40,10 @@ public class Concordances {
             throw new IllegalArgumentException("contextSize cannot be negative");
         if (type == ConcordanceType.FORWARD_INDEX) {
             kwics = new Kwics(hits, contextSize);
+        } else {
+            // Get the concordances
+            concordances = retrieveConcordancesFromContentStore(hits, contextSize);
         }
-    
-        // Get the concordances
-        concordances = retrieveConcordancesFromContentStore(hits, contextSize);
     }
 
     /**

--- a/engine/src/main/resources/example/example.txt
+++ b/engine/src/main/resources/example/example.txt
@@ -1,0 +1,43 @@
+# Example data for DocIndexerExample.
+#
+# This is a toy DocIndexer that demonstrates advanced custom format support.
+#
+# Note that for most XML or TSV formats, you should just use a .blf.yaml
+# configuration file, but if your format doesn't fit this setup, implementing
+# your own DocIndexer will give the most flexibility.
+#
+# The example format is designed to show the building blocks of indexing,
+# not to be practical. It covers some, not all, of the possibilities. See the
+# code for pointers to what else is possible.
+#
+# There is one instruction per line. Each instruction is a uppercase word
+# followed by 0 or more parameter(s), whitespace-separated.
+# Anything after a hash symbol is ignored.
+
+# Add document
+DOC_START                     # begin a new document
+
+  # Add metadata
+  MVALUE author Pete Puck
+  MVALUE title This is a test.
+
+  # Add annotation values
+  AVAL_START contents
+    VAL word The
+    VAL lemma the
+    POS_ADD 1                 # Go to next token position
+    VAL word quick
+    VAL lemma quick
+    POS_ADD 1                 # Go to next token position
+    VAL word brown
+    VAL lemma brown
+    POS_ADD 1                 # Go to next token position
+    VAL word fox
+    VAL lemma fox
+    SPAN named-entity 0 4     # Add span according to token positions
+                              # (note that start is inclusive, end exclusive)
+    VAL word jumps
+    VAL lemma jump
+  AVAL_END
+
+DOC_END                       # end document and add to index

--- a/engine/src/main/resources/example/example.txt
+++ b/engine/src/main/resources/example/example.txt
@@ -1,43 +1,112 @@
 # Example data for DocIndexerExample.
 #
-# This is a toy DocIndexer that demonstrates advanced custom format support.
-#
-# Note that for most XML or TSV formats, you should just use a .blf.yaml
-# configuration file, but if your format doesn't fit this setup, implementing
-# your own DocIndexer will give the most flexibility.
-#
-# The example format is designed to show the building blocks of indexing,
-# not to be practical. It covers some, not all, of the possibilities. See the
-# code for pointers to what else is possible.
-#
-# There is one instruction per line. Each instruction is a uppercase word
-# followed by 0 or more parameter(s), whitespace-separated.
-# Anything after a hash symbol is ignored.
+# This is a toy DocIndexer that demonstrates how to support custom formats
+# in BlackLab. See DocIndexerExample for more details.
 
 # Add document
 DOC_START                     # begin a new document
 
   # Add metadata
-  MVALUE author Pete Puck
-  MVALUE title This is a test.
+  METADATA pid ABC123
+  METADATA author Pete Puck
+  METADATA title This is a test.
 
-  # Add annotation values
-  AVAL_START contents
+  # Annotated field: contents
+  FIELD_START contents
+
+    # Annotation values
+
     VAL word The
     VAL lemma the
-    POS_ADD 1                 # Go to next token position
+    ADVANCE 1   # Go to next token position
+
     VAL word quick
     VAL lemma quick
-    POS_ADD 1                 # Go to next token position
+    ADVANCE 1
+
     VAL word brown
     VAL lemma brown
-    POS_ADD 1                 # Go to next token position
+    ADVANCE 1
+
     VAL word fox
     VAL lemma fox
-    SPAN named-entity 0 4     # Add span according to token positions
-                              # (note that start is inclusive, end exclusive)
+    ADVANCE 1
+
     VAL word jumps
     VAL lemma jump
-  AVAL_END
+    ADVANCE 1
+
+    VAL word over
+    VAL lemma over
+    ADVANCE 1
+
+    VAL word the
+    VAL lemma the
+    ADVANCE 1
+
+    VAL word lazy
+    VAL lemma lazy
+    ADVANCE 1
+
+    VAL word dog
+    VAL lemma dog
+
+
+    # Any spans to add, with start/end token positions and any attributes
+    # (note that start is inclusive, end exclusive)
+
+    # (XML equivalent: <entity genus="Vulpes" speed="quick">The quick brown fox</entity>)
+    SPAN entity 0 4 genus Vulpes speed quick  # The quick brown fox
+
+    SPAN entity 6 9 genus Canis speed slow    # the lazy dog
+
+    # Note that spans don't need to be hierarchical, they can partially overlap as well
+    SPAN weird 2 7 meaning none   # brown fox jumps over the
+
+  FIELD_END
 
 DOC_END                       # end document and add to index
+
+
+DOC_START
+
+  # Add metadata
+  METADATA pid DEF456
+  METADATA author William Weaver
+  METADATA title This is another test.
+
+  # Annotated field: contents
+  FIELD_START contents
+
+    # Annotation values
+
+    VAL word Testing
+    VAL lemma test
+    ADVANCE 1
+
+    VAL word indexing
+    VAL lemma index
+    ADVANCE 1
+
+    VAL word is
+    VAL lemma be
+    ADVANCE 1
+
+    VAL word lots
+    VAL lemma lot
+    ADVANCE 1
+
+    VAL word of
+    VAL lemma of
+    ADVANCE 1
+
+    VAL word fun
+    VAL lemma fun
+
+
+    # (XML equivalent: <evaluation quality="fun" amount="lots">lots of fun</evaluation>)
+    SPAN evaluation 3 6 quality fun amount lots    # lots of fun
+
+  FIELD_END
+
+DOC_END

--- a/engine/src/main/resources/example/example.txt
+++ b/engine/src/main/resources/example/example.txt
@@ -1,7 +1,7 @@
 # Example data for DocIndexerExample.
 #
-# This is a toy DocIndexer that demonstrates how to support custom formats
-# in BlackLab. See DocIndexerExample for more details.
+# DocIndexerExample is a toy DocIndexer that demonstrates how to support
+# custom formats in BlackLab. See DocIndexerExample for more details.
 
 # Add document
 DOC_START                     # begin a new document

--- a/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
+++ b/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import nl.inl.blacklab.indexers.config.ConfigAnnotatedField;
 import nl.inl.blacklab.indexers.config.TextDirection;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedFields;
@@ -57,6 +58,11 @@ public class MockIndexMetadata implements IndexMetadata {
 
             @Override
             public AnnotationGroups annotationGroups(String fieldName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addFromConfig(ConfigAnnotatedField config) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/mocks/src/main/java/nl/inl/blacklab/mocks/MockSpans.java
+++ b/mocks/src/main/java/nl/inl/blacklab/mocks/MockSpans.java
@@ -170,7 +170,7 @@ public class MockSpans extends BLSpans {
     private void setPayloadsInt(int[] aEnd, boolean[] aIsPrimary) {
         this.payloads = new byte[aEnd.length][];
         for (int i = 0; i < aEnd.length; i++) {
-            BytesRef bytesRef = new BytesRef(ByteBuffer.allocate(4).putInt(aEnd[i]).array());
+            BytesRef bytesRef = PayloadUtils.tagEndPositionPayload(aEnd[i]);
             BytesRef withPrimary = PayloadUtils.addIsPrimary(aIsPrimary[i], bytesRef);
             byte[] b = new byte[withPrimary.length];
             System.arraycopy(withPrimary.bytes, withPrimary.offset, b, 0, b.length);

--- a/query-parser/src/main/java/nl/inl/blacklab/queryParser/contextql/ContextualQueryLanguageParser.java
+++ b/query-parser/src/main/java/nl/inl/blacklab/queryParser/contextql/ContextualQueryLanguageParser.java
@@ -13,6 +13,7 @@ import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.exceptions.InvalidQuery;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.CompleteQuery;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.blacklab.search.indexmetadata.IndexMetadata;
 import nl.inl.blacklab.search.textpattern.TextPattern;
@@ -88,12 +89,12 @@ public class ContextualQueryLanguageParser {
     CompleteQuery contains(BlackLabIndex index, String field, String value) {
 
         boolean isContentsSearch = false;
-        String prop = "word";
+        String prop = AnnotatedFieldNameUtil.DEFAULT_MAIN_ANNOT_NAME;
         boolean isProperty;
         if (index != null && !index.getClass().getSimpleName().startsWith("Mock")) // TODO: improve testability
             isProperty = index.mainAnnotatedField().annotations().exists(field);
         else
-            isProperty = field.equals("word") || field.equals("lemma") || field.equals("pos"); // common case
+            isProperty = field.equals(AnnotatedFieldNameUtil.DEFAULT_MAIN_ANNOT_NAME) || field.equals("lemma") || field.equals("pos"); // common case
         if (isProperty) {
             isContentsSearch = true;
             prop = field;

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/BlackLabServerParams.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/BlackLabServerParams.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 
 import nl.inl.blacklab.search.ConcordanceType;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 import nl.inl.blacklab.server.config.BLSConfigParameters;
 import nl.inl.blacklab.server.lib.User;
@@ -104,7 +105,7 @@ public class BlackLabServerParams implements PlainWebserviceParams {
         defaultValues.put("wordstart", "-1");
         defaultValues.put("wordend", "-1");
         defaultValues.put("calc", "");
-        defaultValues.put("property", "word"); // deprecated, use "annotation" now
+        defaultValues.put("property", AnnotatedFieldNameUtil.DEFAULT_MAIN_ANNOT_NAME); // deprecated, use "annotation" now
         defaultValues.put("annotation", "");   // default empty, because we fall back to the old name, "property".
         defaultValues.put("waitfortotal", "no");
         defaultValues.put("number", "50");

--- a/tools/src/main/java/nl/inl/blacklab/performance/ExportForwardIndex.java
+++ b/tools/src/main/java/nl/inl/blacklab/performance/ExportForwardIndex.java
@@ -13,6 +13,7 @@ import nl.inl.blacklab.forwardindex.Terms;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndex;
 import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedFieldNameUtil;
 import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.util.LogUtil;
 
@@ -22,7 +23,7 @@ import nl.inl.util.LogUtil;
 public class ExportForwardIndex {
 
     // Annotations to skip
-    private static final List<String> SKIP_ANNOTATIONS = List.of("pos", "punct", "starttag");
+    private static final List<String> SKIP_ANNOTATIONS = List.of("pos", AnnotatedFieldNameUtil.PUNCTUATION_ANNOT_NAME, AnnotatedFieldNameUtil.TAGS_ANNOT_NAME);
 
     private static final int MAX_DOCS = 30;
 


### PR DESCRIPTION
This is a toy indexer that demonstrates how to add support for custom input data formats that aren't covered by the `.blf.yaml` configuration files. See DocIndexerExample for a complete description.