### PR TITLE
Standoff spans

### DIFF
--- a/STANDOFF.md
+++ b/STANDOFF.md
@@ -1,8 +1,0 @@
-# Standoff span annotations branch
-
-TODO:
-
-- allow inlineTags to have tokenIdPath
-  (matching id will map to start tag position for this inlineTag)
-
-- allow standoffAnnotations to have spanStartPath, spanEndPath, spanEndIsInclusive, spanName(Path)

--- a/STANDOFF.md
+++ b/STANDOFF.md
@@ -1,0 +1,8 @@
+# Standoff span annotations branch
+
+TODO:
+
+- allow inlineTags to have tokenIdPath
+  (matching id will map to start tag position for this inlineTag)
+
+- allow standoffAnnotations to have spanStartPath, spanEndPath, spanEndIsInclusive, spanName(Path)

--- a/core/src/main/resources/formats/eaf.blf.yaml
+++ b/core/src/main/resources/formats/eaf.blf.yaml
@@ -15,7 +15,7 @@ annotatedFields:
 
     # If specified, a mapping from this id to token position will be saved, so we 
     # can refer back to it for standoff annotations later.
-    tokenPositionIdPath: "@ANNOTATION_ID"
+    tokenIdPath: "@ANNOTATION_ID"
 
     # What annotation can each word have? How do we index them?
     # (annotations are also called "(word) properties" in BlackLab)
@@ -32,7 +32,7 @@ annotatedFields:
 
     standoffAnnotations:
     - path: "/ANNOTATION_DOCUMENT/TIER[@LINGUISTIC_TYPE_REF='Lemma']/ANNOTATION/REF_ANNOTATION"
-      refTokenPositionIdPath: "@ANNOTATION_REF"
+      tokenRefPath: "@ANNOTATION_REF"
       annotations:
       - name: lemma
         displayName: Lemma
@@ -40,7 +40,7 @@ annotatedFields:
         sensitivity: sensitive_insensitive
 
     - path: "/ANNOTATION_DOCUMENT/TIER[@LINGUISTIC_TYPE_REF='PoS']/ANNOTATION/REF_ANNOTATION"
-      refTokenPositionIdPath: "@ANNOTATION_REF"
+      tokenRefPath: "@ANNOTATION_REF"
       annotations:
       - name: pos
         displayName: PoS

--- a/core/src/main/resources/formats/folia.blf.yaml
+++ b/core/src/main/resources/formats/folia.blf.yaml
@@ -41,7 +41,7 @@ annotatedFields:
 
     # If specified, a mapping from this id to token position will be saved, so we 
     # can refer back to it for standoff annotations later.
-    tokenPositionIdPath: "@xml:id"
+    tokenIdPath: "@xml:id"
 
     # What annotation can each word have? How do we index them?
     # (valuePaths relative to word path)

--- a/core/src/main/resources/formats/naf.blf.yaml
+++ b/core/src/main/resources/formats/naf.blf.yaml
@@ -25,7 +25,7 @@ annotatedFields:
 
     wordPath: .//wf
 
-    tokenPositionIdPath: "@id"
+    tokenIdPath: "@id"
 
     annotations: # basic
       # First annotation is the main annotation
@@ -42,7 +42,7 @@ annotatedFields:
 
     standoffAnnotations:
       - path: terms/term      # Element containing what to index (relative to documentPath)
-        refTokenPositionIdPath: "./span/target/@id" # What token position(s) to index these values at
+        tokenRefPath: "./span/target/@id" # What token position(s) to index these values at
           # (may have multiple matches per path element; values will
         # be indexed at all those positions)
         annotations:           # The actual annotations (structure identical to regular annotations)

--- a/core/src/main/resources/formats/tcf.blf.yaml
+++ b/core/src/main/resources/formats/tcf.blf.yaml
@@ -25,7 +25,7 @@ annotatedFields:
 
     # If specified, a mapping from this id to token position will be saved, so we 
     # can refer back to it for standoff annotations later.
-    #tokenPositionIdPath: "@ID"
+    #tokenIdPath: "@ID"
 
     # What annotation can each word have? How do we index them?
     # (annotations are also called "(word) properties" in BlackLab)

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -278,9 +278,11 @@ public class AnnotationWriter {
             // replace the previous value. This is convenient to keep all the annotations synched
             // up while indexing (by adding an empty string if we don't have a value for a
             // annotation), while still being able to add a value to this position later (for example,
-            // when we encounter an XML close tag.
+            // when we encounter an XML close tag. Note that we don't do this if we store character offsets, or we
+            // lose the offsets for some positions.
             int lastIndex = values.size() - 1;
-            if (lastIndex >= 0 && values.get(lastIndex).length() == 0 && (!hasPayload() || payloads.get(lastIndex) == null)) {
+            if (lastIndex >= 0 && values.get(lastIndex).length() == 0 && !includeOffsets &&
+                    (!hasPayload() || payloads.get(lastIndex) == null)) {
                 // Change the last value and its position increment
                 values.set(lastIndex, value);
                 if (hasPayload())

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigAnnotatedField.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigAnnotatedField.java
@@ -25,7 +25,7 @@ public class ConfigAnnotatedField implements ConfigWithAnnotations {
     private String wordPath;
 
     /** Unique id that will map to this token position */
-    private String tokenPositionIdPath = null;
+    private String tokenIdPath = null;
 
     /** Punctuation between words (or null if we don't need/want to capture this) */
     private String punctPath = null;
@@ -70,7 +70,7 @@ public class ConfigAnnotatedField implements ConfigWithAnnotations {
         result.setDescription(description);
         result.setContainerPath(containerPath);
         result.setWordPath(wordPath);
-        result.setTokenPositionIdPath(tokenPositionIdPath);
+        result.setTokenIdPath(tokenIdPath);
         result.setPunctPath(punctPath);
         for (ConfigAnnotation a : annotations.values())
             result.addAnnotation(a.copy());
@@ -93,8 +93,16 @@ public class ConfigAnnotatedField implements ConfigWithAnnotations {
         this.wordPath = wordPath;
     }
 
-    public void setTokenPositionIdPath(String tokenPositionIdPath) {
-        this.tokenPositionIdPath = tokenPositionIdPath;
+    /**
+     * @deprecated renamed to {@link #setTokenIdPath(String)}
+     */
+    @Deprecated
+    public void setTokenPositionIdPath(String tokenIdPath) {
+        setTokenIdPath(tokenIdPath);
+    }
+
+    public void setTokenIdPath(String tokenIdPath) {
+        this.tokenIdPath = tokenIdPath;
     }
 
     public void setPunctPath(String punctPath) {
@@ -127,8 +135,16 @@ public class ConfigAnnotatedField implements ConfigWithAnnotations {
         return wordPath;
     }
 
+    /**
+     * @deprecated renamed to {@link #getTokenIdPath()}
+     */
+    @Deprecated
     public String getTokenPositionIdPath() {
-        return tokenPositionIdPath;
+        return getTokenIdPath();
+    }
+
+    public String getTokenIdPath() {
+        return tokenIdPath;
     }
 
     public String getPunctPath() {

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigInlineTag.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigInlineTag.java
@@ -16,6 +16,13 @@ public class ConfigInlineTag {
      */
     private String displayAs = "";
 
+    /**
+     * XPath to resolve and remember the start positions for,
+     * so we can refer to them from standoff annotations.
+     * (Used for tei:anchor, so end position is not used)
+     */
+    private String tokenIdPath = "";
+
     public ConfigInlineTag() {
     }
 
@@ -48,10 +55,16 @@ public class ConfigInlineTag {
         this.displayAs = displayAs;
     }
 
+    public String getTokenIdPath() {
+        return tokenIdPath;
+    }
+
+    public void setTokenIdPath(String tokenIdPath) {
+        this.tokenIdPath = tokenIdPath;
+    }
+
     @Override
     public String toString() {
         return "ConfigInlineTag [displayAs=" + displayAs + "]";
     }
-
-    
 }

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
@@ -19,7 +19,7 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
      * Unique id of the token position(s) to index these values at. A uniqueId must
      * be defined for words.
      */
-    private String refTokenPositionIdPath;
+    private String tokenRefPath;
 
     /** The annotations to index at the referenced token positions. */
     private final Map<String, ConfigAnnotation> annotations = new LinkedHashMap<>();
@@ -27,21 +27,21 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
     public ConfigStandoffAnnotations() {
     }
 
-    public ConfigStandoffAnnotations(String path, String refTokenPositionIdPath) {
+    public ConfigStandoffAnnotations(String path, String tokenRefPath) {
         this.path = path;
-        this.refTokenPositionIdPath = refTokenPositionIdPath;
+        this.tokenRefPath = tokenRefPath;
     }
 
     public void validate() {
         String t = "standoff annotations";
         ConfigInputFormat.req(path, t, "path");
-        ConfigInputFormat.req(refTokenPositionIdPath, t, "refTokenPositionIdPath");
+        ConfigInputFormat.req(tokenRefPath, t, "tokenRefPath");
         for (ConfigAnnotation a : annotations.values())
             a.validate();
     }
 
     public ConfigStandoffAnnotations copy() {
-        ConfigStandoffAnnotations result = new ConfigStandoffAnnotations(path, refTokenPositionIdPath);
+        ConfigStandoffAnnotations result = new ConfigStandoffAnnotations(path, tokenRefPath);
         for (ConfigAnnotation a : annotations.values()) {
             result.addAnnotation(a.copy());
         }
@@ -56,12 +56,28 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
         this.path = path;
     }
 
+    /**
+     * @deprecated renamed to { @link {@link #getTokenRefPath() }
+     */
+    @Deprecated
     public String getRefTokenPositionIdPath() {
-        return refTokenPositionIdPath;
+        return getTokenRefPath();
     }
 
-    public void setRefTokenPositionIdPath(String refTokenPositionIdPath) {
-        this.refTokenPositionIdPath = refTokenPositionIdPath;
+    /**
+     * @deprecated renamed to { @link {@link #setTokenRefPath(String) }
+     */
+    @Deprecated
+    public void setRefTokenPositionIdPath(String path) {
+        setTokenRefPath(path);
+    }
+
+    public String getTokenRefPath() {
+        return tokenRefPath;
+    }
+
+    public void setTokenRefPath(String path) {
+        this.tokenRefPath = path;
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
@@ -30,7 +30,7 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
     private String spanEndPath = "";
 
     /**
-     * If this is a span, does spanEndpath refer to the last token inside the span (inclusive)
+     * If this is a span, does spanEndPath refer to the last token inside the span (inclusive)
      * or the first token outside the span (exclusive)?
      */
     private boolean spanEndIsInclusive = true;

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/ConfigStandoffAnnotations.java
@@ -18,8 +18,28 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
     /**
      * Unique id of the token position(s) to index these values at. A uniqueId must
      * be defined for words.
+     * If this is a span (that is, spanEndPath is not empty), this refers to the start of
+     * the span.
      */
     private String tokenRefPath;
+
+    /**
+     * How to find the end of the span. If non-empty, this is a span annotation instead of
+     * a regular one.
+     */
+    private String spanEndPath = "";
+
+    /**
+     * If this is a span, does spanEndpath refer to the last token inside the span (inclusive)
+     * or the first token outside the span (exclusive)?
+     */
+    private boolean spanEndIsInclusive = true;
+
+    /**
+     * XPath needed to find the name of the span, if this is one (i.e. spanEndPath is non-empty).
+     * E.g. for a sentence this will usually resolve to "s".
+     */
+    private String spanNamePath;
 
     /** The annotations to index at the referenced token positions. */
     private final Map<String, ConfigAnnotation> annotations = new LinkedHashMap<>();
@@ -78,6 +98,30 @@ public class ConfigStandoffAnnotations implements ConfigWithAnnotations {
 
     public void setTokenRefPath(String path) {
         this.tokenRefPath = path;
+    }
+
+    public String getSpanEndPath() {
+        return spanEndPath;
+    }
+
+    public void setSpanEndPath(String spanEndPath) {
+        this.spanEndPath = spanEndPath;
+    }
+
+    public boolean isSpanEndIsInclusive() {
+        return spanEndIsInclusive;
+    }
+
+    public void setSpanEndIsInclusive(boolean spanEndIsInclusive) {
+        this.spanEndIsInclusive = spanEndIsInclusive;
+    }
+
+    public String getSpanNamePath() {
+        return spanNamePath;
+    }
+
+    public void setSpanNamePath(String spanNamePath) {
+        this.spanNamePath = spanNamePath;
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -534,7 +534,6 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
      * calls {@link #getCharacterPosition()}
      */
     protected void endWord() {
-
         String punct;
         if (punctuation.length() == 0)
             punct = addDefaultPunctuation && !preventNextDefaultPunctuation ? " " : "";

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -555,6 +555,10 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
             punctuation.setLength(0);
     }
 
+    protected void annotation(String name, String value, int increment, List<Integer> indexAtPositions) {
+        annotation(name, value, increment, indexAtPositions, -1, null);
+    }
+
     /**
      * Index an annotation.
      *
@@ -569,17 +573,28 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
      * @param increment if indexAtPosition == null: the token increment to use
      * @param indexAtPositions if null: index at the current position; otherwise:
      *            index at these positions
+     * @param spanEndPos if >= 0, this is a span annotation and this is the first token position after the span
+     * @param spanName span name if this is a span annotation
      */
-    protected void annotation(String name, String value, int increment, List<Integer> indexAtPositions) {
-        AnnotationWriter annotation = getAnnotation(name);
+    protected void annotation(String name, String value, int increment, List<Integer> indexAtPositions,
+            int spanEndPos, String spanName) {
+        AnnotationWriter annotation = getAnnotation(spanEndPos >= 0 ? AnnotatedFieldNameUtil.TAGS_ANNOT_NAME : name);
         if (annotation != null) {
+            BytesRef payload = null;
+            if (spanEndPos >= 0) {
+                // This is a span annotation. These are all indexed in one Lucene field (the annotation called "starttag")
+                // with the attribute name and value combined.
+                payload = PayloadUtils.tagEndPositionPayload(spanEndPos);
+                value = AnnotatedFieldNameUtil.tagAttributeIndexValue(name, value);
+            }
             if (indexAtPositions == null) {
+                int position = annotation.lastValuePosition() + increment;
                 if (name.equals(AnnotatedFieldNameUtil.DEFAULT_MAIN_ANNOT_NAME))
                     trace(value + " ");
-                annotation.addValue(value, increment);
+                annotation.addValueAtPosition(value, position, payload);
             } else {
                 for (Integer position : indexAtPositions) {
-                    annotation.addValueAtPosition(value, position, null);
+                    annotation.addValueAtPosition(value, position, payload);
                 }
             }
         } else {

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -46,14 +46,6 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
     private static final boolean TRACE = false;
 
     /**
-     * Keep track of the last position of the main annotation at the start
-     * of a word, so we can track that each word gets a value for the main
-     * annotation (even if it's an empty string). This is necessary for character
-     * offsets for each position to be stored.
-     */
-    private int lastMainAnnotPosition;
-
-    /**
      * Position of start tags and their index in the annotation arrays, so we can add
      * payload when we find the end tags
      */
@@ -536,20 +528,12 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
      */
     protected void beginWord() {
         addStartChar(getCharacterPosition());
-        lastMainAnnotPosition = annotMain.lastValuePosition();
     }
 
     /**
      * calls {@link #getCharacterPosition()}
      */
     protected void endWord() {
-
-        if (annotMain.lastValuePosition() == lastMainAnnotPosition) {
-            // No value was indexed for the main annotation. Rectify this, so character offsets will be stored
-            // correctly for this position.
-            // (this normally shouldn't happen, but just in case)
-            annotMain.addValue("");
-        }
 
         String punct;
         if (punctuation.length() == 0)

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -346,13 +346,19 @@ public class DocIndexerXPath extends DocIndexerConfig {
 
                 // Capture tokenId for this token position?
                 if (apTokenId != null) {
+                    navpush();
                     apTokenId.resetXPath();
                     String tokenId = apTokenId.evalXPathToString();
                     tokenPositionsMap.put(tokenId, getCurrentTokenPosition());
+                    navpop();
                 }
 
                 // Does an inline object occur before this word?
                 long wordFragment = nav.getContentFragment();
+                if (wordFragment < 0) {
+                    // Self-closing tag; use the element fragment instead
+                    wordFragment = nav.getElementFragment();
+                }
                 int wordOffset = (int) wordFragment;
                 while (nextInlineObject != null && wordOffset >= nextInlineObject.getOffset()) {
                     // Yes. Handle it.

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -287,6 +287,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
             List<InlineObject> tagsAndPunct = new ArrayList<>();
             int i = 0;
             for (AutoPilot apInlineTag : apsInlineTag) {
+                // If we want to capture token ids for this inline tag, create the AutoPilot for this
                 ConfigInlineTag configInlineTag = annotatedField.getInlineTags().get(i);
                 String inlineTagTokenIdPath = configInlineTag.getTokenIdPath();
                 AutoPilot apTokenIdPath = null;
@@ -294,6 +295,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
                     apTokenIdPath = acquireAutoPilot(inlineTagTokenIdPath);
                 }
 
+                // Collect the occurrences of this inline tag
                 navpush();
                 apInlineTag.resetXPath();
                 while (apInlineTag.evalXPath() != -1) {
@@ -424,7 +426,6 @@ public class DocIndexerXPath extends DocIndexerConfig {
             AutoPilot apStandoff = acquireAutoPilot(standoff.getPath());
             AutoPilot apTokenPos = acquireAutoPilot(standoff.getTokenRefPath());
             AutoPilot apSpanEnd = null, apSpanName = null;
-            boolean spanEndIsInclusive = standoff.isSpanEndIsInclusive();
             if (!StringUtils.isEmpty(standoff.getSpanEndPath())) {
                 // This is a span annotation. Also get XPaths for span end and name.
                 apSpanEnd = acquireAutoPilot(standoff.getSpanEndPath());
@@ -448,6 +449,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
                 navpop();
 
                 if (apSpanEnd != null) {
+                    // Standoff span annotation. Find span end and name.
                     int spanEndPos = tokenPositions == null || tokenPositions.isEmpty() ? -1 : tokenPositions.get(0);
                     String spanName = "span";
                     navpush();
@@ -462,7 +464,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
                             spanEndPos = tokenPositionsMap.get(tokenId);
                         }
                     }
-                    if (spanEndIsInclusive) {
+                    if (standoff.isSpanEndIsInclusive()) {
                         // The matched token should be included in the span, but we always store
                         // the first token outside the span as the end. Adjust the position accordingly.
                         spanEndPos++;

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -265,10 +265,10 @@ public class DocIndexerXPath extends DocIndexerConfig {
         AutoPilot apPunct = null;
         if (annotatedField.getPunctPath() != null)
             apPunct = acquireAutoPilot(annotatedField.getPunctPath());
-        String tokenPositionIdPath = annotatedField.getTokenPositionIdPath();
-        AutoPilot apTokenPositionId = null;
-        if (tokenPositionIdPath != null) {
-            apTokenPositionId = acquireAutoPilot(tokenPositionIdPath);
+        String tokenIdPath = annotatedField.getTokenIdPath();
+        AutoPilot apTokenId = null;
+        if (tokenIdPath != null) {
+            apTokenId = acquireAutoPilot(tokenIdPath);
         }
 
         // For each body element...
@@ -332,11 +332,11 @@ public class DocIndexerXPath extends DocIndexerConfig {
             for (Pair<Integer, BookMark> wordPosition : wordPositions) {
                 wordPosition.getValue().setCursorPosition();
 
-                // Capture tokenPositionId for this token position?
-                if (apTokenPositionId != null) {
-                    apTokenPositionId.resetXPath();
-                    String tokenPositionId = apTokenPositionId.evalXPathToString();
-                    tokenPositionsMap.put(tokenPositionId, getCurrentTokenPosition());
+                // Capture tokenId for this token position?
+                if (apTokenId != null) {
+                    apTokenId.resetXPath();
+                    String tokenId = apTokenId.evalXPathToString();
+                    tokenPositionsMap.put(tokenId, getCurrentTokenPosition());
                 }
 
                 // Does an inline object occur before this word?
@@ -398,7 +398,7 @@ public class DocIndexerXPath extends DocIndexerConfig {
             // For each instance of this standoff annotation..
             navpush();
             AutoPilot apStandoff = acquireAutoPilot(standoff.getPath());
-            AutoPilot apTokenPos = acquireAutoPilot(standoff.getRefTokenPositionIdPath());
+            AutoPilot apTokenPos = acquireAutoPilot(standoff.getTokenRefPath());
             while (apStandoff.evalXPath() != -1) {
 
                 // Determine what token positions to index these values at
@@ -432,8 +432,8 @@ public class DocIndexerXPath extends DocIndexerConfig {
         }
         if (apPunct != null)
             releaseAutoPilot(apPunct);
-        if (apTokenPositionId != null)
-            releaseAutoPilot(apTokenPositionId);
+        if (apTokenId != null)
+            releaseAutoPilot(apTokenId);
         releaseAutoPilot(bodies);
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -249,6 +249,13 @@ public class DocIndexerXPath extends DocIndexerConfig {
 
     protected void processAnnotatedField(ConfigAnnotatedField annotatedField)
             throws VTDException {
+        // This is where we'll capture token ("word") ids and remember the position associated with each id.
+        // In the case to <tei:anchor> between tokens, these are also stored here (referring to the token position after
+        // the anchor).
+        // This is used for standoff annotations, that refer back to the captured ids to add annotations later.
+        // Standoff span annotations are also supported.
+        // The full documentation is available here:
+        // https://inl.github.io/BlackLab/guide/how-to-configure-indexing.html#standoff-annotations
         Map<String, Integer> tokenPositionsMap = new HashMap<>();
 
         // Determine some useful stuff about the field we're processing

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/InlineObject.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/InlineObject.java
@@ -33,7 +33,15 @@ class InlineObject implements Comparable<InlineObject> {
 
     private Map<String, String> attributes;
 
+    /** An open tag's token id, for if we want to capture e.g. tei:anchor positions to refer to later
+     *  from standoff annotations. If null, don't capture token ids. */
+    private String tokenId;
+
     public InlineObject(String text, int offset, InlineObjectType type, Map<String, String> attributes) {
+        this(text, offset, type, attributes, null);
+    }
+
+    public InlineObject(String text, int offset, InlineObjectType type, Map<String, String> attributes, String tokenId) {
         super();
         this.text = text;
         this.offset = offset;
@@ -43,6 +51,7 @@ class InlineObject implements Comparable<InlineObject> {
         this.attributes = Collections.emptyMap();
         if (attributes != null)
             this.attributes = attributes;
+        this.tokenId = tokenId;
     }
 
     public String getText() {
@@ -132,6 +141,10 @@ class InlineObject implements Comparable<InlineObject> {
         } else if (!text.equals(other.text))
             return false;
         return type == other.type;
+    }
+
+    public String getTokenId() {
+        return tokenId;
     }
 
 }

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
@@ -349,8 +349,9 @@ public class InputFormatReader extends YamlJsonReader {
                 case "wordPath":
                     af.setWordPath(str(e));
                     break;
-                case "tokenPositionIdPath":
-                    af.setTokenPositionIdPath(str(e));
+                case "tokenPositionIdPath": // old name, DEPRECATED
+                case "tokenIdPath":
+                    af.setTokenIdPath(str(e));
                     break;
                 case "punctPath":
                     af.setPunctPath(str(e));
@@ -488,8 +489,9 @@ public class InputFormatReader extends YamlJsonReader {
                 case "path":
                     s.setPath(str(e));
                     break;
-                case "refTokenPositionIdPath":
-                    s.setRefTokenPositionIdPath(str(e));
+                case "refTokenPositionIdPath": // old name, DEPRECATED
+                case "tokenRefPath":
+                    s.setTokenRefPath(str(e));
                     break;
                 case "annotations":
                     readAnnotations(e, s);

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
@@ -491,7 +491,17 @@ public class InputFormatReader extends YamlJsonReader {
                     break;
                 case "refTokenPositionIdPath": // old name, DEPRECATED
                 case "tokenRefPath":
+                case "spanStartPath":   // synonym for tokenRefPath, used in case of span annotation
                     s.setTokenRefPath(str(e));
+                    break;
+                case "spanEndPath":
+                    s.setSpanEndPath(str(e));
+                    break;
+                case "spanEndIsInclusive":
+                    s.setSpanEndIsInclusive(bool(e));
+                    break;
+                case "spanNamePath":
+                    s.setSpanNamePath(str(e));
                     break;
                 case "annotations":
                     readAnnotations(e, s);

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/InputFormatReader.java
@@ -530,6 +530,9 @@ public class InputFormatReader extends YamlJsonReader {
                 case "displayAs":
                     t.setDisplayAs(str(e));
                     break;
+                case "tokenIdPath":
+                    t.setTokenIdPath(str(e));
+                    break;
                 default:
                     throw new InvalidInputFormatConfig("Unknown key " + e.getKey() + " in inline tag " + t.getPath());
                 }

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -1,0 +1,21 @@
+package nl.inl.blacklab.index;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import nl.inl.blacklab.indexers.config.ConfigInputFormat;
+
+public class TestStandoffSpans {
+
+    @Test
+    public void testDuplicatObjects() throws IOException {
+        DocIndexerFactoryConfig factoryConfig = new DocIndexerFactoryConfig();
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        File file = new File(classLoader.getResource("standoff/tei-standoff-spans.blf.yaml").getFile());
+        ConfigInputFormat fmt = factoryConfig.load("tei-standoff-spans", file).orElseThrow();
+        System.err.println("BLA");
+    }
+
+}

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -15,7 +15,6 @@ public class TestStandoffSpans {
         ClassLoader classLoader = this.getClass().getClassLoader();
         File file = new File(classLoader.getResource("standoff/tei-standoff-spans.blf.yaml").getFile());
         ConfigInputFormat fmt = factoryConfig.load("tei-standoff-spans", file).orElseThrow();
-        System.err.println("BLA");
     }
 
 }

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -3,18 +3,89 @@ package nl.inl.blacklab.index;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import nl.inl.blacklab.indexers.config.ConfigInputFormat;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+import nl.inl.blacklab.exceptions.DocumentFormatNotFound;
+import nl.inl.blacklab.exceptions.ErrorOpeningIndex;
+import nl.inl.blacklab.exceptions.InvalidQuery;
+import nl.inl.blacklab.search.BlackLab;
+import nl.inl.blacklab.search.BlackLabIndex;
+import nl.inl.blacklab.search.BlackLabIndexWriter;
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
+import nl.inl.blacklab.search.lucene.BLSpanQuery;
+import nl.inl.blacklab.search.lucene.SpanQueryTags;
+import nl.inl.blacklab.search.results.Hits;
+import nl.inl.blacklab.searches.SearchEmpty;
+import nl.inl.util.UtilsForTesting;
 
 public class TestStandoffSpans {
 
+    public static final String TEST_FORMAT_NAME = "tei-standoff-spans";
+
+    private static DocIndexerFactoryConfig factoryConfig;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        factoryConfig = new DocIndexerFactoryConfig();
+        File file = getFile("standoff/tei-standoff-spans.blf.yaml");
+        factoryConfig.load(TEST_FORMAT_NAME, file).orElseThrow();
+        DocumentFormats.registerFactory(factoryConfig);
+    }
+
+    private static File getFile(String path) {
+        ClassLoader classLoader = TestStandoffSpans.class.getClassLoader();
+        return new File(classLoader.getResource(path).getFile());
+    }
+
+    private static BlackLabIndex createTestIndex() {
+        File indexDir = UtilsForTesting.createBlackLabTestDir("TestIndex");
+        // Instantiate the BlackLab indexer, supplying our DocIndexer class
+        try {
+            BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true,
+                    TEST_FORMAT_NAME);
+            Indexer indexer = Indexer.get(indexWriter);
+            indexer.setListener(new IndexListener() {
+                @Override
+                public boolean errorOccurred(Throwable e, String path, File f) {
+                    System.err.println("Error while indexing. path=" + path + ", file=" + f);
+                    e.printStackTrace();
+                    return false; // don't continue
+                }
+            });
+            try {
+                indexer.index(getFile("standoff/test.xml"));
+            } finally {
+                // Finalize and close the index.
+                indexer.close();
+            }
+
+            // Create the BlackLab index object
+            return BlackLab.open(indexDir);
+        } catch (DocumentFormatNotFound | ErrorOpeningIndex e) {
+            throw BlackLabRuntimeException.wrap(e);
+        }
+    }
+
     @Test
-    public void testDuplicatObjects() throws IOException {
-        DocIndexerFactoryConfig factoryConfig = new DocIndexerFactoryConfig();
-        ClassLoader classLoader = this.getClass().getClassLoader();
-        File file = new File(classLoader.getResource("standoff/tei-standoff-spans.blf.yaml").getFile());
-        ConfigInputFormat fmt = factoryConfig.load("tei-standoff-spans", file).orElseThrow();
+    public void testStandoffSpans() throws IOException, InvalidQuery {
+        File testDir;
+        try (BlackLabIndex index = createTestIndex()) {
+            testDir = index.indexDirectory();
+            SearchEmpty s = index.search();
+            String fieldName = index.mainAnnotatedField().tagsAnnotation().
+                    sensitivity(MatchSensitivity.SENSITIVE).luceneField();
+            BLSpanQuery query = new SpanQueryTags(s.queryInfo(), fieldName,
+                    "speech-rate", null);
+            Hits results = s.find(query).execute();
+            Assert.assertEquals(5, results.size());
+            Assert.assertEquals(0, results.get(0).start());
+            Assert.assertEquals(6, results.get(0).end()); // FAILS, actually 7, but that's wrong
+        }
+        FileUtils.deleteDirectory(testDir);
     }
 
 }

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -81,9 +81,11 @@ public class TestStandoffSpans {
             BLSpanQuery query = new SpanQueryTags(s.queryInfo(), fieldName,
                     "speech-rate", null);
             Hits results = s.find(query).execute();
-            Assert.assertEquals(5, results.size());
+            Assert.assertEquals(2, results.size());
             Assert.assertEquals(0, results.get(0).start());
-            Assert.assertEquals(6, results.get(0).end()); // FAILS, actually 7, but that's wrong
+            Assert.assertEquals(2, results.get(0).end()); // FAILS, actually 3, but that's wrong
+            Assert.assertEquals(3, results.get(1).start());
+            Assert.assertEquals(5, results.get(1).end());
         }
         FileUtils.deleteDirectory(testDir);
     }

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -26,11 +26,9 @@ public class TestStandoffSpans {
 
     public static final String TEST_FORMAT_NAME = "tei-standoff-spans";
 
-    private static DocIndexerFactoryConfig factoryConfig;
-
     @BeforeClass
     public static void setup() throws IOException {
-        factoryConfig = new DocIndexerFactoryConfig();
+        DocIndexerFactoryConfig factoryConfig = new DocIndexerFactoryConfig();
         File file = getFile("standoff/tei-standoff-spans.blf.yaml");
         factoryConfig.load(TEST_FORMAT_NAME, file).orElseThrow();
         DocumentFormats.registerFactory(factoryConfig);
@@ -79,7 +77,7 @@ public class TestStandoffSpans {
             String fieldName = index.mainAnnotatedField().tagsAnnotation().
                     sensitivity(MatchSensitivity.SENSITIVE).luceneField();
             BLSpanQuery query = new SpanQueryTags(s.queryInfo(), fieldName,
-                    "speech-rate", null);
+                    "character", null);
             Hits results = s.find(query).execute();
             Assert.assertEquals(2, results.size());
             Assert.assertEquals(0, results.get(0).start());

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -1,5 +1,6 @@
 namespaces:
-  'xml': http://www.w3.org/XML/1998/namespace
+    '': http://www.tei-c.org/ns/1.0
+    'tei': http://www.tei-c.org/ns/1.0
 
 documentPath: /TEI
 
@@ -38,7 +39,7 @@ annotatedFields:
       valuePath: "@type"
 
     standoffAnnotations:
-    - path: spanGrp[not(@subtype)]/span
+    - path: .//tei:spanGrp[not(@subtype)]/tei:span
 
       #tokenRefPath: "@ref"        # for annotation on single token (renamed from "refTokenPositionIdPath")
       # For span annotation: first and last token, and XPath to determine span name
@@ -51,7 +52,7 @@ annotatedFields:
         - name: value
           valuePath: .
 
-    - path: spanGrp[@subtype="time-based"]/span
+    - path: .//tei:spanGrp[@subtype="time-based"]/tei:span
 
       spanStartPath: "@from"
       spanEndPath: "@to"

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -38,6 +38,10 @@ annotatedFields:
     - name: type
       valuePath: "@type"
 
+    # Index the element name so we can distinguish between w/pause/incident/vocal
+    - name: element
+      valuePath: name()
+
     standoffAnnotations:
     - path: .//tei:spanGrp[not(@subtype)]/tei:span
 

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -1,0 +1,81 @@
+namespaces:
+  'xml': http://www.w3.org/XML/1998/namespace
+
+documentPath: /TEI
+
+annotatedFields:
+
+  contents:
+
+    containerPath: .//text
+
+    # All w, pause, incident and vocal elements should be indexed as separate tokens ("words")
+    # Note that this will treat all these elements the same (i.e. apply the valuePaths declared
+    # in the annotations on them).
+    wordPath: .//*[self::w or self::pause or self::incident or self::vocal]
+
+    # Remember xml:id attribute for each token so we can refer to them from standoff annotations
+    tokenIdPath: "@xml:id"     # (renamed from "tokenPositionIdPath")
+
+    annotations:
+
+    - name: word
+      valuePath: .
+      sensitivity: sensitive_insensitive
+
+    - name: norm
+      valuePath: "@norm"
+      sensitivity: sensitive_insensitive
+
+    - name: lemma
+      valuePath: "@lemma"
+      sensitivity: sensitive_insensitive
+
+    - name: phon
+      valuePath: "@phon"
+
+    - name: type
+      valuePath: "@type"
+
+    standoffAnnotations:
+    - path: "spanGrp[not(@subtype)]/span"
+
+      #tokenRefPath: "@ref"        # for annotation on single token (renamed from "refTokenPositionIdPath")
+      # For span annotation
+      spanStartPath: "@from"
+      spanEndPath: "@to"
+      spanEndIsInclusive: true
+      spanNamePath: ./parent::node()/@type  # XPath to determine spanName
+
+      annotations:
+        - name: value
+          valuePath: .
+
+    - path: "spanGrp[@subtype=\"time-based\"]/span"
+
+      spanStartPath: "@from"
+      spanEndPath: "@to"
+      spanEndIsInclusive: false
+      spanNamePath: ./parent::node()/@type  # XPath to determine spanName
+
+      annotations:
+
+        - name: target
+          valuePath: "@target"
+
+        - name: value
+          valuePath: .
+
+
+    inlineTags:
+    - path: .//annotationBlock   # user contribution
+
+      # NOTE: attributes for inlineTags are be indexed automatically,
+      #       no need to declare them
+      #annotations:
+      #  - name: speaker
+      #    valuePath: "@who"
+
+    - path: .//anchor
+      # Remember synch attribute for each anchor so we can refer to them from standoff annotations
+      tokenIdPath: "@synch"

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -1,19 +1,19 @@
+# XPath can have issues requires namespace prefixes in documents that use namespaces
 namespaces:
-    '': http://www.tei-c.org/ns/1.0
     'tei': http://www.tei-c.org/ns/1.0
 
-documentPath: /TEI
+documentPath: /tei:TEI
 
 annotatedFields:
 
   contents:
 
-    containerPath: .//text
+    containerPath: .//tei:text
 
     # All w, pause, incident and vocal elements should be indexed as separate tokens ("words")
     # Note that this will treat all these elements the same (i.e. apply the valuePaths declared
     # in the annotations on them).
-    wordPath: .//*[self::w or self::pause or self::incident or self::vocal]
+    wordPath: .//*[self::tei:w or self::tei:pause or self::tei:incident or self::tei:vocal]
 
     # Remember xml:id attribute for each token so we can refer to them from standoff annotations
     tokenIdPath: "@xml:id"     # (renamed from "tokenPositionIdPath")
@@ -69,14 +69,15 @@ annotatedFields:
 
 
     inlineTags:
-    - path: .//annotationBlock   # user contribution
+    - path: .//tei:annotationBlock   # user contribution
 
       # NOTE: attributes for inlineTags are be indexed automatically,
       #       no need to declare them
+      #       (also, declaring custom annotations on inline tags is not supported ATM)
       #annotations:
       #  - name: speaker
       #    valuePath: "@who"
 
-    - path: .//anchor
+    - path: .//tei:anchor
       # Remember synch attribute for each anchor so we can refer to them from standoff annotations
       tokenIdPath: "@synch"

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -38,20 +38,20 @@ annotatedFields:
       valuePath: "@type"
 
     standoffAnnotations:
-    - path: "spanGrp[not(@subtype)]/span"
+    - path: spanGrp[not(@subtype)]/span
 
       #tokenRefPath: "@ref"        # for annotation on single token (renamed from "refTokenPositionIdPath")
-      # For span annotation
+      # For span annotation: first and last token, and XPath to determine span name
       spanStartPath: "@from"
       spanEndPath: "@to"
       spanEndIsInclusive: true
-      spanNamePath: ./parent::node()/@type  # XPath to determine spanName
+      spanNamePath: ./parent::node()/@type
 
       annotations:
         - name: value
           valuePath: .
 
-    - path: "spanGrp[@subtype=\"time-based\"]/span"
+    - path: spanGrp[@subtype="time-based"]/span
 
       spanStartPath: "@from"
       spanEndPath: "@to"

--- a/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
+++ b/engine/src/test/resources/standoff/tei-standoff-spans.blf.yaml
@@ -1,3 +1,8 @@
+# Test configuration for standoff span annotations, i.e.
+# standoff annotations that apply to spans of tokens instead of a single token.
+# Note that we refer to token positions both by w/@xml:id (regular word ids)
+# as well as anchor/@synch (attribute on an inlineTag)
+
 # XPath can have issues requires namespace prefixes in documents that use namespaces
 namespaces:
     'tei': http://www.tei-c.org/ns/1.0
@@ -76,11 +81,8 @@ annotatedFields:
     - path: .//tei:annotationBlock   # user contribution
 
       # NOTE: attributes for inlineTags are be indexed automatically,
-      #       no need to declare them
-      #       (also, declaring custom annotations on inline tags is not supported ATM)
-      #annotations:
-      #  - name: speaker
-      #    valuePath: "@who"
+      #   no need to declare them
+      #   (also, declaring custom annotations on inline tags is not supported ATM)
 
     - path: .//tei:anchor
       # Remember synch attribute for each anchor so we can refer to them from standoff annotations

--- a/engine/src/test/resources/standoff/test.xml
+++ b/engine/src/test/resources/standoff/test.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Test data for standoff span annotations (spanGrp/span elements),
+     referring to token positions by both w/@xml:id and anchor/@synch -->
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <text>
     <body>
@@ -7,8 +9,8 @@
         <w xml:id="w1" lemma="Kris">Kris</w>
         <w xml:id="w2" lemma="Kringle">Kringle</w>
         <anchor synch="T2" />
-        <spanGrp type="speech-rate" subtype="time-based">
-          <span from="T1" to="T2">123</span>
+        <spanGrp type="character" subtype="time-based">
+          <span from="T1" to="T2">Santa Claus</span>
         </spanGrp>
       </annotationBlock>
       <pause start="w2" end="w3"/>
@@ -21,16 +23,10 @@
           <desc>short breathe in</desc>
         </vocal>
         <anchor synch="T5"/>
-        <spanGrp type="speech-rate" subtype="time-based">
-          <span from="T3" to="T4">456</span>
-        </spanGrp>
       </annotationBlock>
       <incident start="T4" end="T5">
         <desc>laugh</desc>
-      </incident>    
-      <spanGrp type="character" subtype="time-based">
-        <span from="T1" to="T2">Santa Claus</span>
-      </spanGrp>
+      </incident>
       <spanGrp type="character">
         <span from="w3" to="w4">Easter Bunny</span>
       </spanGrp>

--- a/engine/src/test/resources/standoff/test.xml
+++ b/engine/src/test/resources/standoff/test.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- (a small excerpt from the Archive of Spoken German, https://agd.ids-mannheim.de/, used with permission) -->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <idno type="XXX">T_01</idno>
   <teiHeader>

--- a/engine/src/test/resources/standoff/test.xml
+++ b/engine/src/test/resources/standoff/test.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <idno type="XXX">T_01</idno>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>T_01</title>
+      </titleStmt>
+      <sourceDesc>
+        <recordingStmt>
+          <recording type="audio">
+            <media mimeType="audio/wav"/>
+          </recording>
+        </recordingStmt>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <person xml:id="XX" n="XX">
+          <idno type="AGD-ID">XX</idno>
+          <persName><forename>XX</forename><abbr>XX</abbr></persName>
+        </person>
+        <person xml:id="XY" n="XY">
+          <idno type="AGD-ID">XY</idno>
+          <persName><forename>XY</forename><abbr>XY</abbr></persName>
+        </person>
+      </particDesc>
+    </profileDesc>
+    <encodingDesc>
+      <appInfo>
+        <application ident="FOLKER" version="1.1">
+          <label>FOLK Editor</label>
+          <desc>Transcription Tool providing a TEI Export</desc>
+        </application>
+      </appInfo>
+      <transcriptionDesc ident="cGAT" version="2014">
+        <desc><!--Fill me in--></desc>
+        <label><!--Fill me in--></label>
+      </transcriptionDesc>
+    </encodingDesc>
+    <revisionDesc>
+      <change when="2021-04-23T08:22:57.000">Created by XSL transformation from a FOLKER
+        transcription</change>
+    </revisionDesc>
+  </teiHeader>
+  <text xml:lang="de">
+    <timeline unit="s">
+      <when xml:id="TLI_1525" interval="2300.116" since="TLI_0"/>
+      <when xml:id="TLI_1526" interval="2301.512" since="TLI_0"/>
+      <when xml:id="TLI_1527" interval="2313.26" since="TLI_0"/>
+      <when xml:id="TLI_1528" interval="2315.252" since="TLI_0"/>
+      <when xml:id="TLI_1529" interval="2316.684" since="TLI_0"/>
+      <when xml:id="TLI_1530" interval="2318.24" since="TLI_0"/>
+      <when xml:id="TLI_1531" interval="2320.004" since="TLI_0"/>
+      <when xml:id="TLI_1532" interval="2320.264" since="TLI_0"/>
+      <when xml:id="TLI_1533" interval="2322.236" since="TLI_0"/>
+      <when xml:id="TLI_1534" interval="2323.588" since="TLI_0"/>
+      <when xml:id="TLI_1535" interval="2325.664" since="TLI_0"/>
+    </timeline>
+    <body>
+      <annotationBlock xml:id="c1320" who="XX" start="TLI_1525" end="TLI_1526">
+        <u xml:id="u_d865e16115"><seg type="contribution" xml:id="seg_d865e16115"><anchor
+              synch="TLI_1525"/><w xml:id="w4217" norm="wer" lemma="wer" pos="PWS" phon="veːɐ"
+              >wer</w><w xml:id="w4218" norm="kann" lemma="können" pos="VMFIN" phon="kan">kann</w><w
+              xml:id="w4219" norm="die" lemma="die" pos="PDS" phon="diː">die</w><w xml:id="w4220"
+              norm="noch" lemma="noch" pos="PTKMWL" phon="nɔx">noch</w><w xml:id="w4220a" norm="mal"
+              lemma="mal" pos="ADV" phon="maːl">mal</w><w xml:id="w4221" norm="zusammenfassen"
+              lemma="zusammenfassen" pos="VVINF" phon="tsu.za.mən.fa.sən">zusammenfassen</w><anchor
+              synch="TLI_1526"/></seg></u>
+        <spanGrp type="speech-rate" subtype="time-based">
+          <span from="TLI_1525" to="TLI_1526">7.16</span>
+        </spanGrp>
+      </annotationBlock>
+      <pause xml:id="p839" rend="(11.75)" dur="PT11.75S" start="TLI_1526" end="TLI_1527"/>
+      <annotationBlock xml:id="c1322" who="XX" start="TLI_1527" end="TLI_1529">
+        <u xml:id="u_d865e16134"><seg type="contribution" xml:id="seg_d865e16134"><anchor
+              synch="TLI_1527"/><w xml:id="w4222" norm="NAME" lemma="NAME" pos="NE"
+              phon="na.diːn">XX</w><w xml:id="w4223" norm="kannst" lemma="können" pos="VMFIN"
+              phon="kanst">kannst</w><w xml:id="w4224" norm="Du" lemma="du" pos="PPER" phon="duː"
+              >du</w><w xml:id="w4225" norm="einfach" lemma="einfach" pos="PTKMA" phon="ʔaɪn.fax"
+              >einfach</w><w xml:id="w4226" norm="noch" lemma="noch" pos="PTKMWL" phon="nɔx"
+              >noch</w><w xml:id="w4226a" norm="mal" lemma="mal" pos="ADV" phon="maːl">mal</w><w
+              xml:id="w4227" norm="kurz" lemma="kurz" pos="ADJD" phon="kʊɐts">kurz</w><w
+              xml:id="w4228" norm="wiederholen" lemma="wiederholen" pos="VVINF"
+              phon="viː.dɐ.hoː.lən">wiederholen</w><w xml:id="w4229" norm="was" lemma="was"
+              pos="PWS" phon="vas">was</w><w xml:id="w4230" norm="wir" lemma="wir" pos="PPER"
+              phon="viːɐ">wir</w><w xml:id="w4231" norm="jetzt" lemma="jetzt" pos="ADV" phon="jɛtst"
+              >jetzt</w><anchor synch="TLI_1528"/><vocal xml:id="b115">
+              <desc rend="°h">short breathe in</desc>
+            </vocal><w xml:id="w4232" norm="herausgefunden" lemma="herausfinden" pos="VVPP"
+              phon="hɛr.aʊs.ɡə.fʊn.dən">herausgefunden</w><w xml:id="w4233" norm="haben"
+              lemma="haben" pos="VAINF" phon="haː.bən">haben</w><anchor synch="TLI_1529"/></seg></u>
+        <spanGrp type="speech-rate" subtype="time-based">
+          <span from="TLI_1527" to="TLI_1529">6.72</span>
+        </spanGrp>
+      </annotationBlock>
+      <pause xml:id="p840" rend="(1.56)" dur="PT1.56S" start="TLI_1529" end="TLI_1530"/>
+      <annotationBlock xml:id="c1324" who="XY" start="TLI_1530" end="TLI_1531">
+        <u xml:id="u_d865e16170"><seg type="contribution" xml:id="seg_d865e16170"><anchor
+              synch="TLI_1530"/><w xml:id="w4234" norm="ja" lemma="ja" pos="NGIRR" phon="ja"
+              >ja</w><w xml:id="w4235" norm="dass" lemma="dass" pos="KOUS" phon="das">dass</w><w
+              xml:id="w4236" norm="da" lemma="da" pos="ADV" phon="da">da</w><w xml:id="w4237"
+              norm="halt" lemma="halt" pos="PTKMA" phon="halt">halt</w><w xml:id="w4238"
+              norm="Parallelen" lemma="Parallele" pos="NN" phon="par.a.lə.lən">parallelen</w><w
+              xml:id="w4239" norm="liegen" lemma="liegen" pos="VVINF" phon="liː.ɡən"
+              >liegen</w><anchor synch="TLI_1531"/></seg></u>
+        <spanGrp type="speech-rate" subtype="time-based">
+          <span from="TLI_1530" to="TLI_1531">5.67</span>
+        </spanGrp>
+      </annotationBlock>
+      <pause xml:id="p841" rend="(0.26)" dur="PT0.26S" start="TLI_1531" end="TLI_1532"/>
+      <annotationBlock xml:id="c1326" who="XY" start="TLI_1532" end="TLI_1533">
+        <u xml:id="u_d865e16189"><seg type="contribution" xml:id="seg_d865e16189"><anchor
+              synch="TLI_1532"/><w xml:id="w4240" norm="zwischen" lemma="zwischen" pos="APPR"
+              phon="tsvɪʃ.ən">zwischen</w><w xml:id="w4241" norm="der" lemma="d" pos="ART"
+              phon="deːɐ">der</w><w xml:id="w4242" norm="Parabel" lemma="Parabel" pos="NN"
+              phon="par.aː.bəl">parabel</w><w xml:id="w4243" norm="und" lemma="und" pos="KON"
+              phon="ʔʊnt">und</w><w xml:id="w4244" norm="dem" lemma="d" pos="ART" phon="deːm"
+              >der</w><w xml:id="w4245" norm="Roman" lemma="Roman" pos="NN" phon="ro.maːn"
+              >zeitung</w><anchor synch="TLI_1533"/></seg></u>
+        <spanGrp type="speech-rate" subtype="time-based">
+          <span from="TLI_1532" to="TLI_1533">5.07</span>
+        </spanGrp>
+      </annotationBlock>
+      <annotationBlock xml:id="c1327" who="XX" start="TLI_1533" end="TLI_1534">
+        <u xml:id="u_d865e16204"><seg type="contribution" xml:id="seg_d865e16204"><anchor
+              synch="TLI_1533"/><pause xml:id="p842" rend="(.)" type="micro"/><w xml:id="w4246"
+              norm="okay" lemma="okay" pos="NGIRR" phon="ʔo.keː">okay</w><w xml:id="w4247"
+              norm="das" lemma="die" pos="PDS" phon="dɛs">des</w><w xml:id="w4248" norm="habe"
+              lemma="haben" pos="VAFIN" phon="haːp">hab</w><w xml:id="w4249" norm="ich" lemma="ich"
+              pos="PPER" phon="ʔɪç">ich</w><w xml:id="w4250" norm="grad" lemma="gerade" pos="ADV"
+              phon="ɡraːt">grad</w><w xml:id="w4251" norm="auch" lemma="auch" pos="PTKIFG"
+              phon="ʔaʊx">auch</w><w xml:id="w4252" norm="gesagt" lemma="sagen" pos="VVPP"
+              phon="ɡə.zaːkt">gesagt</w><anchor synch="TLI_1534"/></seg></u>
+        <spanGrp type="speech-rate" subtype="time-based">
+          <span from="TLI_1533" to="TLI_1534">6.66</span>
+        </spanGrp>
+      </annotationBlock>
+      <incident xml:id="n54" start="TLI_1534" end="TLI_1535">
+        <desc rend="((lachen))">lachen</desc>
+      </incident>    
+      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="af">
+        <tei:span from="w4222" to="w4233" who="XX">Kannst Du X?</tei:span>
+      </tei:spanGrp>
+      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="ar">
+        <tei:span target="Kannst Du X?" from="w4234" to="w4245" who="XY"
+          >Bestätigung/Zustimmung/Annahme/Ausführung</tei:span>
+      </tei:spanGrp>
+      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="as" subtype="time-based">
+        <tei:span from="TLI_1525" to="TLI_1538" target="Kannst Du X?"
+          >Frage/Bitte/Aufforderung</tei:span>
+      </tei:spanGrp>
+    </body>
+  </text>
+</TEI>

--- a/engine/src/test/resources/standoff/test.xml
+++ b/engine/src/test/resources/standoff/test.xml
@@ -1,156 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- (a small excerpt from the Archive of Spoken German, https://agd.ids-mannheim.de/, used with permission) -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <idno type="XXX">T_01</idno>
-  <teiHeader>
-    <fileDesc>
-      <titleStmt>
-        <title>T_01</title>
-      </titleStmt>
-      <sourceDesc>
-        <recordingStmt>
-          <recording type="audio">
-            <media mimeType="audio/wav"/>
-          </recording>
-        </recordingStmt>
-      </sourceDesc>
-    </fileDesc>
-    <profileDesc>
-      <particDesc>
-        <person xml:id="XX" n="XX">
-          <idno type="AGD-ID">XX</idno>
-          <persName><forename>XX</forename><abbr>XX</abbr></persName>
-        </person>
-        <person xml:id="XY" n="XY">
-          <idno type="AGD-ID">XY</idno>
-          <persName><forename>XY</forename><abbr>XY</abbr></persName>
-        </person>
-      </particDesc>
-    </profileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application ident="FOLKER" version="1.1">
-          <label>FOLK Editor</label>
-          <desc>Transcription Tool providing a TEI Export</desc>
-        </application>
-      </appInfo>
-      <transcriptionDesc ident="cGAT" version="2014">
-        <desc><!--Fill me in--></desc>
-        <label><!--Fill me in--></label>
-      </transcriptionDesc>
-    </encodingDesc>
-    <revisionDesc>
-      <change when="2021-04-23T08:22:57.000">Created by XSL transformation from a FOLKER
-        transcription</change>
-    </revisionDesc>
-  </teiHeader>
-  <text xml:lang="de">
-    <timeline unit="s">
-      <when xml:id="TLI_1525" interval="2300.116" since="TLI_0"/>
-      <when xml:id="TLI_1526" interval="2301.512" since="TLI_0"/>
-      <when xml:id="TLI_1527" interval="2313.26" since="TLI_0"/>
-      <when xml:id="TLI_1528" interval="2315.252" since="TLI_0"/>
-      <when xml:id="TLI_1529" interval="2316.684" since="TLI_0"/>
-      <when xml:id="TLI_1530" interval="2318.24" since="TLI_0"/>
-      <when xml:id="TLI_1531" interval="2320.004" since="TLI_0"/>
-      <when xml:id="TLI_1532" interval="2320.264" since="TLI_0"/>
-      <when xml:id="TLI_1533" interval="2322.236" since="TLI_0"/>
-      <when xml:id="TLI_1534" interval="2323.588" since="TLI_0"/>
-      <when xml:id="TLI_1535" interval="2325.664" since="TLI_0"/>
-    </timeline>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <text>
     <body>
-      <annotationBlock xml:id="c1320" who="XX" start="TLI_1525" end="TLI_1526">
-        <u xml:id="u_d865e16115"><seg type="contribution" xml:id="seg_d865e16115"><anchor
-              synch="TLI_1525"/><w xml:id="w4217" norm="wer" lemma="wer" pos="PWS" phon="veːɐ"
-              >wer</w><w xml:id="w4218" norm="kann" lemma="können" pos="VMFIN" phon="kan">kann</w><w
-              xml:id="w4219" norm="die" lemma="die" pos="PDS" phon="diː">die</w><w xml:id="w4220"
-              norm="noch" lemma="noch" pos="PTKMWL" phon="nɔx">noch</w><w xml:id="w4220a" norm="mal"
-              lemma="mal" pos="ADV" phon="maːl">mal</w><w xml:id="w4221" norm="zusammenfassen"
-              lemma="zusammenfassen" pos="VVINF" phon="tsu.za.mən.fa.sən">zusammenfassen</w><anchor
-              synch="TLI_1526"/></seg></u>
+      <annotationBlock>
+        <anchor synch="T1" />
+        <w xml:id="w1" lemma="Kris">Kris</w>
+        <w xml:id="w2" lemma="Kringle">Kringle</w>
+        <anchor synch="T2" />
         <spanGrp type="speech-rate" subtype="time-based">
-          <span from="TLI_1525" to="TLI_1526">7.16</span>
+          <span from="T1" to="T2">123</span>
         </spanGrp>
       </annotationBlock>
-      <pause xml:id="p839" rend="(11.75)" dur="PT11.75S" start="TLI_1526" end="TLI_1527"/>
-      <annotationBlock xml:id="c1322" who="XX" start="TLI_1527" end="TLI_1529">
-        <u xml:id="u_d865e16134"><seg type="contribution" xml:id="seg_d865e16134"><anchor
-              synch="TLI_1527"/><w xml:id="w4222" norm="NAME" lemma="NAME" pos="NE"
-              phon="na.diːn">XX</w><w xml:id="w4223" norm="kannst" lemma="können" pos="VMFIN"
-              phon="kanst">kannst</w><w xml:id="w4224" norm="Du" lemma="du" pos="PPER" phon="duː"
-              >du</w><w xml:id="w4225" norm="einfach" lemma="einfach" pos="PTKMA" phon="ʔaɪn.fax"
-              >einfach</w><w xml:id="w4226" norm="noch" lemma="noch" pos="PTKMWL" phon="nɔx"
-              >noch</w><w xml:id="w4226a" norm="mal" lemma="mal" pos="ADV" phon="maːl">mal</w><w
-              xml:id="w4227" norm="kurz" lemma="kurz" pos="ADJD" phon="kʊɐts">kurz</w><w
-              xml:id="w4228" norm="wiederholen" lemma="wiederholen" pos="VVINF"
-              phon="viː.dɐ.hoː.lən">wiederholen</w><w xml:id="w4229" norm="was" lemma="was"
-              pos="PWS" phon="vas">was</w><w xml:id="w4230" norm="wir" lemma="wir" pos="PPER"
-              phon="viːɐ">wir</w><w xml:id="w4231" norm="jetzt" lemma="jetzt" pos="ADV" phon="jɛtst"
-              >jetzt</w><anchor synch="TLI_1528"/><vocal xml:id="b115">
-              <desc rend="°h">short breathe in</desc>
-            </vocal><w xml:id="w4232" norm="herausgefunden" lemma="herausfinden" pos="VVPP"
-              phon="hɛr.aʊs.ɡə.fʊn.dən">herausgefunden</w><w xml:id="w4233" norm="haben"
-              lemma="haben" pos="VAINF" phon="haː.bən">haben</w><anchor synch="TLI_1529"/></seg></u>
+      <pause start="w2" end="w3"/>
+      <annotationBlock>
+        <anchor synch="T3"/>
+        <w xml:id="w3" lemma="Oschter">Oschter</w>
+        <w xml:id="w4" lemma="Haws">Haws</w>
+        <anchor synch="T4"/>
+        <vocal>
+          <desc>short breathe in</desc>
+        </vocal>
+        <anchor synch="T5"/>
         <spanGrp type="speech-rate" subtype="time-based">
-          <span from="TLI_1527" to="TLI_1529">6.72</span>
+          <span from="T3" to="T4">456</span>
         </spanGrp>
       </annotationBlock>
-      <pause xml:id="p840" rend="(1.56)" dur="PT1.56S" start="TLI_1529" end="TLI_1530"/>
-      <annotationBlock xml:id="c1324" who="XY" start="TLI_1530" end="TLI_1531">
-        <u xml:id="u_d865e16170"><seg type="contribution" xml:id="seg_d865e16170"><anchor
-              synch="TLI_1530"/><w xml:id="w4234" norm="ja" lemma="ja" pos="NGIRR" phon="ja"
-              >ja</w><w xml:id="w4235" norm="dass" lemma="dass" pos="KOUS" phon="das">dass</w><w
-              xml:id="w4236" norm="da" lemma="da" pos="ADV" phon="da">da</w><w xml:id="w4237"
-              norm="halt" lemma="halt" pos="PTKMA" phon="halt">halt</w><w xml:id="w4238"
-              norm="Parallelen" lemma="Parallele" pos="NN" phon="par.a.lə.lən">parallelen</w><w
-              xml:id="w4239" norm="liegen" lemma="liegen" pos="VVINF" phon="liː.ɡən"
-              >liegen</w><anchor synch="TLI_1531"/></seg></u>
-        <spanGrp type="speech-rate" subtype="time-based">
-          <span from="TLI_1530" to="TLI_1531">5.67</span>
-        </spanGrp>
-      </annotationBlock>
-      <pause xml:id="p841" rend="(0.26)" dur="PT0.26S" start="TLI_1531" end="TLI_1532"/>
-      <annotationBlock xml:id="c1326" who="XY" start="TLI_1532" end="TLI_1533">
-        <u xml:id="u_d865e16189"><seg type="contribution" xml:id="seg_d865e16189"><anchor
-              synch="TLI_1532"/><w xml:id="w4240" norm="zwischen" lemma="zwischen" pos="APPR"
-              phon="tsvɪʃ.ən">zwischen</w><w xml:id="w4241" norm="der" lemma="d" pos="ART"
-              phon="deːɐ">der</w><w xml:id="w4242" norm="Parabel" lemma="Parabel" pos="NN"
-              phon="par.aː.bəl">parabel</w><w xml:id="w4243" norm="und" lemma="und" pos="KON"
-              phon="ʔʊnt">und</w><w xml:id="w4244" norm="dem" lemma="d" pos="ART" phon="deːm"
-              >der</w><w xml:id="w4245" norm="Roman" lemma="Roman" pos="NN" phon="ro.maːn"
-              >zeitung</w><anchor synch="TLI_1533"/></seg></u>
-        <spanGrp type="speech-rate" subtype="time-based">
-          <span from="TLI_1532" to="TLI_1533">5.07</span>
-        </spanGrp>
-      </annotationBlock>
-      <annotationBlock xml:id="c1327" who="XX" start="TLI_1533" end="TLI_1534">
-        <u xml:id="u_d865e16204"><seg type="contribution" xml:id="seg_d865e16204"><anchor
-              synch="TLI_1533"/><pause xml:id="p842" rend="(.)" type="micro"/><w xml:id="w4246"
-              norm="okay" lemma="okay" pos="NGIRR" phon="ʔo.keː">okay</w><w xml:id="w4247"
-              norm="das" lemma="die" pos="PDS" phon="dɛs">des</w><w xml:id="w4248" norm="habe"
-              lemma="haben" pos="VAFIN" phon="haːp">hab</w><w xml:id="w4249" norm="ich" lemma="ich"
-              pos="PPER" phon="ʔɪç">ich</w><w xml:id="w4250" norm="grad" lemma="gerade" pos="ADV"
-              phon="ɡraːt">grad</w><w xml:id="w4251" norm="auch" lemma="auch" pos="PTKIFG"
-              phon="ʔaʊx">auch</w><w xml:id="w4252" norm="gesagt" lemma="sagen" pos="VVPP"
-              phon="ɡə.zaːkt">gesagt</w><anchor synch="TLI_1534"/></seg></u>
-        <spanGrp type="speech-rate" subtype="time-based">
-          <span from="TLI_1533" to="TLI_1534">6.66</span>
-        </spanGrp>
-      </annotationBlock>
-      <incident xml:id="n54" start="TLI_1534" end="TLI_1535">
-        <desc rend="((lachen))">lachen</desc>
+      <incident start="T4" end="T5">
+        <desc>laugh</desc>
       </incident>    
-      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="af">
-        <tei:span from="w4222" to="w4233" who="XX">Kannst Du X?</tei:span>
-      </tei:spanGrp>
-      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="ar">
-        <tei:span target="Kannst Du X?" from="w4234" to="w4245" who="XY"
-          >Bestätigung/Zustimmung/Annahme/Ausführung</tei:span>
-      </tei:spanGrp>
-      <tei:spanGrp xmlns:tei="http://www.tei-c.org/ns/1.0" type="as" subtype="time-based">
-        <tei:span from="TLI_1525" to="TLI_1538" target="Kannst Du X?"
-          >Frage/Bitte/Aufforderung</tei:span>
-      </tei:spanGrp>
+      <spanGrp type="character" subtype="time-based">
+        <span from="T1" to="T2">Santa Claus</span>
+      </spanGrp>
+      <spanGrp type="character">
+        <span from="w3" to="w4">Easter Bunny</span>
+      </spanGrp>
     </body>
   </text>
 </TEI>

--- a/site/docs/guide/how-to-configure-indexing.md
+++ b/site/docs/guide/how-to-configure-indexing.md
@@ -324,7 +324,7 @@ standoffAnnotations:
       valuePath: "@speed"
 ```
 
-Note the use of `spanEndIsInclusive: true` to signify that the `to` attribute refers to the last token of the span, not the first token _after_ the span (which is the default, the same as how hit positions are reported by BlackLab Server).
+Note the setting `spanEndIsInclusive: true` to indicate that the `to` attribute refers to the last token of the span, not the first token _after_ the span. (`true` is the default value for this setting, but it is included here for completeness)
 
 The above would allow you to search for `<animal/> containing "fox"` or `<animal speed="fast" />` to find "The quick brown fox".
 
@@ -376,8 +376,7 @@ Note the use of `spanEndIsInclusive: false` because the anchor id that `to` refe
 
 ### Standoff annotations without a unique token id
 
-There is an alternate way of doing standoff annotations that does not rely on a unique token id like the method described
-above (although you will need some way to connect the standoff annotation to the word, obviously). It is not recommended as it is likely to be significantly slower, but in some cases, it may be useful.
+There is an alternate way of doing standoff annotations that does not rely on a unique token id like the method described above (although you will need some way to connect the standoff annotation to the word, obviously). This will probably be slower, but in some cases, it may be useful.
 
 Let's say you want to index a color with every word, and your document looks like this:
 
@@ -400,14 +399,14 @@ Let's say you want to index a color with every word, and your document looks lik
 </root>
 ```
 
-A standoff annotation of this type is defined in the same section as regular non-standoff annotations. It relies on capturing one or more values to help us locate the color we want to index at each position. These captured values are then substituted in the valuePath that fetches the color value:
+A standoff annotation of this type is defined in the same section as regular (non-standoff) annotations. It relies on capturing one or more values to help us locate the color we want to index at each position. These captured values are then substituted in the valuePath that fetches the color value:
 
 ```yaml
 - name: color
   captureValuePaths:                  # value(s) we need from the current word to find the color
   - "@colorId"
   valuePath: /root/colors[@id='$1']   # how to get the value for this annotation from the document,
-                                          # using the value(s) captured.
+                                      # using the value(s) captured.
 ```
 
 ## Subannotations

--- a/site/docs/guide/how-to-configure-indexing.md
+++ b/site/docs/guide/how-to-configure-indexing.md
@@ -270,7 +270,7 @@ annotatedFields:
     
     # If specified, the token position for each id will be saved,
     # so you can index standoff annotations referring to this id later.
-    tokenPositionIdPath: "@id"
+    tokenIdPath: "@id"
 
     annotations:
     - name: word  # First annotation becomes the main annotation
@@ -278,7 +278,7 @@ annotatedFields:
       sensitivity: sensitive_insensitive
     standoffAnnotations:
     - path: standoff/annotation      # Element containing what to index (relative to documentPath)
-      refTokenPositionIdPath: "@ref" # What token position(s) to index these values at
+      tokenRefPath: "@ref" # What token position(s) to index these values at
                                      # (may have multiple matches per path element; values will 
                                      # be indexed at all those positions)
       annotations:           # The actual annotations (structure identical to regular annotations)
@@ -930,7 +930,7 @@ annotatedFields:
 
     # If specified, a mapping from this id to token position will be saved, so we 
     # can refer back to it for standoff annotations later. (relative to wordPath)
-    tokenPositionIdPath: "@xml:id"
+    tokenIdPath: "@xml:id"
 
     # What annotation can each word have? How do we index them?
     # (annotations are also called "(word) properties" in BlackLab)
@@ -976,12 +976,12 @@ annotatedFields:
 
     # Standoff annotations are annotations that are defined separately from the word
     # elements, elsewhere in the same document. To use standoff annotations, you must
-    # define a tokenPositionIdPath (see above). This will make sure you can refer back
+    # define a tokenIdPath (see above). This will make sure you can refer back
     # to token positions so BlackLab knows at what position to index a standoff annotation.
     standoffAnnotations:
     - path: //timesegment               # Element containing the values to index
-      refTokenPositionIdPath: wref/@id  # What token position(s) to index these values at
-                                        # (these refer back to the tokenPositionIdPath values)
+      tokenRefPath: wref/@id  # What token position(s) to index these values at
+                                        # (these refer back to the tokenIdPath values)
       annotations:                      # Annotation(s) to index there
       - name: begintime
         valuePath: ../@begintime        # relative to path


### PR DESCRIPTION
This enables standoff annotations that signify a span of tokens instead of individual tokens. E.g. if instead of 

```xml
<doc>
  <s><w>I</w> <w>am</w>.</s>
</doc>
```

your document looks more like this:

```xml
<doc>
  <w id="w1">I</w> <w id="w2">am</w>.
  <s from="w1" to="w2" />
</doc>
```

Done:
- documentation was updated (check there for more details)
- standoff annotation configuration: `tokenPositionIdPath` was simplified to `tokenIdPath`; similarly `refTokenPositionIdPath` became `tokenRefPath` (old names still work but are deprecated).
- settings `spanStartPath` (synonym of `tokenIdPath`), `spanEndPath`, `spanEndIsInclusive` and `spanNamePath` were added to configure how standoff span annotations are resolved.
- `inlineTags` can now get `tokenIdPath` as well, to allow referring to an `<anchor id="..." />` tag between words. These ids must be distinct from any word ids in the document, though.
- a test was added for standoff span annotations