### PR TITLE
Multiple annotation values in Saxon

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -179,16 +179,14 @@ public class DocIndexerSaxon extends DocIndexerConfig {
                 for (Map.Entry<String, ConfigAnnotation> an : annotatedField.getAnnotations().entrySet()) {
                     ConfigAnnotation annotation = an.getValue();
                     // now supporting multiple values here
-                    if (annotation.isMultipleValues()) {
-                        int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
-                        for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
-                            String value = saxonHelper.getValue(".", val);
-                            annotation(annotation.getName(),value,positionIncrement,null);
-                            positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
+                    int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
+                    for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
+                        String value = saxonHelper.getValue(".", val);
+                        annotation(annotation.getName(),value,positionIncrement,null);
+                        if (annotation.isMultipleValues() == false) {
+                            break; // if multiple were matched, only index the first one
                         }
-                    } else {
-                        String value = saxonHelper.getValue(annotation.getValuePath(),word);
-                        annotation(annotation.getName(),value,1,null);
+                        positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
                     }
                 }
                 charPos = saxonHelper.getEndPos(word);

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -178,9 +178,18 @@ public class DocIndexerSaxon extends DocIndexerConfig {
                 beginWord();
                 for (Map.Entry<String, ConfigAnnotation> an : annotatedField.getAnnotations().entrySet()) {
                     ConfigAnnotation annotation = an.getValue();
-                    // TODO we may need to support multiple values here
-                    String value = saxonHelper.getValue(annotation.getValuePath(),word);
-                    annotation(annotation.getName(),value,1,null);
+                    // now supporting multiple values here
+                    // no support yet for processing steps
+                    int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
+                    for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
+                        if (val instanceof NodeInfo) {
+                            String unprocessedValue = saxonHelper.getValue(".", val);
+                        } else {
+                            String unprocessedValue = String.valueOf(val);
+                        }
+                        annotation(annotation.getName(),unprocessedValue,positionIncrement,null);
+                        positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
+                    }
                 }
                 charPos = saxonHelper.getEndPos(word);
                 endWord();

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -182,10 +182,11 @@ public class DocIndexerSaxon extends DocIndexerConfig {
                     // no support yet for processing steps
                     int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
                     for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
+                        String unprocessedValue;
                         if (val instanceof NodeInfo) {
-                            String unprocessedValue = saxonHelper.getValue(".", val);
+                            unprocessedValue = saxonHelper.getValue(".", val);
                         } else {
-                            String unprocessedValue = String.valueOf(val);
+                            unprocessedValue = String.valueOf(val);
                         }
                         annotation(annotation.getName(),unprocessedValue,positionIncrement,null);
                         positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -179,12 +179,16 @@ public class DocIndexerSaxon extends DocIndexerConfig {
                 for (Map.Entry<String, ConfigAnnotation> an : annotatedField.getAnnotations().entrySet()) {
                     ConfigAnnotation annotation = an.getValue();
                     // now supporting multiple values here
-                    // no support yet for processing steps
-                    int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
-                    for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
-                        String unprocessedValue = saxonHelper.getValue(".", val);
-                        annotation(annotation.getName(),unprocessedValue,positionIncrement,null);
-                        positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
+                    if (annotation.isMultipleValues()) {
+                        int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
+                        for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
+                            String value = saxonHelper.getValue(".", val);
+                            annotation(annotation.getName(),value,positionIncrement,null);
+                            positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
+                        }
+                    } else {
+                        String value = saxonHelper.getValue(annotation.getValuePath(),word);
+                        annotation(annotation.getName(),value,1,null);
                     }
                 }
                 charPos = saxonHelper.getEndPos(word);

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -182,12 +182,7 @@ public class DocIndexerSaxon extends DocIndexerConfig {
                     // no support yet for processing steps
                     int positionIncrement = 1; // the first value should get increment 1; the rest will get 0
                     for (Object val : saxonHelper.find(annotation.getValuePath(),word)) {
-                        String unprocessedValue;
-                        if (val instanceof NodeInfo) {
-                            unprocessedValue = saxonHelper.getValue(".", val);
-                        } else {
-                            unprocessedValue = String.valueOf(val);
-                        }
+                        String unprocessedValue = saxonHelper.getValue(".", val);
                         annotation(annotation.getName(),unprocessedValue,positionIncrement,null);
                         positionIncrement = 0; // only the first value should get increment 1; the rest get 0 (same pos)
                     }


### PR DESCRIPTION
Added basic support for multiple annotation values in Saxon. I've only tested it on my own corpus, but very few changes were needed to make this work, so I don't expect that I have introduced any bugs.