### PR TITLE
Fix: status page throws exception while indexing

### DIFF
--- a/core/src/test/java/nl/inl/blacklab/IndexAndTestExample.java
+++ b/core/src/test/java/nl/inl/blacklab/IndexAndTestExample.java
@@ -80,7 +80,7 @@ public class IndexAndTestExample {
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true,
                     "exampleformat", null);
-            indexer = Indexer.get(indexWriter, "exampleformat");
+            indexer = Indexer.create(indexWriter, "exampleformat");
             for (int i = 0; i < testData.length; i++) {
                 indexer.index("test" + (i + 1), testData[i].getBytes(StandardCharsets.UTF_8));
             }

--- a/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
+++ b/core/src/test/java/nl/inl/blacklab/testutil/TestIndex.java
@@ -202,7 +202,7 @@ public class TestIndex {
         // Instantiate the BlackLab indexer, supplying our DocIndexer class
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, true, TEST_FORMAT_NAME, null, indexType);
-            Indexer indexer = Indexer.get(indexWriter);
+            Indexer indexer = Indexer.create(indexWriter);
             indexer.setListener(new IndexListenerAbortOnError()); // throw on error
             try {
                 // Index each of our test "documents".
@@ -214,7 +214,7 @@ public class TestIndex {
                     // (close and re-open to be sure the document was written to disk first)
                     indexer.close();
                     indexWriter = BlackLab.openForWriting(indexDir, false, null, null, indexType);
-                    indexer = Indexer.get(indexWriter);
+                    indexer = Indexer.create(indexWriter);
                     String luceneField = indexer.indexWriter().metadata().annotatedField("contents").annotation("word").sensitivity(MatchSensitivity.INSENSITIVE).luceneField();
                     indexer.indexWriter().delete(new TermQuery(new Term(luceneField, "dog")));
                 }

--- a/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/Indexer.java
@@ -27,7 +27,7 @@ public interface Indexer {
      * @return the indexer
      * @throws DocumentFormatNotFound if the default format isn't supported
      */
-    static Indexer get(BlackLabIndexWriter writer) throws DocumentFormatNotFound {
+    static Indexer create(BlackLabIndexWriter writer) throws DocumentFormatNotFound {
         return new IndexerImpl(writer, null);
     }
 
@@ -42,12 +42,12 @@ public interface Indexer {
      * @return the indexer
      * @throws DocumentFormatNotFound if the format isn't supported
      */
-    static Indexer get(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
+    static Indexer create(BlackLabIndexWriter writer, String formatIdentifier) throws DocumentFormatNotFound {
         return new IndexerImpl(writer, formatIdentifier);
     }
 
     /**
-     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
+     * @deprecated use {@link #create(BlackLabIndexWriter, String)} with
      *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
@@ -56,7 +56,7 @@ public interface Indexer {
     }
 
     /**
-     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
+     * @deprecated use {@link #create(BlackLabIndexWriter, String)} with
      *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
@@ -65,7 +65,7 @@ public interface Indexer {
     }
 
     /**
-     * @deprecated use {@link #get(BlackLabIndexWriter, String)} with
+     * @deprecated use {@link #create(BlackLabIndexWriter, String)} with
      *   {@link BlackLab#openForWriting(File, boolean, String, File)} instead
      */
     @Deprecated
@@ -216,13 +216,6 @@ public interface Indexer {
      * @param contents file contents 
      */
     default void index(String fileName, byte[] contents) { index(fileName, contents, null); }
-    
-//    /**
-//     * Get our index directory
-//     *
-//     * @return the index directory
-//     */
-//    File indexLocation();
 
     /**
      * The index we're writing to.

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
@@ -119,6 +119,8 @@ public class BlackLabIndexExternal extends BlackLabIndexAbstract {
             ((ForwardIndexAbstract)fi).close();
         }
 
+        // Note that we call super.close() AFTER closing the forward indexes, or our index will momentarily
+        // seem to be "finished" will actually being in an invalid state.
         super.close();
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexExternal.java
@@ -114,12 +114,12 @@ public class BlackLabIndexExternal extends BlackLabIndexAbstract {
 
     @Override
     public void close() {
-        super.close();
-
         // Close the (external) forward indices
         for (ForwardIndex fi: forwardIndices.values()) {
             ((ForwardIndexAbstract)fi).close();
         }
+
+        super.close();
     }
 
     @Override

--- a/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
+++ b/engine/src/test/java/nl/inl/blacklab/index/TestStandoffSpans.java
@@ -45,7 +45,7 @@ public class TestStandoffSpans {
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(testDir.file(), true,
                     TEST_FORMAT_NAME);
-            Indexer indexer = Indexer.get(indexWriter);
+            Indexer indexer = Indexer.create(indexWriter);
             indexer.setListener(new IndexListener() {
                 @Override
                 public boolean errorOccurred(Throwable e, String path, File f) {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -360,7 +360,8 @@ public abstract class RequestHandler {
         // Create the WebserviceParams structure from the UserRequest.
         // We cast to WebserviceParamsImpl because we need to set some fields based on the URL path.
         // Better would be to move that logic into UserRequestBls.
-        params = (WebserviceParamsImpl)userRequest.getParams(blIndex(), operation);
+        BlackLabIndex index = indexMan.getIndex(indexName).getStatus() == IndexStatus.INDEXING ? null : blIndex();
+        params = (WebserviceParamsImpl)userRequest.getParams(index, operation);
     }
 
     protected BlackLabIndex blIndex() throws BlsException {

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -360,14 +361,22 @@ public abstract class RequestHandler {
         // Create the WebserviceParams structure from the UserRequest.
         // We cast to WebserviceParamsImpl because we need to set some fields based on the URL path.
         // Better would be to move that logic into UserRequestBls.
-        BlackLabIndex index = indexMan.getIndex(indexName).getStatus() == IndexStatus.INDEXING ? null : blIndex();
-        params = (WebserviceParamsImpl)userRequest.getParams(index, operation);
+        Optional<Index> index = index();
+        BlackLabIndex blIndex = index.isEmpty() ? null : (index.get().getStatus() == IndexStatus.INDEXING ? null : index.get().blIndex());
+        params = (WebserviceParamsImpl)userRequest.getParams(blIndex, operation);
+    }
+
+    protected Optional<Index> index() {
+        if (indexName.isEmpty() || !indexMan.indexExists(indexName))
+            return Optional.empty();
+        return Optional.of(indexMan.getIndex(indexName));
     }
 
     protected BlackLabIndex blIndex() throws BlsException {
-        if (indexName.isEmpty() || !indexMan.indexExists(indexName))
-            return null;
-        return indexMan.getIndex(indexName).blIndex();
+        Optional<Index> index = index();
+        if (index.isPresent())
+            return index.get().blIndex();
+        return null;
     }
 
     public User getUser() {

--- a/solr/src/main/java/org/ivdnt/blacklab/solr/BLSolrXMLLoader.java
+++ b/solr/src/main/java/org/ivdnt/blacklab/solr/BLSolrXMLLoader.java
@@ -70,7 +70,7 @@ public class BLSolrXMLLoader extends ContentStreamLoader {
         String fileName = params.get("bl.filename");
         String indexName = req.getCore().getName();
         try (BlackLabIndexWriter index = BlackLab.implicitInstance().openForWriting(indexName, reader, format)) {
-            Indexer indexer = Indexer.get(index, params.get("bl.format"));
+            Indexer indexer = Indexer.create(index, params.get("bl.format"));
             InputStream is = stream.getStream();
 
             indexer.index(fileName, is);

--- a/solr/src/main/java/org/ivdnt/blacklab/solr/UserRequestSolr.java
+++ b/solr/src/main/java/org/ivdnt/blacklab/solr/UserRequestSolr.java
@@ -111,7 +111,8 @@ public class UserRequestSolr implements UserRequest {
         if (params.getDocumentFilterQuery().isEmpty()) {
             // No explicit bl.filter specified; use Solr's document results as our filter query
             DocSet docSet = rb.getResults() != null ? rb.getResults().docSet : null;
-            params.setFilterQuery(new DocSetFilter(docSet, index.metadata().metadataDocId()));
+            if (docSet != null && index != null)
+                params.setFilterQuery(new DocSetFilter(docSet, index.metadata().metadataDocId()));
         }
         return params;
     }

--- a/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
+++ b/tools/src/main/java/nl/inl/blacklab/tools/IndexTool.java
@@ -290,7 +290,7 @@ public class IndexTool {
         try {
             BlackLabIndexWriter indexWriter = BlackLab.openForWriting(indexDir, forceCreateNew,
                 formatIdentifier, indexTemplateFile, indexType);
-            indexer = Indexer.get(indexWriter, formatIdentifier);
+            indexer = Indexer.create(indexWriter, formatIdentifier);
         } catch (DocumentFormatNotFound e) {
             System.err.println(e.getMessage());
             usage();

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -49,8 +49,6 @@ import nl.inl.blacklab.server.search.SearchManager;
  */
 public class Index {
 
-    //private static final Logger logger = LogManager.getLogger(Index.class);
-
     private static final String SHARE_WITH_USERS_FILENAME = ".shareWithUsers";
 
     public enum IndexStatus {
@@ -197,8 +195,8 @@ public class Index {
      * @throws ServiceUnavailable when the index is in use.
      */
     // TODO index should not have references to it held for longer times outside of this class
-    // (references should ideally never leave a synchronized(Index) block... [this might not be possible due to simultaneous searches]
-    // (this is a large job)
+    //   (references should ideally never leave a synchronized(Index) block... [this might not be possible due to simultaneous searches]
+    //   (this is a large job)
     public synchronized BlackLabIndex blIndex() throws InternalServerError, ServiceUnavailable {
         openForSearching();
         return index;
@@ -253,11 +251,9 @@ public class Index {
         if (this.index != null)
             return;
 
-        //logger.debug("    Opening index '" + id + "', dir = " + dir);
         try {
             index = searchMan.blackLabInstance().open(this.dir);
             index.setCache(searchMan.getBlackLabCache());
-            //logger.debug("Done opening index '" + id + "'");
         } catch (IndexVersionMismatch e) {
             throw BlsException.indexVersionMismatch(e);
         } catch (ErrorOpeningIndex e) {
@@ -318,7 +314,6 @@ public class Index {
      */
     public synchronized void close() {
         if (this.index != null) {
-//          searchMan.getCache().clearCacheForIndex(this.id);
             searchMan.getBlackLabCache().removeSearchesForIndex(this.index);
 
             this.index.close();

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -232,10 +232,14 @@ public class Index {
     }
 
     public synchronized IndexStatus getStatus() throws BlsException {
+        return IndexStatus.INDEXING; //@@@@DEBUG
+/*  @@@ DEBUG
         if (this.indexer != null && this.indexer.isOpen())
             return IndexStatus.INDEXING;
 
         return this.blIndex().isEmpty() ? IndexStatus.EMPTY : IndexStatus.AVAILABLE;
+
+ */
     }
 
     /**
@@ -305,7 +309,8 @@ public class Index {
         if (this.getStatus() != IndexStatus.INDEXING)
             return null;
 
-        return this.indexer.listener();
+        return new IndexListener();  //@@@DEBUG
+        //@@@DEBUG return this.indexer.listener();
     }
 
     /**

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -266,7 +266,7 @@ public class Index {
     }
 
     /**
-     * Get an Indexer that can be used to add new data to this Index. Only one
+     * Create an Indexer that can be used to add new data to this Index. Only one
      * indexer may be obtained at a time, meaning until the previous indexer can
      * be/has been cleaned up, ServiceUnavailable will be thrown. It is up to the
      * user to close the returned Indexer.
@@ -279,13 +279,13 @@ public class Index {
      * @throws ServiceUnavailable when there is already an Indexer on this Index
      *             that's still processing
      */
-    public synchronized Indexer getIndexer() throws InternalServerError, ServiceUnavailable {
+    public synchronized Indexer createIndexer() throws InternalServerError, ServiceUnavailable {
         cleanupClosedIndexerOrThrow();
         close(); // Close any BlackLabIndex that is still in search mode
         try {
             BlackLabIndexWriter indexWriter = searchMan.blackLabInstance()
                     .openForWriting(this.dir, false);
-            this.indexer = Indexer.get(indexWriter);
+            this.indexer = Indexer.create(indexWriter);
             indexer.setNumberOfThreadsToUse(BlackLab.config().getIndexing().getNumberOfThreads());
         } catch (Exception e) {
             throw new InternalServerError("Could not open index '" + id + "'", "INTERR_OPENING_INDEXWRITER", e);
@@ -311,6 +311,10 @@ public class Index {
     /**
      * Close this index if it's currently open. Force closes any current Indexer.
      * Has no effect if the index was already closed.
+     *
+     * TODO: this might take quite a while. It would be better not to synchronize
+     *   the entire method, but only a few quick lines that update the index status
+     *   when appropriate.
      */
     public synchronized void close() {
         if (this.index != null) {

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -232,14 +232,10 @@ public class Index {
     }
 
     public synchronized IndexStatus getStatus() throws BlsException {
-        return IndexStatus.INDEXING; //@@@@DEBUG
-/*  @@@ DEBUG
         if (this.indexer != null && this.indexer.isOpen())
             return IndexStatus.INDEXING;
 
         return this.blIndex().isEmpty() ? IndexStatus.EMPTY : IndexStatus.AVAILABLE;
-
- */
     }
 
     /**
@@ -309,8 +305,7 @@ public class Index {
         if (this.getStatus() != IndexStatus.INDEXING)
             return null;
 
-        return new IndexListener();  //@@@DEBUG
-        //@@@DEBUG return this.indexer.listener();
+        return this.indexer.listener();
     }
 
     /**

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
@@ -631,7 +631,7 @@ public class WebserviceOperations {
                     + " tokens allowed in a user index. Cannot add any more data to it.");
         }
 
-        Indexer indexer = index.getIndexer();
+        Indexer indexer = index.createIndexer();
         final String[] indexErr = { null }; // array because we set it from closure
         indexer.setListener(new IndexListenerReportConsole() {
             @Override

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
@@ -73,13 +73,13 @@ public class WebserviceRequestHandler {
         ResultIndexStatus corpusStatus = WebserviceOperations.resultIndexStatus(params);
         DStream.indexStatusResponse(ds, corpusStatus);
     }
+
     /**
      * Show server information.
      *
      * @param params parameters
      * @param ds output stream
      */
-
     public static void opServerInfo(WebserviceParams params, boolean debugMode, DataStream ds) {
         ResultServerInfo serverInfo = WebserviceOperations.serverInfo(params, debugMode);
         DStream.serverInfo(ds, serverInfo);


### PR DESCRIPTION
While indexing, checking the index status would instead throw an exception saying the index is busy, when the whole point of checking the status is to see whether or not this is the case.