### PR TITLE
Proxy: fix docInfo separating out metadata in XML response.

### DIFF
--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/DocInfoAdapter.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/DocInfoAdapter.java
@@ -1,0 +1,58 @@
+package org.ivdnt.blacklab.proxy.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.namespace.QName;
+
+import org.ivdnt.blacklab.proxy.representation.DocInfo;
+import org.ivdnt.blacklab.proxy.representation.MetadataValues;
+
+/**
+ * Helps us to (de)serialize autocomplete response in XML.
+ */
+public class DocInfoAdapter extends XmlAdapter<DocInfoAdapter.DocInfoWrapper, DocInfo> {
+
+    @XmlSeeAlso({MetadataValues.class})
+    public static class DocInfoWrapper {
+        @XmlAnyElement
+        List<JAXBElement<?>> elements;
+    }
+
+    @Override
+    public DocInfoWrapper marshal(DocInfo m) {
+        DocInfoWrapper wrapper = new DocInfoWrapper();
+        wrapper.elements = new ArrayList<>();
+        for (Map.Entry<String, MetadataValues> e: m.metadata.entrySet()) {
+            QName elName = new QName(SerializationUtil.getCleanLabel(e.getKey()));
+            JAXBElement<?> jaxbElement = new JAXBElement<>(elName, MetadataValues.class,
+                    e.getValue());
+            wrapper.elements.add(jaxbElement);
+        }
+        wrapper.elements.add(new JAXBElement<>(new QName("lengthInTokens"), Integer.class, m.lengthInTokens));
+        wrapper.elements.add(new JAXBElement<>(new QName("mayView"), Boolean.class, m.mayView));
+        return wrapper;
+    }
+
+    @Override
+    public DocInfo unmarshal(DocInfoWrapper wrapper) {
+        DocInfo docInfo = new DocInfo();
+        for (JAXBElement<?> element: wrapper.elements) {
+            String name = element.getName().getLocalPart();
+            if (name.equals("lengthInTokens")) {
+                docInfo.lengthInTokens = Integer.parseInt(element.getValue().toString());
+            } else if (name.equals("mayView")) {
+                docInfo.mayView = Boolean.parseBoolean(element.getValue().toString());
+            } else {
+                // Actual metadata value.
+                docInfo.metadata.put(name, (MetadataValues) element.getValue());
+            }
+        }
+        return docInfo;
+    }
+}

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/DocInfoAdapter.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/DocInfoAdapter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.namespace.QName;
@@ -20,6 +21,9 @@ public class DocInfoAdapter extends XmlAdapter<DocInfoAdapter.DocInfoWrapper, Do
 
     @XmlSeeAlso({MetadataValues.class})
     public static class DocInfoWrapper {
+        @XmlAttribute
+        String pid;
+
         @XmlAnyElement
         List<JAXBElement<?>> elements;
     }
@@ -27,6 +31,7 @@ public class DocInfoAdapter extends XmlAdapter<DocInfoAdapter.DocInfoWrapper, Do
     @Override
     public DocInfoWrapper marshal(DocInfo m) {
         DocInfoWrapper wrapper = new DocInfoWrapper();
+        wrapper.pid = m.pid;
         wrapper.elements = new ArrayList<>();
         for (Map.Entry<String, MetadataValues> e: m.metadata.entrySet()) {
             QName elName = new QName(SerializationUtil.getCleanLabel(e.getKey()));

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/MapAdapterMetadataValues.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/helper/MapAdapterMetadataValues.java
@@ -21,9 +21,9 @@ import org.w3c.dom.Element;
  */
 public class MapAdapterMetadataValues extends XmlAdapter<MapAdapterMetadataValues.MapWrapperMetadataValues, Map<String, MetadataValues>> {
     @Override
-    public MapWrapperMetadataValues marshal(Map<String, MetadataValues> m) throws Exception {
+    public MapWrapperMetadataValues marshal(Map<String, MetadataValues> m) {
         MapWrapperMetadataValues wrapper = new MapWrapperMetadataValues();
-        List elements = new ArrayList();
+        List<JAXBElement<MetadataValues>> elements = new ArrayList<>();
         for (Map.Entry<String, MetadataValues> property : m.entrySet()) {
 
             elements.add(new JAXBElement<>(new QName(SerializationUtil.getCleanLabel(property.getKey())),
@@ -34,9 +34,9 @@ public class MapAdapterMetadataValues extends XmlAdapter<MapAdapterMetadataValue
     }
 
     @Override
-    public Map<String, MetadataValues> unmarshal(MapWrapperMetadataValues v) throws Exception {
-        Map<String, MetadataValues> returnval = new LinkedHashMap();
-        for (Object o : v.elements) {
+    public Map<String, MetadataValues> unmarshal(MapWrapperMetadataValues v) {
+        Map<String, MetadataValues> returnval = new LinkedHashMap<>();
+        for (JAXBElement<MetadataValues> o : v.elements) {
             Element e = (Element) o;
 
             List<String> values = new ArrayList<>();

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/DocInfo.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/DocInfo.java
@@ -5,12 +5,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.ivdnt.blacklab.proxy.helper.DocInfoAdapter;
 import org.ivdnt.blacklab.proxy.helper.MapAdapterMetadataValues;
 import org.ivdnt.blacklab.proxy.helper.SerializationUtil;
 
@@ -27,7 +27,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @XmlRootElement(name="blacklabResponse")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType()
+@XmlJavaTypeAdapter(DocInfoAdapter.class)
 @JsonSerialize(using=DocInfo.Serializer.class)
 @JsonDeserialize(using=DocInfo.Deserializer.class)
 public class DocInfo {


### PR DESCRIPTION
The BLS API has a quirk where document metadata is intermingled with `lengthInTokens` and `mayView`, which are not metadata fields but other document properties.

The proxy uses JAXB and keeps these separate. This wasn't a problem for JSON, which has a custom (de)serializer anyway, but the XML response was incorrect because of this. Now fixed with a custom XmlAdapter.