### PR TITLE
Bugfixes in Proxy and Solr

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/AnnotatedFieldImpl.java
@@ -36,10 +36,9 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
                 // Set during indexing, when we don't actually have annotation information
                 // available (because the index is being built up, so we couldn't detect
                 // it on startup).
-                // Just create an annotation with the correct name, or retrieve it if it
-                // was defined in the indexmetadata.
+                // Just retrieve it now.
                 mainAnnotation = annots.get(mainAnnotationName);
-                mainAnnotationName = null;
+                //mainAnnotationName = null;
             }
             return mainAnnotation;
         }
@@ -228,7 +227,6 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
             if (!annots.containsKey(mainAnnotationName))
                 throw new IllegalArgumentException("Main annotation '" + mainAnnotationName + "' (from index metadata) not found!");
             mainAnnotation = annots.get(mainAnnotationName);
-            mainAnnotationName = null;
         }
         
         if (annots.isEmpty())
@@ -292,7 +290,7 @@ public class AnnotatedFieldImpl extends FieldImpl implements AnnotatedField {
     
     @Override
     public String offsetsField() {
-        AnnotationSensitivity offsetsSensitivity = mainAnnotation.offsetsSensitivity();
+        AnnotationSensitivity offsetsSensitivity = annotations.main().offsetsSensitivity();
         return offsetsSensitivity == null ? null : offsetsSensitivity.luceneField();
     }
 

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/ErrorResponse.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/ErrorResponse.java
@@ -10,6 +10,8 @@ public class ErrorResponse {
 
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class Desc {
+        int httpStatusCode = 200;
+
         String code;
 
         String message;
@@ -18,10 +20,14 @@ public class ErrorResponse {
 
         private Desc() {}
 
-        public Desc(String code, String message, String stackTrace) {
+        public Desc(int httpStatusCode, String code, String message, String stackTrace) {
             this.code = code;
             this.message = message;
             this.stackTrace = stackTrace;
+        }
+
+        public int getHttpStatusCode() {
+            return httpStatusCode;
         }
 
         public String getCode() {
@@ -45,16 +51,16 @@ public class ErrorResponse {
         this.error = error;
     }
 
-    public ErrorResponse(String code, String message, String stackTrace) {
-        this.error = new Desc(code, message, stackTrace);
+    public ErrorResponse(int httpStatusCode, String code, String message, String stackTrace) {
+        this.error = new Desc(httpStatusCode, code, message, stackTrace);
     }
 
     public String getMessage() {
         return error.code + "||" + error.message;
     }
 
-    public void setError(String code, String message, String stackTrace) {
-        error = new Desc(code, message, stackTrace);
+    public void setError(int httpStatusCode, String code, String message, String stackTrace) {
+        error = new Desc(httpStatusCode, code, message, stackTrace);
     }
 
     public Desc getError() {

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/InputFormatInfo.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/InputFormatInfo.java
@@ -1,0 +1,21 @@
+package org.ivdnt.blacklab.proxy.representation;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name="blacklabResponse")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(propOrder={"formatName", "configFileType", "configFile" })
+public class InputFormatInfo {
+
+    public String formatName;
+
+    public String configFileType;
+
+    public String configFile;
+
+    InputFormatInfo() {}
+
+}

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/InputFormatXsltResults.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/InputFormatXsltResults.java
@@ -6,17 +6,17 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="blacklabResponse")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class DocContentsResults {
+public class InputFormatXsltResults {
 
-    public String contents;
+    public String xslt;
 
     // required for Jersey
-    public DocContentsResults() {}
+    public InputFormatXsltResults() {}
 
     @Override
     public String toString() {
-        return "DocContentsResults{" +
-                "contents='" + contents + '\'' +
+        return "InputFormatXsltResults{" +
+                "xslt='" + xslt + '\'' +
                 '}';
     }
 }

--- a/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/StatusResponse.java
+++ b/proxy/jaxb/src/main/java/org/ivdnt/blacklab/proxy/representation/StatusResponse.java
@@ -26,7 +26,7 @@ public class StatusResponse {
     }
 
     public StatusResponse(String code, String message, String stackTrace) {
-        this.status = new Desc(code, message, stackTrace);
+        this.status = new Desc(200, code, message, stackTrace);
     }
 
     public String getMessage() {
@@ -42,7 +42,7 @@ public class StatusResponse {
     }
 
     public void setStatus(String code, String message, String stackTrace) {
-        status = new Desc(code, message, stackTrace);
+        status = new Desc(200, code, message, stackTrace);
     }
 
     public Desc getStatus() {

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/logic/Requests.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/logic/Requests.java
@@ -174,7 +174,9 @@ public class Requests {
                 } else {
                     // Couldn't map to any of the supplied classes. See if it's a BLS error.
                     try {
-                        return objectMapper.treeToValue(blacklab, ErrorResponse.class);
+                        ErrorResponse err = objectMapper.treeToValue(blacklab, ErrorResponse.class);
+                        // Yes. Throw it so it will be handled by the GenericExceptionMapper.
+                        throw new BlsRequestException(Response.Status.fromStatusCode(status), err);
                     } catch (JsonProcessingException e2) {
                         // Error didn't work either. Fail.
                         String classes = entityTypes.stream().map(c -> c.getName()).collect(Collectors.joining(" / "));

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/logic/Requests.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/logic/Requests.java
@@ -159,7 +159,7 @@ public class Requests {
             // Not a regular response; try to read error entity
             SolrGeneralErrorResponse err = response.readEntity(SolrGeneralErrorResponse.class);
             throw new BlsRequestException(Response.Status.fromStatusCode(status),
-                    new ErrorResponse("INTERNAL_ERROR", "(" + err.getServlet() + ") " + err.getStatus() + " " + err.getMessage() + ": " + err.getUrl(), ""));
+                    new ErrorResponse(500, "INTERNAL_ERROR", "(" + err.getServlet() + ") " + err.getStatus() + " " + err.getMessage() + ": " + err.getUrl(), ""));
         }
 
         JsonNode blacklab = solrResponse.getBlacklab();
@@ -176,7 +176,7 @@ public class Requests {
                     try {
                         ErrorResponse err = objectMapper.treeToValue(blacklab, ErrorResponse.class);
                         // Yes. Throw it so it will be handled by the GenericExceptionMapper.
-                        throw new BlsRequestException(Response.Status.fromStatusCode(status), err);
+                        throw new BlsRequestException(Response.Status.fromStatusCode(err.getError().getHttpStatusCode()), err);
                     } catch (JsonProcessingException e2) {
                         // Error didn't work either. Fail.
                         String classes = entityTypes.stream().map(c -> c.getName()).collect(Collectors.joining(" / "));

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
@@ -39,7 +39,7 @@ import org.ivdnt.blacklab.proxy.representation.TokenFreqList;
 import nl.inl.blacklab.webservice.WebserviceOperation;
 import nl.inl.blacklab.webservice.WebserviceParameter;
 
-@Path("/{corpusName}")
+@Path("/{corpusName : ^(?!input-formats$)}")
 public class CorpusResource {
 
     private static final String MIME_TYPE_CSV = "text/csv";
@@ -69,7 +69,7 @@ public class CorpusResource {
         return params;
     }
 
-    private static Map<WebserviceParameter, String> getParams(UriInfo uriInfo, WebserviceOperation op) {
+    static Map<WebserviceParameter, String> getParams(UriInfo uriInfo, WebserviceOperation op) {
         Map<WebserviceParameter, String> params = uriInfo.getQueryParameters().entrySet().stream()
                 .filter(e -> WebserviceParameter.fromValue(e.getKey()).isPresent()) // keep only known parameters
                 .map(e -> Map.entry(WebserviceParameter.fromValue(e.getKey()).orElse(null),
@@ -111,10 +111,6 @@ public class CorpusResource {
         String defaultCorpusName = ProxyConfig.get().getProxyTarget().getDefaultCorpusName();
 
         switch (corpusName) {
-        case "input-formats":
-            return success(Requests.get(client, getParams(uriInfo, defaultCorpusName, WebserviceOperation.LIST_INPUT_FORMATS),
-                    InputFormats.class));
-
         case "cache-info":
             return notImplemented("/cache-info");
 
@@ -208,7 +204,7 @@ public class CorpusResource {
             @Context UriInfo uriInfo) {
         Map<WebserviceParameter, String> params = getParams(uriInfo, corpusName, WebserviceOperation.DOC_CONTENTS);
         params.put(WebserviceParameter.DOC_PID, docPid);
-        DocContentsResults entity = (DocContentsResults)Requests.get(client, params, DocContentsResults.class);
+        DocContentsResults entity = Requests.get(client, params, DocContentsResults.class);
         return Response.ok().entity(entity.contents).type(MediaType.APPLICATION_XML).build();
     }
 

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
@@ -50,7 +50,7 @@ public class CorpusResource {
     }
 
     public static Response error(Response.Status status, String code, String message, String stackTrace) {
-        ErrorResponse error = new ErrorResponse(code, message, stackTrace);
+        ErrorResponse error = new ErrorResponse(status.getStatusCode(), code, message, stackTrace);
         return Response.status(status).entity(error).build();
     }
 

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/CorpusResource.java
@@ -30,7 +30,6 @@ import org.ivdnt.blacklab.proxy.representation.DocSnippetResponse;
 import org.ivdnt.blacklab.proxy.representation.DocsResults;
 import org.ivdnt.blacklab.proxy.representation.ErrorResponse;
 import org.ivdnt.blacklab.proxy.representation.HitsResults;
-import org.ivdnt.blacklab.proxy.representation.InputFormats;
 import org.ivdnt.blacklab.proxy.representation.JsonCsvResponse;
 import org.ivdnt.blacklab.proxy.representation.MetadataField;
 import org.ivdnt.blacklab.proxy.representation.TermFreqList;
@@ -39,7 +38,7 @@ import org.ivdnt.blacklab.proxy.representation.TokenFreqList;
 import nl.inl.blacklab.webservice.WebserviceOperation;
 import nl.inl.blacklab.webservice.WebserviceParameter;
 
-@Path("/{corpusName : ^(?!input-formats$)}")
+@Path("/{corpusName : (?!input-formats\\b)[^/]+}")
 public class CorpusResource {
 
     private static final String MIME_TYPE_CSV = "text/csv";

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/RootResource.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/RootResource.java
@@ -49,7 +49,7 @@ public class RootResource {
             @Context HttpHeaders headers) {
         Map<WebserviceParameter, String> params = CorpusResource.getParams(uriInfo, WebserviceOperation.LIST_INPUT_FORMATS);
         InputFormats entity = Requests.get(client, params, InputFormats.class);
-        return Response.ok().entity(entity).type(MediaType.APPLICATION_XML).build();
+        return Response.ok().entity(entity).build();
     }
 
     @GET
@@ -62,7 +62,7 @@ public class RootResource {
         Map<WebserviceParameter, String> params = CorpusResource.getParams(uriInfo, WebserviceOperation.INPUT_FORMAT_INFO);
         params.put(WebserviceParameter.INPUT_FORMAT, formatName);
         InputFormatInfo entity = Requests.get(client, params, InputFormatInfo.class);
-        return Response.ok().entity(entity).type(MediaType.APPLICATION_XML).build();
+        return Response.ok().entity(entity).build();
     }
 
     @GET

--- a/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/RootResource.java
+++ b/proxy/service/src/main/java/org/ivdnt/blacklab/proxy/resources/RootResource.java
@@ -5,12 +5,19 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.ivdnt.blacklab.proxy.logic.Requests;
+import org.ivdnt.blacklab.proxy.representation.InputFormatInfo;
+import org.ivdnt.blacklab.proxy.representation.InputFormatXsltResults;
+import org.ivdnt.blacklab.proxy.representation.InputFormats;
 import org.ivdnt.blacklab.proxy.representation.Server;
 
 import nl.inl.blacklab.webservice.WebserviceOperation;
@@ -33,5 +40,44 @@ public class RootResource {
         Map<WebserviceParameter, String> params = Map.of(WebserviceParameter.OPERATION, WebserviceOperation.SERVER_INFO.value());
         return CorpusResource.success(Requests.get(client, params, Server.class));
     }
+
+    @GET
+    @Path("/input-formats")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public Response format(
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
+        Map<WebserviceParameter, String> params = CorpusResource.getParams(uriInfo, WebserviceOperation.LIST_INPUT_FORMATS);
+        InputFormats entity = Requests.get(client, params, InputFormats.class);
+        return Response.ok().entity(entity).type(MediaType.APPLICATION_XML).build();
+    }
+
+    @GET
+    @Path("/input-formats/{formatName}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public Response format(
+            @PathParam("formatName") String formatName,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
+        Map<WebserviceParameter, String> params = CorpusResource.getParams(uriInfo, WebserviceOperation.INPUT_FORMAT_INFO);
+        params.put(WebserviceParameter.INPUT_FORMAT, formatName);
+        InputFormatInfo entity = Requests.get(client, params, InputFormatInfo.class);
+        return Response.ok().entity(entity).type(MediaType.APPLICATION_XML).build();
+    }
+
+    @GET
+    @Path("/input-formats/{formatName}/xslt")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public Response xslt(
+            @PathParam("formatName") String formatName,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
+        Map<WebserviceParameter, String> params = CorpusResource.getParams(uriInfo, WebserviceOperation.INPUT_FORMAT_XSLT);
+        params.put(WebserviceParameter.INPUT_FORMAT, formatName);
+        InputFormatXsltResults entity = Requests.get(client, params, InputFormatXsltResults.class);
+        return Response.ok().entity(entity.xslt).type(MediaType.APPLICATION_XML).build();
+    }
+
+
 
 }

--- a/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
+++ b/server/src/main/java/nl/inl/blacklab/server/BlackLabServer.java
@@ -53,9 +53,6 @@ public class BlackLabServer extends HttpServlet {
 
     private static final Logger logger = LogManager.getLogger(BlackLabServer.class);
 
-    /** Root element to use for XML responses. */
-    public static final String BLACKLAB_RESPONSE_ROOT_ELEMENT = "blacklabResponse";
-
     private static final Charset REQUEST_ENCODING = StandardCharsets.UTF_8;
 
     private static final Charset OUTPUT_ENCODING = StandardCharsets.UTF_8;
@@ -242,7 +239,7 @@ public class BlackLabServer extends HttpServlet {
 
         int cacheTime = requestHandler.isCacheAllowed() ? searchManager.config().getCache().getClientCacheTimeSec() : 0;
 
-        String rootEl = requestHandler.omitBlackLabResponseRootElement() ? null : BLACKLAB_RESPONSE_ROOT_ELEMENT;
+        String rootEl = requestHandler.omitBlackLabResponseRootElement() ? null : ResponseStreamer.BLACKLAB_RESPONSE_ROOT_ELEMENT;
 
         // === Handle the request
         StringWriter buf = new StringWriter();

--- a/server/src/main/java/nl/inl/blacklab/server/datastream/DataStreamXml.java
+++ b/server/src/main/java/nl/inl/blacklab/server/datastream/DataStreamXml.java
@@ -59,7 +59,7 @@ public class DataStreamXml extends DataStreamAbstract {
 
     @Override
     public void outputProlog() {
-        print("<?xml version=\"1.0\" encoding=\"utf-8\" ?>").newline();
+        print(XML_PROLOG).newline();
     }
 
     @Override

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocContents.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerDocContents.java
@@ -1,9 +1,7 @@
 package nl.inl.blacklab.server.requesthandlers;
 
 import nl.inl.blacklab.exceptions.InvalidQuery;
-import nl.inl.blacklab.server.BlackLabServer;
 import nl.inl.blacklab.server.datastream.DataFormat;
-import nl.inl.blacklab.server.datastream.DataStreamXml;
 import nl.inl.blacklab.server.exceptions.BlsException;
 import nl.inl.blacklab.server.lib.results.ResponseStreamer;
 import nl.inl.blacklab.server.lib.results.ResultDocContents;
@@ -38,38 +36,8 @@ public class RequestHandlerDocContents extends RequestHandler {
         params.setDocPid(docPid);
 
         ResultDocContents resultDocContents = WebserviceOperations.docContents(params);
-        docContentsResponse((DataStreamXml)rs.getDataStream(), resultDocContents);
+        rs.docContentsResponsePlain(resultDocContents);
         return HTTP_OK;
-    }
-
-    public static void docContentsResponse(DataStreamXml ds, ResultDocContents resultDocContents) {
-        if (resultDocContents.needsXmlDeclaration()) {
-            // We haven't outputted an XML declaration yet, and there's none in the document. Do so now.
-            ds.outputProlog();
-        }
-
-        // Output root element and namespaces if necessary
-        // (i.e. when we're not returning the full document, only part of it)
-        if (!resultDocContents.isFullDocument()) {
-            // Surround with root element and make sure it has the required namespaces
-            ds.outputProlog();
-            ds.startOpenEl(BlackLabServer.BLACKLAB_RESPONSE_ROOT_ELEMENT);
-            for (String ns: resultDocContents.getNamespaces()) {
-                ds.plain(" ").plain(ns);
-            }
-            for (String anon: resultDocContents.getAnonNamespaces()) {
-                ds.plain(" ").plain(anon);
-            }
-            ds.endOpenEl();
-        }
-
-        // Output (part of) the document
-        ds.plain(resultDocContents.getContent());
-
-        if (!resultDocContents.isFullDocument()) {
-            // Close the root el we opened
-            ds.closeEl();
-        }
     }
 
     @Override

--- a/solr/docker-compose.override.yml
+++ b/solr/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
         - "8983:8983"
 
         # Allow us to attach to the JVM using JDWP for remote debugging
-      - "5005:5005"
+        - "5005:5005"
 
     environment:
 

--- a/solr/src/main/java/org/ivdnt/blacklab/solr/BlackLabSearchComponent.java
+++ b/solr/src/main/java/org/ivdnt/blacklab/solr/BlackLabSearchComponent.java
@@ -157,31 +157,31 @@ public class BlackLabSearchComponent extends SearchComponent implements SolrCore
     public synchronized void process(ResponseBuilder rb) {
         // Should we run at all?
         if (QueryParamsSolr.shouldRunComponent(rb.req.getParams())) {
-            IndexReader reader = rb.req.getSearcher().getIndexReader();
-            String indexName = rb.req.getSearcher().getCore().getName();
-            BlackLabIndex index = searchManager.getEngine().getIndexFromReader(indexName, reader, true, false);
-
-            // We keep setting the cache for every request; the cache should probably be owner by the
-            // BlackLabEngine, and set automatically when the BlackLabIndex is instantiated.
-            // For now, this doesn't cause any problems, it's just messy.
-            index.setCache(searchManager.getBlackLabCache());
-
-            UserRequest userRequest = new UserRequestSolr(rb, this);
-            WebserviceParams params = userRequest.getParams(index, null);
-            if (!searchManager.getIndexManager().indexExists(params.getCorpusName())) {
-                searchManager.getIndexManager().registerIndex(params.getCorpusName(), index);
-            }
-            DataStream ds = new DataStreamSolr(rb.rsp).startDocument("");
-
-            // FIXME: Produce CSV output?
-            //   Solr includes a CSV output type, but that seems to be geared towards outputting documents
-            //   with their fields. Maybe there's some way to customize this, or add another output type for
-            //   "blacklab-csv" output?
-            //if (outputType == DataFormat.CSV)
-
-            ds.startEntry(Constants.SOLR_BLACKLAB_SECTION_NAME);
-            ResponseStreamer dstream = ResponseStreamer.get(ds, params.apiCompatibility());
             try {
+                IndexReader reader = rb.req.getSearcher().getIndexReader();
+                String indexName = rb.req.getSearcher().getCore().getName();
+                BlackLabIndex index = searchManager.getEngine().getIndexFromReader(indexName, reader, true, false);
+
+                // We keep setting the cache for every request; the cache should probably be owner by the
+                // BlackLabEngine, and set automatically when the BlackLabIndex is instantiated.
+                // For now, this doesn't cause any problems, it's just messy.
+                index.setCache(searchManager.getBlackLabCache());
+
+                UserRequest userRequest = new UserRequestSolr(rb, this);
+                WebserviceParams params = userRequest.getParams(index, null);
+                if (!searchManager.getIndexManager().indexExists(params.getCorpusName())) {
+                    searchManager.getIndexManager().registerIndex(params.getCorpusName(), index);
+                }
+                DataStream ds = new DataStreamSolr(rb.rsp).startDocument("");
+
+                // FIXME: Produce CSV output?
+                //   Solr includes a CSV output type, but that seems to be geared towards outputting documents
+                //   with their fields. Maybe there's some way to customize this, or add another output type for
+                //   "blacklab-csv" output?
+                //if (outputType == DataFormat.CSV)
+
+                ds.startEntry(Constants.SOLR_BLACKLAB_SECTION_NAME);
+                ResponseStreamer dstream = ResponseStreamer.get(ds, params.apiCompatibility());
                 boolean debugMode = userRequest.isDebugMode();
                 switch (params.getOperation()) {
                 // "Root" endpoint

--- a/solr/src/main/java/org/ivdnt/blacklab/solr/UserRequestSolr.java
+++ b/solr/src/main/java/org/ivdnt/blacklab/solr/UserRequestSolr.java
@@ -106,7 +106,12 @@ public class UserRequestSolr implements UserRequest {
             // Request was passed as separate bl.* parameters. Parse them.
             qpSolr = new QueryParamsSolr(getCorpusName(), searchMan, solrParams, user);
         }
-        boolean isDocs = qpSolr.getOperation().isDocsOperation();
+        try {
+            operation = qpSolr.getOperation();
+        } catch (UnsupportedOperationException e) {
+            throw new BadRequest("UNKNOWN_OPERATION", "Unknown operation");
+        }
+        boolean isDocs = operation.isDocsOperation();
         WebserviceParamsImpl params = WebserviceParamsImpl.get(isDocs, isDebugMode(), qpSolr);
         if (params.getDocumentFilterQuery().isEmpty()) {
             // No explicit bl.filter specified; use Solr's document results as our filter query

--- a/wslib/src/main/java/nl/inl/blacklab/server/datastream/DataStream.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/datastream/DataStream.java
@@ -10,14 +10,15 @@ import nl.inl.blacklab.search.indexmetadata.Annotation;
 import nl.inl.blacklab.server.util.WebserviceUtil;
 
 public interface DataStream {
+    String XML_PROLOG = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>";
+
     /**
      * Construct a simple status response object.
-     *
      * Status response may indicate success, or e.g. that the server is carrying out
      * the request and will have results later.
      *
      * @param code (string) status code
-     * @param msg the message
+     * @param msg  the message
      */
     default void statusObject(String code, String msg) {
         startMap()
@@ -34,8 +35,8 @@ public interface DataStream {
      * Construct a simple error response object.
      *
      * @param code (string) error code
-     * @param msg the error message
-     * @param e if specified, include stack trace
+     * @param msg  the error message
+     * @param e    if specified, include stack trace
      */
     default void error(String code, String msg, Throwable e) {
         startMap()
@@ -58,7 +59,7 @@ public interface DataStream {
      * Construct a simple error response object.
      *
      * @param code (string) error code
-     * @param msg the error message
+     * @param msg  the error message
      */
     default void error(String code, String msg) {
         error(code, msg, null);
@@ -146,7 +147,9 @@ public interface DataStream {
         return startEntry(key).value(value).endEntry();
     }
 
-    default DataStream entry(String key, boolean value) { return startEntry(key).value(value).endEntry(); }
+    default DataStream entry(String key, boolean value) {
+        return startEntry(key).value(value).endEntry();
+    }
 
     default DataStream attrEntry(String elementName, String attrName, String key, String value) {
         return startAttrEntry(elementName, attrName, key).value(value).endAttrEntry();
@@ -190,18 +193,17 @@ public interface DataStream {
 
     /**
      * Output a map.
-     *
      * May contain nested structures (Map, List) and/or values.
      *
      * @param value map to output
-     * @param <S> entry key type
-     * @param <T> entry value type
+     * @param <S>   entry key type
+     * @param <T>   entry value type
      * @return this data stream
      */
     default <S, T> DataStream value(Map<S, T> value) {
         startMap();
         if (value != null) {
-            for (Map.Entry<S, T> entry : value.entrySet()) {
+            for (Map.Entry<S, T> entry: value.entrySet()) {
                 startEntry(entry.getKey().toString()).value(entry.getValue()).endEntry();
             }
         }
@@ -211,19 +213,17 @@ public interface DataStream {
 
     /**
      * Output a list.
-     *
      * May contain nested structures (Map, List) and/or values.
-     *
      * Uses "item" for the list item name (in XML mode).
      *
      * @param value list to output
-     * @param <T> list item type
+     * @param <T>   list item type
      * @return this data stream
      */
     default <T> DataStream value(List<T> value) {
         startList();
         if (value != null) {
-            for (T item : value) {
+            for (T item: value) {
                 startItem("item").value(item).endItem();
             }
         }
@@ -239,17 +239,17 @@ public interface DataStream {
      */
     default DataStream value(Object value) {
         if (value instanceof Map) {
-            return value((Map)value);
+            return value((Map) value);
         } else if (value instanceof List) {
-            return value((List)value);
+            return value((List) value);
         } else if (value instanceof String) {
-            return value((String)value);
+            return value((String) value);
         } else if (value instanceof Integer || value instanceof Long) {
             return value(((Number) value).longValue());
         } else if (value instanceof Double || value instanceof Float) {
             return value(((Number) value).doubleValue());
         } else if (value instanceof Boolean) {
-            return value((boolean)value);
+            return value((boolean) value);
         } else {
             return value(value == null ? "" : value.toString());
         }
@@ -257,7 +257,9 @@ public interface DataStream {
 
     DataStream plain(String value);
 
-    /** Should contextList omit empty annotations if possible? (XML only) */
+    /**
+     * Should contextList omit empty annotations if possible? (XML only)
+     */
     default void setOmitEmptyAnnotations(boolean omitEmptyAnnotations) { /* do nothing */ }
 
     DataStream xmlFragment(String fragment);
@@ -282,9 +284,32 @@ public interface DataStream {
 
     DataStream space();
 
-    /** Output a full CSV document. Subclasses may choose to embed it in their response format. */
-    default void csv(String csv) { plain(csv); }
+    /**
+     * Output a full CSV document. Subclasses may choose to embed it in their response format.
+     */
+    default void csv(String csv) {
+        plain(csv);
+    }
 
-    /** Output a full XSLT document. Subclasses may choose to embed it in their response format. */
-    default void xslt(String xslt) { plain(xslt); }
+    /**
+     * Output a full XSLT document. Subclasses may choose to embed it in their response format.
+     */
+    default void xslt(String xslt) {
+        plain(xslt);
+    }
+
+    /** Needed to return parts of the XML document, wrapped in an extra root element and optional namespaces. */
+    default DataStream startOpenEl(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Needed to return parts of the XML document, wrapped in an extra root element and optional namespaces. */
+    default DataStream endOpenEl() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Needed to return parts of the XML document, wrapped in an extra root element and optional namespaces. */
+    default DataStream closeEl() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
@@ -169,7 +169,7 @@ public class WebserviceRequestHandler {
      */
     public static void opDocContents(WebserviceParams params, ResponseStreamer rs) throws InvalidQuery {
         ResultDocContents result = WebserviceOperations.docContents(params);
-        rs.docContentsResponse(result);
+        rs.docContentsResponseAsCdata(result);
     }
 
     /**

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceRequestHandler.java
@@ -281,7 +281,10 @@ public class WebserviceRequestHandler {
     }
 
     public static void opInputFormatXslt(WebserviceParams params, ResponseStreamer rs) {
-        ResultInputFormat result = WebserviceOperations.inputFormat(params.getInputFormat().get());
+        Optional<String> inputFormat = params.getInputFormat();
+        if (!inputFormat.isPresent())
+            throw new BadRequest("NO_INPUT_FORMAT", "No input format specified (" + WebserviceParameter.INPUT_FORMAT.value() + ")");
+        ResultInputFormat result = WebserviceOperations.inputFormat(inputFormat.get());
         rs.formatXsltResponse(result);
     }
 }


### PR DESCRIPTION
Fixed: 
- NPE when using mainAnnotation before it was set
- getting partial doc contents in Solr did not produce correct XML
- better error handling when various things go wrong in different parts of the code
- implemented input-formats endpoints and placed them in RootResource (with some regex trickery in CorpusResource)
- HTTP status code for BlackLab operation is now being returned from Solr and passed through proxy