### PR TITLE
Bugfix/snippet wordsaroundhit 430

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/HitPropertyContextWords.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/HitPropertyContextWords.java
@@ -217,7 +217,8 @@ public class HitPropertyContextWords extends HitProperty {
         if (words == null) {
             // "entire hit text"
             this.words = new ArrayList<>();
-            this.words.add(new ContextPart(ContextStart.HIT_TEXT_FROM_START, 0, 1, blIndex.defaultContextSize().left()));
+            this.words.add(new ContextPart(ContextStart.HIT_TEXT_FROM_START, 0, 1,
+                    blIndex.defaultContextSize().before()));
         } else {
             // Determine the maximum length of each part, by limiting it to the
             // maximum possible given the anchor point, direction and first word.
@@ -236,7 +237,7 @@ public class HitPropertyContextWords extends HitProperty {
                         break;
                     default:
                         // Limit to length of left or right context.
-                        part.maxLength = Math.min(part.maxLength, blIndex.defaultContextSize().left() - part.firstWord);
+                        part.maxLength = Math.min(part.maxLength, blIndex.defaultContextSize().before() - part.firstWord);
                         break;
                     }
                     if (part.maxLength < 0)
@@ -416,7 +417,7 @@ public class HitPropertyContextWords extends HitProperty {
     
     @Override
     public ContextSize needsContextSize(BlackLabIndex index) {
-        int maxContextSize = index.defaultContextSize().left();
+        int maxContextSize = index.defaultContextSize().before();
         return this.words.stream().map(w -> ContextSize.get(Math.min(w.maxLength, maxContextSize))).reduce(ContextSize::union).orElse(null);
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Concordances.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Concordances.java
@@ -33,10 +33,8 @@ public class Concordances {
     
     Kwics kwics = null;
 
-    /**
-     */
     public Concordances(Hits hits, ConcordanceType type, ContextSize contextSize) {
-        if (contextSize.left() < 0 || contextSize.right() < 0)
+        if (contextSize.before() < 0 || contextSize.after() < 0)
             throw new IllegalArgumentException("contextSize cannot be negative");
         if (type == ConcordanceType.FORWARD_INDEX) {
             kwics = new Kwics(hits, contextSize);
@@ -96,10 +94,10 @@ public class Concordances {
             int hitStart = hit.start();
             int hitEnd = hit.end() - 1;
 
-            int start = hitStart - wordsAroundHit.left();
+            int start = hitStart - wordsAroundHit.before();
             if (start < 0)
                 start = 0;
-            int end = hitEnd + wordsAroundHit.right();
+            int end = hitEnd + wordsAroundHit.after();
 
             startsOfWords[startEndArrayIndex] = start;
             startsOfWords[startEndArrayIndex + 1] = hitStart;

--- a/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
@@ -3,7 +3,7 @@ package nl.inl.blacklab.search.results;
 /**
  * Represents the size of the context around a hit.
  * 
- * WARNING: right now, only left() is used (for both left and right context size)!
+ * WARNING: right now, only before() is used (for both before and after context size)!
  * The other functionality will be added in the future.
  */
 public class ContextSize {
@@ -11,42 +11,42 @@ public class ContextSize {
     /**
      * Get ContexSize.
      *
-     * WARNING: right now, only left() is used (for both left and right context size)!
+     * WARNING: right now, only before() is used (for both before and after context size)!
      * The other functionality will be added in the future.
      *
-     * @param left left context size
-     * @param right right context size
+     * @param before context size before hit
+     * @param after context size after hit
      * @param includeHit should the hit itself be included in the context or not?
      * @return context size object
      */
-    public static ContextSize get(int left, int right, boolean includeHit) {
-        return new ContextSize(left, right, includeHit);
+    public static ContextSize get(int before, int after, boolean includeHit) {
+        return new ContextSize(before, after, includeHit);
     }
 
     /**
      * Get ContexSize.
      *
-     * WARNING: right now, only left() is used (for both left and right context size)!
+     * WARNING: right now, only before() is used (for both before and after context size)!
      * The other functionality will be added in the future.
      *
      * Hit is always included in the context with this method.
      *
-     * @param left left context size
-     * @param right right context size
+     * @param before context size before hit
+     * @param after context size after hit
      * @return context size object
      */
-    public static ContextSize get(int left, int right) {
-        return new ContextSize(left, right, true);
+    public static ContextSize get(int before, int after) {
+        return new ContextSize(before, after, true);
     }
 
     /**
      * Get ContexSize.
      *
-     * The number is used for the context size both to the left and the right.
+     * The number is used for the context size both before and after the hit.
      *
      * Hit is always included in the context with this method.
      *
-     * @param size left and right context size
+     * @param size context size before and after hit
      * @return context size object
      */
     public static ContextSize get(int size) {
@@ -61,39 +61,49 @@ public class ContextSize {
      * @return union of both context sizes
      */
     public static ContextSize union(ContextSize a, ContextSize b) {
-        int left = Math.max(a.left, b.left);
-        int right = Math.max(a.right, b.right);
+        int before = Math.max(a.before, b.before);
+        int after = Math.max(a.after, b.after);
         boolean includeHit = a.includeHit || b.includeHit;
-        return ContextSize.get(left, right, includeHit);
+        return ContextSize.get(before, after, includeHit);
     }
 
-    private final int left;
+    private final int before;
 
-    private final int right;
+    private final int after;
 
     private final boolean includeHit;
 
-    private ContextSize(int left, int right, boolean includeHit) {
+    private ContextSize(int before, int after, boolean includeHit) {
         super();
-        this.left = left;
-        this.right = right;
+        this.before = before;
+        this.after = after;
         this.includeHit = includeHit;
     }
 
-    public int left() {
-        return left;
+    public int before() {
+        return before;
     }
 
+    public int after() {
+        return after;
+    }
+
+    @Deprecated
+    public int left() {
+        return before();
+    }
+
+    @Deprecated
 	public int right() {
-	    return right;
+	    return after();
 	}
 	
 	/**
 	 * Should the hit itself be included in the context or not?
 	 * 
 	 * By default it always is, but for some operations you only need
-	 * the left context. And to determine collocations you might only want
-	 * left and right context and not the hit context itself (because you're
+	 * the before context. And to determine collocations you might only want
+	 * before and after context and not the hit context itself (because you're
 	 * counting words that occur around the hit)
 	 * 
 	 * @return whether or not the hit context should be included
@@ -107,8 +117,8 @@ public class ContextSize {
         final int prime = 31;
         int result = 1;
         result = prime * result + (includeHit ? 1231 : 1237);
-        result = prime * result + left;
-        result = prime * result + right;
+        result = prime * result + before;
+        result = prime * result + after;
         return result;
     }
 
@@ -123,12 +133,16 @@ public class ContextSize {
         ContextSize other = (ContextSize) obj;
         if (includeHit != other.includeHit)
             return false;
-        if (left != other.left)            return false;
-        return right == other.right;
+        if (before != other.before)            return false;
+        return after == other.after;
     }
     
     @Override
     public String toString() {
-        return "ContextSize(" + left + ", " + right + ", " + includeHit + ")";
+        return "ContextSize(" + before + ", " + after + ", " + includeHit + ")";
+    }
+
+    public boolean isNone() {
+        return before == 0 && after == 0;
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
@@ -7,53 +7,55 @@ package nl.inl.blacklab.search.results;
  * The other functionality will be added in the future.
  */
 public class ContextSize {
-    
+
+    /**
+     * Get ContexSize.
+     *
+     * WARNING: right now, only left() is used (for both left and right context size)!
+     * The other functionality will be added in the future.
+     *
+     * @param left left context size
+     * @param right right context size
+     * @param includeHit should the hit itself be included in the context or not?
+     * @return context size object
+     */
     public static ContextSize get(int left, int right, boolean includeHit) {
         return new ContextSize(left, right, includeHit);
     }
-	
+
+    /**
+     * Get ContexSize.
+     *
+     * WARNING: right now, only left() is used (for both left and right context size)!
+     * The other functionality will be added in the future.
+     *
+     * Hit is always included in the context with this method.
+     *
+     * @param left left context size
+     * @param right right context size
+     * @return context size object
+     */
     public static ContextSize get(int left, int right) {
-        return new ContextSize(left, right);
-    }
-    
-    public static ContextSize get(int size) {
-        return new ContextSize(size);
-    }
-    
-    public static ContextSize hitOnly() {
-        return get(0);
-    }
-    
-	private final int left;
-	
-    ContextSize(int size) {
-        this.left = size;
-        this.right = size;
-        this.includeHit = true;
-    }
-
-    public int left() {
-        return left;
-    }
-
-    private final int right;
-    
-    private final boolean includeHit;
-    
-    ContextSize(int left, int right, boolean includeHit) {
-        super();
-        this.left = left;
-        this.right = right;
-        this.includeHit = includeHit;
-    }
-
-    ContextSize(int left, int right) {
-        this(left, right, true);
+        return new ContextSize(left, right, true);
     }
 
     /**
-     * Return the minimal context size that encompasses both parameters. 
-     * 
+     * Get ContexSize.
+     *
+     * The number is used for the context size both to the left and the right.
+     *
+     * Hit is always included in the context with this method.
+     *
+     * @param size left and right context size
+     * @return context size object
+     */
+    public static ContextSize get(int size) {
+        return new ContextSize(size, size, true);
+    }
+
+    /**
+     * Return the minimal context size that encompasses both parameters.
+     *
      * @param a first context size
      * @param b second context size
      * @return union of both context sizes
@@ -63,6 +65,23 @@ public class ContextSize {
         int right = Math.max(a.right, b.right);
         boolean includeHit = a.includeHit || b.includeHit;
         return ContextSize.get(left, right, includeHit);
+    }
+
+    private final int left;
+
+    private final int right;
+
+    private final boolean includeHit;
+
+    private ContextSize(int left, int right, boolean includeHit) {
+        super();
+        this.left = left;
+        this.right = right;
+        this.includeHit = includeHit;
+    }
+
+    public int left() {
+        return left;
     }
 
 	public int right() {

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Contexts.java
@@ -176,8 +176,8 @@ public class Contexts implements Iterable<int[]> {
         EphemeralHit hit = new EphemeralHit();
         for (long i = start; i < end; ++i) {
             hits.getEphemeral(i, hit);
-            startsOfSnippets[(int)(i - start)] = Math.max(0, hit.start - contextSize.left());
-            endsOfSnippets[(int)(i - start)] = hit.end + contextSize.right();
+            startsOfSnippets[(int)(i - start)] = Math.max(0, hit.start - contextSize.before());
+            endsOfSnippets[(int)(i - start)] = hit.end + contextSize.after();
         }
 
         int fiNumber = 0;

--- a/engine/src/main/java/nl/inl/blacklab/search/results/Kwics.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/Kwics.java
@@ -26,7 +26,7 @@ public class Kwics {
     /**
      */
     protected Kwics(Hits hits, ContextSize contextSize) {
-        if (contextSize.left() < 0 || contextSize.right() < 0)
+        if (contextSize.before() < 0 || contextSize.after() < 0)
             throw new IllegalArgumentException("contextSize cannot be negative");
     
         // Get the concordances

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/WebserviceParamsImpl.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/WebserviceParamsImpl.java
@@ -359,7 +359,7 @@ public class WebserviceParamsImpl implements WebserviceParams {
     public ContextSettings contextSettings() {
         ContextSize contextSize = ContextSize.get(getWordsAroundHit());
         int maxContextSize = configParam().getContextSize().getMaxInt();
-        if (contextSize.left() > maxContextSize) { // no check on right needed - same as left
+        if (contextSize.before() > maxContextSize) { // no check on right needed - same as left
             //debug(logger, "Clamping context size to " + maxContextSize + " (" + contextSize + " requested)");
             contextSize = ContextSize.get(maxContextSize);
         }

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResponseStreamer.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResponseStreamer.java
@@ -379,7 +379,7 @@ public class ResponseStreamer {
         }
 
         ContextSize contextSize = params.contextSettings().size();
-        boolean includeContext = contextSize.left() > 0 || contextSize.right() > 0;
+        boolean includeContext = contextSize.before() > 0 || contextSize.after() > 0;
         if (concordanceContext.isConcordances()) {
             // Add concordance from original XML
             Concordance c = concordanceContext.getConcordance(hit);

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocInfo.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocInfo.java
@@ -48,7 +48,7 @@ public class ResultDocInfo {
             if (docPid.length() == 0)
                 throw new BadRequest("NO_DOC_ID", "Specify document pid.");
             int luceneDocId = BlsUtils.getDocIdFromPid(index, docPid);
-            if (luceneDocId < 0)
+            if (luceneDocId < 0 || luceneDocId >= index.reader().maxDoc())
                 throw new NotFound("DOC_NOT_FOUND", "Document with pid '" + docPid + "' not found.");
             this.document = index.luceneDoc(luceneDocId);
             if (this.document == null)
@@ -72,8 +72,9 @@ public class ResultDocInfo {
         String tokenLengthField = index.mainAnnotatedField().tokenLengthField();
         lengthInTokens = null;
         if (tokenLengthField != null) {
-            lengthInTokens =
-                    Integer.parseInt(document.get(tokenLengthField)) - BlackLabIndexAbstract.IGNORE_EXTRA_CLOSING_TOKEN;
+            String strDocLength = document.get(tokenLengthField);
+            lengthInTokens = strDocLength == null ? 0 :
+                    Integer.parseInt(strDocLength) - BlackLabIndexAbstract.IGNORE_EXTRA_CLOSING_TOKEN;
         }
         mayView = index.mayView(document);
 

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocSnippet.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocSnippet.java
@@ -55,7 +55,7 @@ public class ResultDocSnippet {
         } else {
             start = params.getWordStart();
             end = params.getWordEnd();
-            wordsAroundHit = ContextSize.hitOnly();
+            wordsAroundHit = ContextSize.get(0);
         }
 
         if (start < 0 || end < 0 || wordsAroundHit.left() < 0 || wordsAroundHit.right() < 0 || start > end) {


### PR DESCRIPTION
Fixes clamping max. snippet size, cleanups.

Changes ContextSize from left/right to before/after. Improves handling of non-existent docIds when getting doc info.