### PR TITLE
Synchronize methods that use IndexInput.clone().

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/codec/BlackLab40StoredFieldsReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/codec/BlackLab40StoredFieldsReader.java
@@ -285,7 +285,9 @@ public class BlackLab40StoredFieldsReader extends StoredFieldsReader {
      *
      * @return content store segment reader
      */
-    public ContentStoreSegmentReader contentStore() {
+    public synchronized ContentStoreSegmentReader contentStore() {
+        // NOTE: this method is synchronized because IndexInput.clone() is not thread-safe!
+        //       so if multiple threads could call this method simultaneously, disaster could strike.
         return new ContentStoreSegmentReader() {
 
             // Buffer for decoding blocks. Automatically reallocated if needed.

--- a/engine/src/main/java/nl/inl/blacklab/codec/SegmentForwardIndex.java
+++ b/engine/src/main/java/nl/inl/blacklab/codec/SegmentForwardIndex.java
@@ -62,6 +62,16 @@ class SegmentForwardIndex implements AutoCloseable {
         _tokensFile = postingsReader.openIndexFile(BlackLab40PostingsFormat.TOKENS_EXT);
     }
 
+    private synchronized IndexInput getCloneOfTokensIndexFile() {
+        // synchronized because clone() is not thread-safe
+        return _tokensIndexFile.clone();
+    }
+
+    private synchronized IndexInput getCloneOfTokensFile() {
+        // synchronized because clone() is not thread-safe
+        return _tokensFile.clone();
+    }
+
     @Override
     public void close() {
         try {
@@ -109,13 +119,13 @@ class SegmentForwardIndex implements AutoCloseable {
 
         private IndexInput tokensIndex() {
             if (_tokensIndex == null)
-                _tokensIndex = _tokensIndexFile.clone();
+                _tokensIndex = getCloneOfTokensIndexFile();
             return _tokensIndex;
         }
 
         private IndexInput tokens() {
             if (_tokens == null)
-                _tokens = _tokensFile.clone();
+                _tokens = getCloneOfTokensFile();
             return _tokens;
         }
 


### PR DESCRIPTION
IndexInput.clone() is not threadsafe and so must not be called by two threads at the same time. This enforces that requirement by synchronizing methods that call IndexInput.clone().