### PR TITLE
Fix issues with Terms and sensitive collator

### DIFF
--- a/core/src/test/java/nl/inl/blacklab/search/TestTerms.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestTerms.java
@@ -1,0 +1,77 @@
+package nl.inl.blacklab.search;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import nl.inl.blacklab.forwardindex.Terms;
+import nl.inl.blacklab.search.indexmetadata.Annotation;
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
+import nl.inl.blacklab.testutil.TestIndex;
+import nl.inl.util.StringUtil;
+
+@RunWith(Parameterized.class)
+public class TestTerms {
+
+    static TestIndex testIndexExternal;
+
+    static TestIndex testIndexIntegrated;
+
+    @Parameterized.Parameters(name = "index type {0}")
+    public static Collection<BlackLabIndex.IndexType> typeToUse() {
+        return List.of(BlackLabIndex.IndexType.EXTERNAL_FILES, BlackLabIndex.IndexType.INTEGRATED);
+    }
+
+    @Parameterized.Parameter
+    public BlackLabIndex.IndexType indexType;
+
+    private TestIndex testIndex;
+
+    private Terms terms;
+
+    @BeforeClass
+    public static void setUpClass() {
+        testIndexExternal = TestIndex.getWithTestDelete(BlackLabIndex.IndexType.EXTERNAL_FILES);
+        testIndexIntegrated = TestIndex.getWithTestDelete(BlackLabIndex.IndexType.INTEGRATED);
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        testIndexExternal.close();
+        testIndexIntegrated.close();
+    }
+
+    @Before
+    public void setUp() {
+        testIndex = indexType == BlackLabIndex.IndexType.EXTERNAL_FILES ? testIndexExternal : testIndexIntegrated;
+        BlackLabIndex index = testIndex.index();
+        Annotation ann = index.mainAnnotatedField().mainAnnotation();
+        terms = index.annotationForwardIndex(ann).terms();
+    }
+
+    @Test
+    public void testTerms() {
+        for (int i = 0; i < terms.numberOfTerms(); i++) {
+            String term = terms.get(i);
+            int index = terms.indexOf(term);
+            Assert.assertEquals(i, index);
+
+            String termDesensitized = StringUtil.desensitize(term);
+            MutableIntSet results = new IntHashSet();
+            terms.indexOf(results, term, MatchSensitivity.INSENSITIVE);
+            results.forEach(termId -> {
+                String foundTerm = StringUtil.desensitize(terms.get(termId));
+                Assert.assertEquals(termDesensitized, foundTerm);
+            });
+        }
+    }
+}

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexAbstract.java
@@ -34,7 +34,7 @@ public abstract class ForwardIndexAbstract implements ForwardIndex {
             throw new IllegalArgumentException("Value(s) out of range, start = " + snippetStart
                     + ", end = " + snippetEnd + ", content length = " + docLength);
         }
-        if (snippetEnd < snippetStart) {
+        if (snippetStart > snippetEnd) {
             throw new IllegalArgumentException(
                     "Tried to read negative length snippet (from " + snippetStart
                             + " to " + snippetEnd + ")");

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/Terms.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/Terms.java
@@ -17,8 +17,8 @@ public interface Terms {
     /** The value to use meaning "no term" (e.g. if the document ends) */
     int NO_TERM = -1;
 
-    /** Default (only) charset we use for serializing terms. */
-    Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+    /** Charset we use for serializing terms. */
+    Charset TERMS_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * Get the existing index number of a term, or add it to the term list and

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsExternalUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsExternalUtil.java
@@ -71,7 +71,7 @@ public abstract class TermsExternalUtil {
             for (; currentTerm < firstTermInBlock + numTermsThisBlock; currentTerm++) {
                 int offset = termStringOffsets[currentTerm];
                 int length = termStringOffsets[currentTerm + 1] - offset;
-                String str = new String(termStringsThisBlock, offset, length, Terms.DEFAULT_CHARSET);
+                String str = new String(termStringsThisBlock, offset, length, Terms.TERMS_CHARSET);
 
                 // We need to find term for id while searching
                 terms[currentTerm] = str;

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsIntegrated.java
@@ -225,7 +225,7 @@ public class TermsIntegrated extends TermsReaderAbstract {
                 // Keep the same sort position because the terms are the same
                 sortPosition = prevSortPosition;
                 // This should never happen with sensitive sort (all values should be unique)
-                assert cmp == CMP_TERM_INSENSITIVE;
+                assert cmp == CMP_TERM_INSENSITIVE : "Duplicate term in sensitive sort: " + terms[prevTermId].term + " vs. " + terms[termId].term;
             } else {
                 // Remember the sort position in case the next term is identical
                 prevSortPosition = sortPosition;

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsIntegrated.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsIntegrated.java
@@ -48,7 +48,7 @@ public class TermsIntegrated extends TermsReaderAbstract {
         public TermInIndex(String term, int globalTermId) {
             this.term = term;
             this.globalTermId = globalTermId;
-            ckSensitive = collator.getCollationKey(term);
+            ckSensitive = collatorSensitive.getCollationKey(term);
             ckInsensitive = collatorInsensitive.getCollationKey(term);
         }
 

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReaderAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReaderAbstract.java
@@ -213,8 +213,7 @@ public abstract class TermsReaderAbstract implements Terms {
             }
             sortPosition2GroupOffset[sortPosition] = groupOffset;
         }
-
-        fixSortPosition2GroupOffsetArray(sortPosition2GroupOffset);
+        fixSortPosition2GroupOffsetArray(sortPosition2GroupOffset); // fix empty spaces in array so binary search works
         return sortPosition2GroupOffset;
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReaderAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsReaderAbstract.java
@@ -269,7 +269,7 @@ public abstract class TermsReaderAbstract implements Terms {
         this.termId2CharDataOffset = new long[numberOfTerms];
         for (int i = 0; i < numberOfTerms; ++i) {
             this.termId2CharDataOffset[i] = bytesWritten;
-            byte[] bytes = terms[i].getBytes(DEFAULT_CHARSET);
+            byte[] bytes = terms[i].getBytes(TERMS_CHARSET);
             byte[][] bb = BigArrays.wrap(bytes);
             termCharData.addElements(bytesWritten, bb);
             bytesWritten += bytes.length;
@@ -330,13 +330,13 @@ public abstract class TermsReaderAbstract implements Terms {
             return "";
         }
         boolean isLastId = id == (this.termId2CharDataOffset.length - 1);
-        long start = this.termId2CharDataOffset[id];
-        long end = (isLastId ? this.termCharData.size64() : this.termId2CharDataOffset[id+1]);
-        int length = (int) (end-start);
+        long startOffsetBytes = this.termId2CharDataOffset[id];
+        long endOffsetBytes = (isLastId ? this.termCharData.size64() : this.termId2CharDataOffset[id+1]);
+        int termLengthBytes = (int) (endOffsetBytes - startOffsetBytes);
 
-        byte[] out = new byte[length];
-        this.termCharData.getElements(start, out, 0, length);
-        return new String(out, DEFAULT_CHARSET);
+        byte[] termBytes = new byte[termLengthBytes];
+        this.termCharData.getElements(startOffsetBytes, termBytes, 0, termLengthBytes);
+        return new String(termBytes, TERMS_CHARSET);
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/forwardindex/TermsWriter.java
@@ -143,7 +143,7 @@ class TermsWriter implements Terms {
                     for (Map.Entry<CollationKey, Integer> entry : termIndex.entrySet()) {
                         String term = entry.getKey().getSourceString();
                         terms[entry.getValue()] = term;
-                        termStringsByteSize += term.getBytes(DEFAULT_CHARSET).length;
+                        termStringsByteSize += term.getBytes(TERMS_CHARSET).length;
                     }
 
                     // Calculate the file length and map the file
@@ -174,7 +174,7 @@ class TermsWriter implements Terms {
                         long blockSizeBytes = 2 * Integer.BYTES;
                         while (currentTerm < n) {
                             termStringOffsets[currentTerm] = currentOffset;
-                            byte[] termBytes = terms[currentTerm].getBytes(DEFAULT_CHARSET);
+                            byte[] termBytes = terms[currentTerm].getBytes(TERMS_CHARSET);
                             long newBlockSizeBytes = blockSizeBytes + Integer.BYTES + termBytes.length; // block grows by 1 offset and this term's bytes
                             if (newBlockSizeBytes > maxBlockSize) {
                                 // Block is full. Write it and continue with next block.

--- a/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
@@ -3,6 +3,7 @@ package nl.inl.blacklab.search.results;
 import java.util.List;
 import java.util.Objects;
 
+import nl.inl.blacklab.Constants;
 import nl.inl.blacklab.search.indexmetadata.RelationUtil;
 import nl.inl.blacklab.search.lucene.MatchInfo;
 import nl.inl.blacklab.search.lucene.RelationInfo;
@@ -14,6 +15,8 @@ import nl.inl.blacklab.search.lucene.RelationInfo;
  * The other functionality will be added in the future.
  */
 public class ContextSize {
+
+    public static final int SAFE_MAX_CONTEXT_SIZE = (Constants.JAVA_MAX_ARRAY_SIZE - 100) / 2;
 
     /**
      * Context based on am inline tag containing the hit instead of the hit.
@@ -129,6 +132,10 @@ public class ContextSize {
 
     private ContextSize(int before, int after, boolean includeHit, String matchInfoName, int maxSnippetLength) {
         super();
+        assert before >= 0;
+        assert after >= 0;
+        assert matchInfoName == null || !matchInfoName.isEmpty();
+        assert maxSnippetLength >= 0;
         this.before = before;
         this.after = after;
         this.includeHit = includeHit;
@@ -137,6 +144,8 @@ public class ContextSize {
     }
 
     public static int maxSnippetLengthFromMaxContextSize(int maxContextSize) {
+        if (maxContextSize > SAFE_MAX_CONTEXT_SIZE)
+            maxContextSize = SAFE_MAX_CONTEXT_SIZE;
         return maxContextSize * 2 + 10; // 10 seems a reasonable maximum hit length
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/ContextSize.java
@@ -159,6 +159,7 @@ public class ContextSize {
      * @param endIndex index in endArr to write end position to
      */
     public void getSnippetStartEnd(Hit hit, List<String> matchInfoNames, boolean lastWordInclusive, int[] startArr, int startIndex, int[] endArr, int endIndex) {
+        assert hit.start() <= hit.end();
         int start, end;
         if (!isInlineTag()) {
             // Use the hit to determine snippet
@@ -176,6 +177,8 @@ public class ContextSize {
             // End should point to the last word of the snippet, not to the first word after the snippet
             end--;
         }
+
+        assert start <= end;
 
         // Write results into output arrays
         startArr[startIndex] = start;

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternal.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternal.java
@@ -11,11 +11,11 @@ import nl.inl.blacklab.search.lucene.MatchInfo;
 
 /**
  * A list of simple hits.
- *
+ * <p>
  * Contrary to {@link Hits}, this only contains doc, start and end
  * for each hit, so no captured groups information, and no other
  * bookkeeping (hit/doc retrieved/counted stats, hasAscendingLuceneDocIds, etc.).
- *
+ * <p>
  * This is a read-only interface.
  */
 public interface HitsInternal extends Iterable<EphemeralHit> {
@@ -118,7 +118,7 @@ public interface HitsInternal extends Iterable<EphemeralHit> {
 
     /**
      * Get extra information for a match, such as captured groups and relations.
-     *
+     * <p>
      * Only available if the query captures such information.
      *
      * @return extra information for a match, or null if none available

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalLock.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalLock.java
@@ -6,7 +6,6 @@ import java.util.function.Consumer;
 
 import nl.inl.blacklab.resultproperty.HitProperty;
 import nl.inl.blacklab.search.lucene.MatchInfo;
-import nl.inl.blacklab.search.lucene.RelationInfo;
 
 /**
  * A HitsInternal implementation that locks and can handle huge result sets.
@@ -20,6 +19,7 @@ class HitsInternalLock extends HitsInternalNoLock {
     }
 
     public void add(int doc, int start, int end, MatchInfo[] matchInfo) {
+        assert start <= end;
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -37,6 +37,7 @@ class HitsInternalLock extends HitsInternalNoLock {
      * Add the hit to the end of this list, copying the values. The hit object itself is not retained.
      */
     public void add(EphemeralHit hit) {
+        assert hit.start <= hit.end;
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -53,6 +54,7 @@ class HitsInternalLock extends HitsInternalNoLock {
      * Add the hit to the end of this list, copying the values. The hit object itself is not retained.
      */
     public void add(Hit hit) {
+        assert hit.start() <= hit.end();
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -114,8 +116,10 @@ class HitsInternalLock extends HitsInternalNoLock {
         try {
             // Don't call super method, this is faster (hot code)
             MatchInfo[] matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
-            return new HitImpl(docs.getInt((int) index), starts.getInt((int) index), ends.getInt((int) index),
+            HitImpl hit = new HitImpl(docs.getInt((int) index), starts.getInt((int) index), ends.getInt((int) index),
                     matchInfo);
+            assert hit.start() <= hit.end();
+            return hit;
         } finally {
             lock.readLock().unlock();
         }
@@ -142,6 +146,7 @@ class HitsInternalLock extends HitsInternalNoLock {
             h.start = starts.getInt(index);
             h.end = ends.getInt(index);
             h.matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
+            assert h.start <= h.end;
         } finally {
             lock.readLock().unlock();
         }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalLock32.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalLock32.java
@@ -35,6 +35,7 @@ class HitsInternalLock32 extends HitsInternalNoLock32 {
 
     @Override
     public void add(int doc, int start, int end, MatchInfo[] matchInfo) {
+        assert start <= end;
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -51,6 +52,7 @@ class HitsInternalLock32 extends HitsInternalNoLock32 {
     /** Add the hit to the end of this list, copying the values. The hit object itself is not retained. */
     @Override
     public void add(EphemeralHit hit) {
+        assert hit.start <= hit.end;
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -67,6 +69,7 @@ class HitsInternalLock32 extends HitsInternalNoLock32 {
     /** Add the hit to the end of this list, copying the values. The hit object itself is not retained. */
     @Override
     public void add(Hit hit) {
+        assert hit.start() <= hit.end();
         this.lock.writeLock().lock();
         try {
             // Don't call super method, this is faster (hot code)
@@ -126,7 +129,10 @@ class HitsInternalLock32 extends HitsInternalNoLock32 {
         try {
             // Don't call super method, this is faster (hot code)
             MatchInfo[] matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
-            return new HitImpl(docs.getInt((int)index), starts.getInt((int)index), ends.getInt((int)index), matchInfo);
+            HitImpl hit = new HitImpl(docs.getInt((int) index), starts.getInt((int) index), ends.getInt((int) index),
+                    matchInfo);
+            assert hit.start() <= hit.end();
+            return hit;
         } finally {
             lock.readLock().unlock();
         }
@@ -155,6 +161,7 @@ class HitsInternalLock32 extends HitsInternalNoLock32 {
             h.start = starts.getInt((int)index);
             h.end = ends.getInt((int)index);
             h.matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
+            assert h.start <= h.end;
         } finally {
             lock.readLock().unlock();
         }

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalNoLock32.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsInternalNoLock32.java
@@ -98,10 +98,19 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
         this.starts = starts;
         this.ends = ends;
         this.matchInfos = matchInfos == null ? new ObjectArrayList<>() : matchInfos;
+        assert allValid(this);
+    }
+
+    private boolean allValid(HitsInternal hits) {
+        for (EphemeralHit h: hits) {
+            assert h.start <= h.end;
+        }
+        return true;
     }
 
     @Override
     public void add(int doc, int start, int end, MatchInfo[] matchInfo) {
+        assert start <= end;
         docs.add(doc);
         starts.add(start);
         ends.add(end);
@@ -112,6 +121,7 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
     /** Add the hit to the end of this list, copying the values. The hit object itself is not retained. */
     @Override
     public void add(EphemeralHit hit) {
+        assert hit.start <= hit.end;
         docs.add(hit.doc);
         starts.add(hit.start);
         ends.add(hit.end);
@@ -122,6 +132,7 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
     /** Add the hit to the end of this list, copying the values. The hit object itself is not retained. */
     @Override
     public void add(Hit hit) {
+        assert hit.start() <= hit.end();
         docs.add(hit.doc());
         starts.add(hit.start());
         ends.add(hit.end());
@@ -130,6 +141,7 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
     }
 
     public void addAll(HitsInternalNoLock32 hits) {
+        assert allValid(hits);
         docs.addAll(hits.docs);
         starts.addAll(hits.starts);
         ends.addAll(hits.ends);
@@ -139,6 +151,7 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
     public void addAll(HitsInternal hits) {
         hits.withReadLock(hr -> {
             for (EphemeralHit h: hr) {
+                assert h.start <= h.end;
                 docs.add(h.doc);
                 starts.add(h.start);
                 ends.add(h.end);
@@ -166,7 +179,10 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
     @Override
     public HitImpl get(long index) {
         MatchInfo[] matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
-        return new HitImpl(docs.getInt((int)index), starts.getInt((int)index), ends.getInt((int)index), matchInfo);
+        HitImpl hit = new HitImpl(docs.getInt((int) index), starts.getInt((int) index), ends.getInt((int) index),
+                matchInfo);
+        assert hit.start() <= hit.end();
+        return hit;
     }
 
     /**
@@ -189,6 +205,7 @@ class HitsInternalNoLock32 implements HitsInternalMutable {
         h.start = starts.getInt((int)index);
         h.end = ends.getInt((int)index);
         h.matchInfo = matchInfos.isEmpty() ? null : matchInfos.get((int) index);
+        assert h.start <= h.end;
     }
 
     @Override

--- a/engine/src/test/java/nl/inl/blacklab/forwardindex/TestTerms.java
+++ b/engine/src/test/java/nl/inl/blacklab/forwardindex/TestTerms.java
@@ -16,9 +16,9 @@ import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 import nl.inl.util.UtilsForTesting;
 
 public class TestTerms {
-    private static TermsReader t;
+    public static final String[] TEST_SENTENCE = { "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog" };
 
-    final static String[] str = { "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog" };
+    private static TermsReader t;
 
     private static UtilsForTesting.TestDir testDir;
 
@@ -33,7 +33,7 @@ public class TestTerms {
         Collators colls = new Collators(coll, CollatorVersion.V2);
         TermsWriter tw = TermsExternalUtil.openForWriting(colls, null);
         tw.setMaxBlockSize(18);
-        for (String s: str) {
+        for (String s: TEST_SENTENCE) {
             tw.indexOf(s);
         }
         File f = new File(testDir.file(), "terms.dat");
@@ -54,9 +54,8 @@ public class TestTerms {
      */
     @Test
     public void testRetrieve() {
-        String[] expected = { "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog" };
-        for (int i = 0; i < expected.length; i++) {
-            Assert.assertEquals(expected[i], t.get(i));
+        for (int i = 0; i < TEST_SENTENCE.length; i++) {
+            Assert.assertEquals(TEST_SENTENCE[i], t.get(i));
         }
     }
 
@@ -93,24 +92,18 @@ public class TestTerms {
 
     @Test
     public void testIndexOf() {
-        String[] input = {
-                "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog"
-        };
         int[] expected = { 0, 1, 2, 3, 4, 5, 6, 7 };
         for (int i = 0; i < expected.length; i++) {
-            Assert.assertEquals(expected[i], t.indexOf(input[i]));
+            Assert.assertEquals(expected[i], t.indexOf(TEST_SENTENCE[i]));
         }
     }
 
     @Test
     public void testIndexOfInsensitive() {
-        String[] input = {
-                "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog"
-        };
         int[] expected = { 0, 1, 2, 3, 4, 5, 6, 7 };
         for (int i = 0; i < expected.length; i++) {
             MutableIntSet results = new IntHashSet();
-            t.indexOf(results, input[i], MatchSensitivity.INSENSITIVE);
+            t.indexOf(results, TEST_SENTENCE[i], MatchSensitivity.INSENSITIVE);
             Assert.assertEquals(expected[i], results.intIterator().next());
         }
     }

--- a/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
@@ -40,7 +40,7 @@ public class TermSerialization {
         s.clear();
         terms.indexOf(s, word, MatchSensitivity.INSENSITIVE);
         report("terms.indexOf insensitive", s);
-`
+
         System.out.println("Checking these insensitive terms...");
         System.out.flush();
         IntIterator it = s.intIterator();

--- a/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
@@ -1,0 +1,83 @@
+package nl.inl.blacklab.testutil;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+
+import nl.inl.blacklab.forwardindex.AnnotationForwardIndex;
+import nl.inl.blacklab.forwardindex.Terms;
+import nl.inl.blacklab.search.BlackLab;
+import nl.inl.blacklab.search.BlackLabIndex;
+import nl.inl.blacklab.search.indexmetadata.AnnotatedField;
+import nl.inl.blacklab.search.indexmetadata.Annotation;
+import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
+
+public class TermSerialization {
+
+    private static Terms terms;
+
+    public static void main(String[] args) throws IOException {
+        String path = args.length >= 1 ? args[0] : ".";
+        String word = args.length >= 2 ? args[1] : "in";
+        String annotationName = args.length >= 3 ? args[2] : "";
+
+        BlackLabIndex index = BlackLab.open(new File(path));
+        AnnotatedField field = index.annotatedField("contents");
+        Annotation annotation = annotationName.isEmpty() ? field.mainAnnotation() : field.annotation(annotationName);
+        AnnotationForwardIndex fi = index.annotationForwardIndex(annotation);
+        terms = fi.terms();
+
+        MutableIntSet s = new IntHashSet();
+        int sensitiveIndex = terms.indexOf(word);
+        s.add(sensitiveIndex);
+        report("terms.indexOf", s);
+        s.clear();
+        terms.indexOf(s, word, MatchSensitivity.SENSITIVE);
+        report("terms.indexOf sensitive", s);
+        s.clear();
+        terms.indexOf(s, word, MatchSensitivity.INSENSITIVE);
+        report("terms.indexOf insensitive", s);
+`
+        System.out.println("Checking these insensitive terms...");
+        System.out.flush();
+        IntIterator it = s.intIterator();
+        while (it.hasNext()) {
+            int termId = it.next();
+            String term = terms.get(termId);
+            int termId2 = terms.indexOf(term);
+            if (termId != termId2) {
+                System.out.println("termId != termId2: " + termId + " != " + termId2 + " (term: " + term + ")");
+            }
+        }
+
+        System.out.println("Checking all terms...");
+        System.out.flush();
+        int n = 0;
+        for (int termId = 0; termId < terms.numberOfTerms(); termId++) {
+            String term = terms.get(termId);
+            int termId2 = terms.indexOf(term);
+            if (termId != termId2) {
+                System.out.println("termId != termId2: " + termId + " != " + termId2 + " (term: " + term + ")");
+                System.out.flush();
+            }
+            n++;
+            if (n % 100000 == 0) {
+                System.out.println(n + " terms checked...");
+                System.out.flush();
+            }
+        }
+    }
+
+    private static void report(String prompt, MutableIntSet s1) {
+        StringBuilder values = new StringBuilder();
+        for (int i : s1.toArray()) {
+            values.append(i).append(" (").append(terms.get(i)).append("); ");
+        }
+        System.out.println(prompt + ": " + values);
+        System.out.flush();
+    }
+
+}

--- a/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/TermSerialization.java
@@ -2,12 +2,14 @@ package nl.inl.blacklab.testutil;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.Collator;
 
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 
 import nl.inl.blacklab.forwardindex.AnnotationForwardIndex;
+import nl.inl.blacklab.forwardindex.Collators;
 import nl.inl.blacklab.forwardindex.Terms;
 import nl.inl.blacklab.search.BlackLab;
 import nl.inl.blacklab.search.BlackLabIndex;
@@ -41,6 +43,9 @@ public class TermSerialization {
         terms.indexOf(s, word, MatchSensitivity.INSENSITIVE);
         report("terms.indexOf insensitive", s);
 
+        Collators collators = fi.collators();
+        Collator collator = collators.get(MatchSensitivity.SENSITIVE);
+
         System.out.println("Checking these insensitive terms...");
         System.out.flush();
         IntIterator it = s.intIterator();
@@ -48,8 +53,9 @@ public class TermSerialization {
             int termId = it.next();
             String term = terms.get(termId);
             int termId2 = terms.indexOf(term);
-            if (termId != termId2) {
-                System.out.println("termId != termId2: " + termId + " != " + termId2 + " (term: " + term + ")");
+            String term2 = terms.get(termId2);
+            if (collator.compare(term, term2) != 0) {
+                System.out.println("term != term2: '" + term + "' != '" + term2 + "'");
             }
         }
 
@@ -59,8 +65,9 @@ public class TermSerialization {
         for (int termId = 0; termId < terms.numberOfTerms(); termId++) {
             String term = terms.get(termId);
             int termId2 = terms.indexOf(term);
-            if (termId != termId2) {
-                System.out.println("termId != termId2: " + termId + " != " + termId2 + " (term: " + term + ")");
+            String term2 = terms.get(termId2);
+            if (collator.compare(term, term2) != 0) {
+                System.out.println("term != term2: '" + term + "' != '" + term2 + "'");
                 System.out.flush();
             }
             n++;

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocSnippet.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultDocSnippet.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import org.apache.lucene.document.Document;
 
-import nl.inl.blacklab.Constants;
 import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 import nl.inl.blacklab.exceptions.InvalidQuery;
 import nl.inl.blacklab.search.BlackLabIndex;
@@ -59,8 +58,6 @@ public class ResultDocSnippet {
 
         // Make sure snippet plus surrounding context don't exceed configured allowable snippet size
         int maxContextSize = params.getSearchManager().config().getParameters().getContextSize().getMaxInt();
-        if (maxContextSize >= Constants.JAVA_MAX_ARRAY_SIZE)
-            maxContextSize = (Constants.JAVA_MAX_ARRAY_SIZE - 100) / 2; // safe maximum
         int maxSnippetSize = ContextSize.maxSnippetLengthFromMaxContextSize(maxContextSize);
 
         int start, end;


### PR DESCRIPTION
Terms used to assume that the sensitive collator sees all different Strings as different, but this is not always true (e.g. different whitespace characters may be treated as identical). This should fix that by accepting that even for sensitive comparison, we may still have a group of term ids that are considered equal to one another.