### PR TITLE
Change how (multiple) metadata values are escaped in CSV

### DIFF
--- a/site/docs/server/overview.md
+++ b/site/docs/server/overview.md
@@ -17,14 +17,6 @@ If both are specified, the parameter has precedence.
 
 We'll usually use JSON in our examples.
 
-::: info Extra parameters for CSV
-
-(for CSV hits/docs results, the parameters `csvsummary` determines whether to include a summary of 
-the search parameters in the output `[no]` and `csvsepline` determines whether to include a separator declaration 
-that will help Microsoft Excel read the file `[no]`)
-
-:::
-
 ### Running results count
 
 BlackLab Server is mostly stateless: a particular URL will always result in the same response. An exception to this is the running result count. When you're requesting a page of results, and there are more results to the query, BlackLab Server will retrieve these results in the background. It will report how many results it has retrieved and whether it has finished or is still retrieving.

--- a/site/docs/server/rest-api/README.md
+++ b/site/docs/server/rest-api/README.md
@@ -4,11 +4,34 @@ This documents all of BlackLab Server's endpoints. For a more guided introducion
 
 <!-- (used this [template](https://github.com/jamescooke/restapidocs/tree/master/examples)) -->
 
-## API compatibility
+## General notes
+
+### API compatibility
 
 Use `api=3` or `api=4` to specify the API version to use. Differences from 3 to 4 are minor; some inconsistencies are fixed and some redundant information was removed from responses. Configure `parameters.api` in your `blacklab-server.yaml` to set the default version to use. Support for older version(s) is a transitionary measure and will eventually be dropped.
 
 Full details can be found in [API versions](api-versions.md).
+
+### Output format
+
+To request a specific output format, either:
+
+- pass the HTTP header `Accept` with the value `application/json`, `application/xml` or `text/csv`, or
+- pass the query parameter `outputformat` with the value `json`, `xml` or `csv`.
+
+If both are specified, the parameter has precedence.
+
+::: details Notes about CSV
+
+For CSV hits/docs results, the parameters `csvsummary` determines whether to include a summary of the search parameters in the output `[no]` and `csvsepline` determines whether to include a separator declaration that will help Microsoft Excel read the file `[no]`.
+
+`listvalues` can be a comman-separated list of annotations to include in the results. `listmetadatavalues` is the same for metadata fields.
+
+If a metadata field has multiple values (e.g. if a document has multiple authors), they will be concatenated with `|` as the separator. `|`, `\n`, `\r` and `\\` will be backslash-escaped.
+
+As is common in CSV, values may be double-quoted if necessary (e.g. if a value contains a comma). Any double quotes already in the values will be doubled, so `say "yes", or "no"?` will become `"say ""yes"", or ""no""?"`
+
+:::
 
 
 ## Root endpoint

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/WriteCsv.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/WriteCsv.java
@@ -220,35 +220,20 @@ public class WriteCsv {
     }
 
     /*
-     * We must support multiple values in a single csv cell.
-     * We must also support values containing quotes/whitespace/commas.
+     * Create a single string value from (potentially) multiple input values.
      *
-     * This mean we must delimit individual values, we do this by surrounding them by quotes and separating them with a single space
-     *
-     * Existing quotes will be escaped by doubling them as per the csv escaping conventions
-     * Essentially transform
-     *      a value containing "quotes"
-     *      a "value" containing , as well as "quotes"
-     * into
-     *      "a value containing ""quotes"""
-     *      "a ""value"" containing , as well as ""quotes"""
-     *
-     * Decoders must split the value on whitespace outside quotes, then strip outside quotes, then replace the doubled quotes with singular quotes
-    */
-    private static String escape(String[] strings) {
-        StringBuilder sb = new StringBuilder();
-        boolean firstValue = true;
-        for (String value : strings) {
-            if (!firstValue) {
-                sb.append(" ");
-            }
-            sb.append('"');
-            sb.append(value.replace("\n", "").replace("\r", "").replace("\"", "\"\""));
-            sb.append('"');
-            firstValue = false;
-        }
-
-        return sb.toString();
+     * Multiple values are concatenated by a pipe symbol.
+     * Pipe symbols, newlines and carriage returns in the input values are
+     * escaped with a backslash.
+     * Any other required escaping should be taken care of by Commons CSV.
+     */
+    static String escape(String[] strings) {
+        return Arrays.stream(strings)
+                .map(value -> value
+                        .replaceAll("\n", "\\\\n")
+                        .replaceAll("\r", "\\\\r")
+                        .replaceAll("\\|", "\\\\|"))
+                .collect(Collectors.joining("|"));
     }
 
     static synchronized void writeRow(CSVPrinter printer, int numColumns, Object... values) {

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/WriteCsv.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/WriteCsv.java
@@ -230,6 +230,7 @@ public class WriteCsv {
     static String escape(String[] strings) {
         return Arrays.stream(strings)
                 .map(value -> value
+                        .replaceAll("\\\\", "\\\\\\\\")
                         .replaceAll("\n", "\\\\n")
                         .replaceAll("\r", "\\\\r")
                         .replaceAll("\\|", "\\\\|"))

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultHitsCsv.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/ResultHitsCsv.java
@@ -97,11 +97,13 @@ public class ResultHitsCsv {
                 first = 0;
 
             long number = params.getSearchManager().config().getSearch().getMaxHitsToRetrieve();
+            if (number < 0)
+                number = Long.MAX_VALUE;
             if (params.optNumberOfResultsToShow().isPresent()) {
                 long requested = params.optNumberOfResultsToShow().get();
-                if (number >= 0 || requested >= 0) { // clamp
-                    number = Math.min(requested, number);
-                }
+                if (requested < 0)
+                    requested = Long.MAX_VALUE;
+                number = Math.min(requested, number);
             }
 
             if (number >= 0)

--- a/wslib/src/test/java/nl/inl/blacklab/server/lib/TestWriteCsv.java
+++ b/wslib/src/test/java/nl/inl/blacklab/server/lib/TestWriteCsv.java
@@ -1,0 +1,36 @@
+package nl.inl.blacklab.server.lib;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestWriteCsv {
+
+    void assertEscapesTo(String expected, String... values) {
+        try {
+            final StringWriter csvContent = new StringWriter();
+            final CSVPrinter csvPrinter = new CSVPrinter(csvContent, CSVFormat.DEFAULT);
+            csvPrinter.printRecord(WriteCsv.escape(values));
+            final String result = csvContent.toString().trim();
+            Assert.assertEquals(expected, result);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEscape() {
+        assertEscapesTo("TAS", "TAS");
+        assertEscapesTo("A|B", "A", "B");
+        assertEscapesTo("A C|B", "A C", "B");
+        assertEscapesTo("\"A\"\"C|B\"", "A\"C", "B");
+        assertEscapesTo("\"A,C|B\"", "A,C", "B");
+        assertEscapesTo("A;C|B", "A;C", "B");
+        assertEscapesTo("A\\nC|B", "A\nC", "B");
+        assertEscapesTo("A\\rC|B", "A\rC", "B");
+    }
+}

--- a/wslib/src/test/java/nl/inl/blacklab/server/lib/TestWriteCsv.java
+++ b/wslib/src/test/java/nl/inl/blacklab/server/lib/TestWriteCsv.java
@@ -32,5 +32,6 @@ public class TestWriteCsv {
         assertEscapesTo("A;C|B", "A;C", "B");
         assertEscapesTo("A\\nC|B", "A\nC", "B");
         assertEscapesTo("A\\rC|B", "A\rC", "B");
+        assertEscapesTo("A\\\\C|B", "A\\C", "B");
     }
 }


### PR DESCRIPTION
Currently, if metadata is included in CSV, lots of quotes are added. This is because a metadata field can have multiple values and the choice was made to surround these values in quotes, which causes these quotes to be doubled up and the entire value to be surrounded in quotes again when actually writing the value to the CSV file. E.g. the two values `A` and `B` become `"A" "B"` which is then written to a CSV file as `"""A"" ""B"""`.

This PR proposes an alternative way of doing it that may be more user-friendly: multiple values are separated by `|`. Pipe symbols in the original values are escaped with a backslash to `\|`. Newlines and carriage returns are escaped this was as well, to `\n` and `\r` (both are currently removed).

Advantages:
- single values will not be changed (whereas currently a single value like `TAS` becomes `"""TAS"""`
- multiple values become more readable / easier to parse (e.g. `A|B` instead of `"""A"" ""B"""`)
- newlines and carriage returns are preserved

Disadvantages:
- from the cell value alone you cannot deduce anymore if this was originally an array of length 1 or a simple string
- mixing two escaping schemes (CSV escapes `"` to `""`; we add backslash escaping, though only in the hopefully rare cases where pipe, newline or CR occur in metadata values)

I feel this is a good trade-off that makes the metadata values in CSV more usable for the average person. Of course it does break compatibility with the previous CSV scheme; we'll have to discuss if this is acceptable.