### PR TITLE
Optimize finding tags/relations with/without attributes

### DIFF
--- a/doc/technical/design/plan-relations.md
+++ b/doc/technical/design/plan-relations.md
@@ -501,8 +501,8 @@ We'll start with the second option, which has the advantage that the associated 
 
 The term indexed is a string of one of these forms:
 
-    relClass::relType\u0003
-    relClass::relType\u0003\u0001attr1\u0002value1\u0003\u0001attr2\u0002value2\u0003...
+    relClass::relType\u0001
+    relClass::relType\u0001\u0003attr1\u0002value1\u0001\u0003attr2\u0002value2\u0001...
 
 We call `relClass::relType` the _full relation type_. It consists of the relation class and the relation type. The relation class distinguishes between different types of relations, e.g. `__tag` for inline tags, `dep` for dependency relations, etc. The relation type is used to distinguish between different relations of the same class, e.g. `dep::subject` for subject relations, `dep::object` for object relations, `dep::nsubj` for nominal subject relations, etc.
 

--- a/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/DocIndexerXmlHandlers.java
@@ -256,14 +256,19 @@ public abstract class DocIndexerXmlHandlers extends DocIndexerLegacy {
         public void endElement(String uri, String localName, String qName) {
             // Add payload to start tag annotation indicating end position
             int lastIndex = openTagIndexes.size() - 1;
-            Integer openTagIndex = openTagIndexes.remove(lastIndex);
             int openTagPosition = openTagPositions.remove(lastIndex);
             int closeTagPosition = propMain.lastValuePosition() + 1;
             BytesRef payload = PayloadUtils.tagEndPositionPayload(openTagPosition,
                     closeTagPosition, getIndexType());
+            Integer openTagIndex = openTagIndexes.remove(lastIndex);
+            if (openTagIndex < 0) {
+                // Negative value means two terms were indexed (one with, one without attributes, for search performance)
+                // and this is the index of the last term. Make sure we update both payloads.
+                openTagIndex = -openTagIndex;
+                propTags.setPayloadAtIndex(openTagIndex - 1, payload);
+            }
             propTags.setPayloadAtIndex(openTagIndex, payload);
         }
-
     }
 
     /**

--- a/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/index/annotated/AnnotationWriter.java
@@ -460,8 +460,12 @@ public class AnnotationWriter {
         } else {
             // integrated index; everything is indexed as a single term
             String value = RelationUtil.indexTerm(fullRelationType, attributes);
-            payload = relationInfo.serialize();
+            // We only add the payload if we know the complete relation info;
+            // for inline tags, we'll only know it when we encounter the closing tag,
+            // and we'll add the payload then.
+            payload = relationInfo.hasTarget() ? relationInfo.serialize() : null;
             addValueAtPosition(value, relationInfo.getSourceStart(), payload);
+
             tagIndexInAnnotation = lastValueIndex();
         }
         return tagIndexInAnnotation;

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerBase.java
@@ -494,7 +494,14 @@ public abstract class DocIndexerBase extends DocIndexerAbstract {
                 throw new MalformedInputFile(
                         "Close tag " + tagName + " found, but " + openTag.name + " expected");
             BytesRef payload = PayloadUtils.tagEndPositionPayload(openTag.position, currentPos, getIndexType());
-            tagsAnnotation().setPayloadAtIndex(openTag.index, payload);
+            int index = openTag.index;
+            if (index < 0) {
+                // Negative value means two terms were indexed (one with, one without attributes, for search performance)
+                // and this is the index of the last term. Make sure we update both payloads.
+                index = -index;
+                tagsAnnotation().setPayloadAtIndex(index - 1, payload);
+            }
+            tagsAnnotation().setPayloadAtIndex(index, payload);
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerSaxon.java
@@ -332,7 +332,7 @@ public class DocIndexerSaxon extends DocIndexerXPath<NodeInfo> {
             try (AxisIterator attributes = nodeInfo.iterateAxis(Axis.ATTRIBUTE.getAxisNumber())) {
                 while ((next = attributes.next()) != null) {
                     if (currentInline.indexAttribute(next.getDisplayName())) {
-                        atts.put(next.getDisplayName(), next.getStringValue());
+                        atts.put(next.getLocalPart(), next.getStringValue());
                     }
                 }
             }

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/DocIndexerXPath.java
@@ -156,6 +156,13 @@ public abstract class DocIndexerXPath<T> extends DocIndexerConfig {
             }
             String valueToIndex = RelationUtil.indexTermMulti(fullType, attributes);
             annotationValue(name, valueToIndex, position, endOrTarget, isRelation);
+            if (attributes != null && !attributes.isEmpty()) {
+                // Also index a version without attributes. We'll use this for faster search if we don't filter on
+                // attributes.
+                // OPT: find a way to only create the payload once, because it is identical for both.
+                valueToIndex = RelationUtil.indexTermMulti(fullType, null);
+                annotationValue(name, valueToIndex, position, endOrTarget, isRelation);
+            }
         }
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/XpathFinderVTD.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/XpathFinderVTD.java
@@ -238,6 +238,7 @@ class XpathFinderVTD {
         try {
             while ((i = apAttr.iterateAttr()) != -1) {
                 String name = nav.toString(i);
+                name = name.replaceAll("^\\w+:", ""); // remove namespace prefix
                 String value = nav.toString(i + 1);
                 attr.put(name, value);
             }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadata.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadata.java
@@ -23,6 +23,8 @@ public interface IndexMetadata extends Freezable {
         return name;
     }
 
+    String indexFlag(String name);
+
     AnnotatedFields annotatedFields();
 	
 	default AnnotatedField mainAnnotatedField() {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataExternal.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataExternal.java
@@ -180,6 +180,12 @@ public class IndexMetadataExternal extends IndexMetadataAbstract {
     }
 
     @Override
+    public String indexFlag(String name) {
+        // External index doesn't support index flags, always returns empty (not set)
+        return "";
+    }
+
+    @Override
     public void freezeBeforeIndexing() {
         // don't freeze; with this index format, it was traditionally allowed
         // for the metadata to change during indexing, because it is re-saved at

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataWriter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataWriter.java
@@ -109,6 +109,10 @@ public interface IndexMetadataWriter extends IndexMetadata {
 	 */
 	void freezeBeforeIndexing();
 
+    default void setIndexFlag(String name, String value) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
     @Override
     AnnotatedFieldsImpl annotatedFields();
 

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationUtil.java
@@ -20,11 +20,14 @@ public class RelationUtil {
      *  (e.g. "s" for sentence tag, or "nsubj" for dependency relation "nominal subject") */
     public static final String RELATION_CLASS_TYPE_SEPARATOR = "::";
 
-    /** Separator before attribute name+value in _relation annotation. */
-    private static final String ATTR_SEPARATOR = "\u0001";
+    /** Separator before attribute name in _relation annotation. */
+    private static final String CH_NAME_START = "\u0001";
 
-    /** Separator between attr and value in _relation annotation. */
-    private static final String KEY_VALUE_SEPARATOR = "\u0002";
+    /** Separator between attribyte name and value in _relation annotation. */
+    private static final String CH_VALUE_START = "\u0002";
+
+    /** Separator between after relation type and attribute value in _relation annotation. */
+    private static final String CH_VALUE_END = "\u0003";
 
     /**
      * Determine the term to index in Lucene for a relation.
@@ -34,8 +37,8 @@ public class RelationUtil {
      * @return term to index in Lucene
      */
     public static String indexTerm(String fullRelationType, Map<String, String> attributes) {
-        if (attributes == null)
-            return fullRelationType + ATTR_SEPARATOR;
+        if (attributes == null || attributes.isEmpty())
+            return fullRelationType + CH_VALUE_END;
 
         // Sort and concatenate the attribute names and values
         String attrPart = attributes.entrySet().stream()
@@ -45,7 +48,7 @@ public class RelationUtil {
                 .collect(Collectors.joining());
 
         // The term to index consists of the type followed by the (sorted) attributes.
-        return fullRelationType + ATTR_SEPARATOR + attrPart;
+        return fullRelationType + CH_VALUE_END + attrPart;
     }
 
     /**
@@ -60,7 +63,7 @@ public class RelationUtil {
      */
     public static String indexTermMulti(String fullRelationType, Map<String, Collection<String>> attributes) {
         if (attributes == null)
-            return fullRelationType + ATTR_SEPARATOR;
+            return fullRelationType + CH_VALUE_END;
 
         // Sort and concatenate the attribute names and values
         String attrPart = attributes.entrySet().stream()
@@ -72,18 +75,21 @@ public class RelationUtil {
                 .collect(Collectors.joining());
 
         // The term to index consists of the type followed by the (sorted) attributes.
-        return fullRelationType + ATTR_SEPARATOR + attrPart;
+        return fullRelationType + CH_VALUE_END + attrPart;
     }
 
     public static Map<String, String> attributesFromIndexedTerm(String indexedTerm) {
-        int i = indexedTerm.indexOf(ATTR_SEPARATOR);
+        int i = indexedTerm.indexOf(CH_NAME_START);
         if (i < 0 || i == indexedTerm.length() - 1)
             return Collections.emptyMap();
         Map<String, String> attributes = new HashMap<>();
-        for (String attrPart: indexedTerm.substring(i + 1).split(ATTR_SEPARATOR)) {
-            String[] keyVal = attrPart.split(KEY_VALUE_SEPARATOR, 2);
-            if (!attributes.containsKey(keyVal[0])) // only the first value if there's multiple!
-                attributes.put(keyVal[0], keyVal[1]);
+        for (String attrPart: indexedTerm.substring(i + 1).split(CH_NAME_START)) {
+            String[] keyVal = attrPart.split(CH_VALUE_START, 2);
+            assert keyVal[1].endsWith(CH_VALUE_END);
+            if (!attributes.containsKey(keyVal[0])) { // only the first value if there's multiple!
+                String value = keyVal[1].substring(0, keyVal[1].length() - 1); // strip closing char
+                attributes.put(keyVal[0], value);
+            }
         }
         return attributes;
     }
@@ -129,7 +135,7 @@ public class RelationUtil {
             // (In the integrated index format, we include all attributes in the term)
             return "@" + name.toLowerCase() + "__" + value.toLowerCase();
         }
-        return name + KEY_VALUE_SEPARATOR + value + ATTR_SEPARATOR;
+        return CH_NAME_START + name + CH_VALUE_START + value + CH_VALUE_END;
     }
 
     /**
@@ -141,7 +147,7 @@ public class RelationUtil {
      * @return the full relation type
      */
     public static String fullTypeFromIndexedTerm(String indexedTerm) {
-        int sep = indexedTerm.indexOf(ATTR_SEPARATOR);
+        int sep = indexedTerm.indexOf(CH_VALUE_END);
         if (sep < 0)
             return indexedTerm;
         return indexedTerm.substring(0, sep);
@@ -185,6 +191,6 @@ public class RelationUtil {
                 .collect(Collectors.joining(".*")); // zero or more chars between attribute matches
 
         // The regex consists of the type part followed by the (sorted) attributes part.
-        return fullRelationType + ATTR_SEPARATOR + ".*" + (attrPart.isEmpty() ? "" : attrPart + ".*");
+        return fullRelationType + CH_VALUE_END + ".*" + (attrPart.isEmpty() ? "" : attrPart + ".*");
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationUtil.java
@@ -183,6 +183,11 @@ public class RelationUtil {
      * @return regex to find this relation
      */
     public static String searchRegex(String fullRelationType, Map<String, String> attributes) {
+        if (attributes == null || attributes.isEmpty()) {
+            // No attribute filters, so find the faster term that only has the relation type.
+            return fullRelationType + ATTR_SEPARATOR;
+        }
+
         // Sort and concatenate the attribute names and values
         String attrPart = attributes == null ? "" : attributes.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/RelationInfo.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/RelationInfo.java
@@ -30,6 +30,19 @@ public class RelationInfo implements MatchInfo {
     }
 
     /**
+     * Check that this relation has a target set.
+     *
+     * E.g. when indexing a span ("inline tag"), we don't know the target until we encounter the closing tag,
+     * so we can't store the payload until then.
+     *
+     * @return whether we have a target or not
+     */
+    public boolean hasTarget() {
+        assert targetStart >= 0 && targetEnd >= 0 || targetStart < 0 && targetEnd < 0 : "targetStart and targetEnd inconsistent";
+        return targetStart >= 0;
+    }
+
+    /**
      * Different spans we can return for a relation
      */
     public enum SpanMode {
@@ -117,10 +130,11 @@ public class RelationInfo implements MatchInfo {
     private boolean onlyHasTarget;
 
     /** Where does the source of the relation start?
-        (the source is called 'head' in dependency relations) */
+     *  NOTE: if the relation has no source, set this to the targetStart as a convention. Invalid if < 0! */
     private int sourceStart;
 
-    /** Where does the source of the relation end? */
+    /** Where does the source of the relation end?
+     *  NOTE: if the relation has no source, set this to the targetEnd as a convention. Invalid if < 0! */
     private int sourceEnd;
 
     /** Where does the target of the relation start?
@@ -193,6 +207,7 @@ public class RelationInfo implements MatchInfo {
         this.sourceEnd = currentTokenPosition + thisLength;
         this.targetStart = currentTokenPosition + relOtherStart;
         this.targetEnd = this.targetStart + otherLength;
+        assert sourceStart >= 0 && sourceEnd >= 0 && targetStart >= 0 && targetEnd >= 0;
     }
 
     /**
@@ -201,6 +216,7 @@ public class RelationInfo implements MatchInfo {
      * @return the serialized data
      */
     public BytesRef serialize() {
+        assert sourceStart >= 0 && sourceEnd >= 0 && targetStart >= 0 && targetEnd >= 0;
         // Determine values to write from our source and target, and the position we're being indexed at
         int thisLength = sourceEnd - sourceStart;
         int relOtherStart = targetStart - sourceStart;

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryRelations.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryRelations.java
@@ -177,7 +177,7 @@ public class SpanQueryRelations extends BLSpanQuery implements TagQuery {
             throw new IllegalArgumentException("ALL_SPANS makes no sense for SpanQueryRelations");
 
         // Construct the clause from the field, relation type and attributes
-        String regexp = RelationUtil.searchRegex(relationType, attributes);
+        String regexp = RelationUtil.searchRegex(queryInfo.index(), relationType, attributes);
         RegexpQuery regexpQuery = new RegexpQuery(new Term(relationFieldName, regexp), RegExp.COMPLEMENT);
         BLSpanQuery clause = new BLSpanMultiTermQueryWrapper<>(queryInfo, regexpQuery);
 

--- a/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestAnnotatedFieldNameUtil.java
+++ b/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestAnnotatedFieldNameUtil.java
@@ -24,7 +24,7 @@ public class TestAnnotatedFieldNameUtil {
 
         // Now search with attributes in a different order - should again be sorted so the regex matches
         Map<String, String> attrSearch = Map.of("attr1", "v1", "attr3", "v3", "attr2", "v2");
-        String regex = RelationUtil.searchRegex(rt, attrSearch);
+        String regex = RelationUtil.searchRegex(null, rt, attrSearch);
         Assert.assertTrue(term.matches(regex));
     }
 }

--- a/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestRelationUtil.java
+++ b/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestRelationUtil.java
@@ -26,5 +26,10 @@ public class TestRelationUtil {
         Map<String, String> attrSearch = Map.of("attr1", "v1", "attr3", "v3", "attr2", "v2");
         String regex = RelationUtil.searchRegex(rt, attrSearch);
         Assert.assertTrue(term.matches(regex));
+
+        Map<String, String> attrDecoded = RelationUtil.attributesFromIndexedTerm(term);
+        Assert.assertEquals(attr, attrDecoded);
+
+        Assert.assertEquals(rt, RelationUtil.fullTypeFromIndexedTerm(term));
     }
 }

--- a/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestRelationUtil.java
+++ b/engine/src/test/java/nl/inl/blacklab/search/indexmetadata/TestRelationUtil.java
@@ -24,7 +24,7 @@ public class TestRelationUtil {
 
         // Now search with attributes in a different order - should again be sorted so the regex matches
         Map<String, String> attrSearch = Map.of("attr1", "v1", "attr3", "v3", "attr2", "v2");
-        String regex = RelationUtil.searchRegex(rt, attrSearch);
+        String regex = RelationUtil.searchRegex(null, rt, attrSearch);
         Assert.assertTrue(term.matches(regex));
 
         Map<String, String> attrDecoded = RelationUtil.attributesFromIndexedTerm(term);

--- a/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
+++ b/mocks/src/main/java/nl/inl/blacklab/mocks/MockIndexMetadata.java
@@ -153,4 +153,8 @@ public class MockIndexMetadata implements IndexMetadata {
         return frozen.isFrozen();
     }
 
+    @Override
+    public String indexFlag(String name) {
+        return "";
+    }
 }

--- a/site/docs/guide/corpus-query-language.md
+++ b/site/docs/guide/corpus-query-language.md
@@ -508,7 +508,7 @@ For those who already know CQL, here's a quick overview of the extent of BlackLa
 
 BlackLab currently supports (arguably) most of the important features of Corpus Query Language:
 
-* Matching on token annotations (also called properties or attributes), using regular expressions and `=`, `!=`, `!`. Example: `[word='bank']` (or just `'bank'`)
+* Matching on token annotations, using regular expressions and `=`, `!=`, `!`. Example: `[word='bank']` (or just `'bank'`)
 * Case/accent sensitive matching. Note that, unlike in CWB, case-INsensitive matching is currently the default. To explicitly match case-/accent-insensitively, use `'(?i)...'`. Example: `'(?-i)Mr\.' '(?-i)Banks'`
 * Combining criteria using `&`, `|` and `!`. Parentheses can also be used for grouping. Example: `[lemma='bank' & pos='V']`
 * Matchall pattern `[]` matches any token. Example: `'a' [] 'day'`

--- a/test/data/saved-responses-integrated/hits/containing.json
+++ b/test/data/saved-responses-integrated/hits/containing.json
@@ -64,10 +64,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S3",
-            "xml:id": "PRint602_u_23"
-          },
           "end": 158,
           "start": 153,
           "tagName": "u",
@@ -139,10 +135,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S1",
-            "xml:id": "PRint602_u_25"
-          },
           "end": 164,
           "start": 159,
           "tagName": "u",
@@ -274,10 +266,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S3",
-            "xml:id": "PRint602_u_36"
-          },
           "end": 246,
           "start": 226,
           "tagName": "u",
@@ -353,10 +341,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S3",
-            "xml:id": "PRint602_u_38"
-          },
           "end": 253,
           "start": 247,
           "tagName": "u",
@@ -452,10 +436,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S1",
-            "xml:id": "PRint602_u_39"
-          },
           "end": 264,
           "start": 253,
           "tagName": "u",

--- a/test/data/saved-responses-integrated/hits/within.json
+++ b/test/data/saved-responses-integrated/hits/within.json
@@ -52,10 +52,6 @@
       },
       "matchInfos": {
         "u": {
-          "attributes": {
-            "who": "#PRint602_S3",
-            "xml:id": "PRint602_u_36"
-          },
           "end": 246,
           "start": 226,
           "tagName": "u",


### PR DESCRIPTION
Attribute names and values are now better delineated in the indexed terms (there's a special character before the name, and before and after the value, so we can match exactly on either of these without any unwanted extra matches).

Tags/relations with attributes are now indexed twice: once without attributes and once with. If your query doesn't filter on any attributes, the former term is searched for; if it does include filters, we search for the latter. This speeds up searches without attribute filters if there are many different attribute values.

Changes how tags/relations are indexed but should gracefully deal with older and newer indexes because of an index metadata flag. (index metadata flags are a new addition and can be used to quickly add temporary properties to the index metadata to deal with this kind of variation without adding a whole new index format version)