### PR TITLE
/shared-with-me endpoint

### DIFF
--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandler.java
@@ -66,6 +66,7 @@ public abstract class RequestHandler {
     public static final String ENDPOINT_INPUT_FORMATS    = "input-formats";
     public static final String ENDPOINT_PARSE_PATTERN    = "parse-pattern";
     public static final String ENDPOINT_RELATIONS        = "relations";
+    public static final String ENDPOINT_SHARED_WITH_ME   = "shared-with-me";
     public static final String ENDPOINT_SHARING          = "sharing";
     public static final String ENDPOINT_STATUS           = "status";
     public static final String ENDPOINT_TERMFREQ         = "termfreq";
@@ -234,6 +235,10 @@ public abstract class RequestHandler {
                     requestHandler = new RequestHandlerCacheInfo(userRequest);
                 } else if (isInputFormatsRequest) {
                     requestHandler = new RequestHandlerListInputFormats(userRequest);
+                } else if (!isNewEndpoint && indexName.equals(ENDPOINT_SHARED_WITH_ME)) {
+                    if (!user.isLoggedIn())
+                        return errorObj.unauthorized("You must be logged in to see corpora shared with you.");
+                    requestHandler = new RequestHandlerSharedWithMe(userRequest);
                 } else if (indexName.length() == 0) {
                     // No index or operation given; server info
                     requestHandler = new RequestHandlerServerInfo(userRequest);

--- a/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerSharedWithMe.java
+++ b/server/src/main/java/nl/inl/blacklab/server/requesthandlers/RequestHandlerSharedWithMe.java
@@ -1,0 +1,38 @@
+package nl.inl.blacklab.server.requesthandlers;
+
+import java.util.List;
+
+import nl.inl.blacklab.server.datastream.DataStream;
+import nl.inl.blacklab.server.exceptions.BlsException;
+import nl.inl.blacklab.server.lib.results.ResponseStreamer;
+import nl.inl.blacklab.server.lib.results.WebserviceOperations;
+import nl.inl.blacklab.webservice.WebserviceOperation;
+
+/**
+ * Get and change sharing options for a user corpus.
+ */
+public class RequestHandlerSharedWithMe extends RequestHandler {
+
+    public RequestHandlerSharedWithMe(UserRequestBls userRequest) {
+        super(userRequest, WebserviceOperation.CORPUS_SHARING);
+    }
+
+    @Override
+    public int handle(ResponseStreamer rs) throws BlsException {
+        debug(logger, "REQ shared-with-me: " + indexName);
+
+        // Regular request: return the list of users this corpus is shared with
+        List<String> sharedWithMe = WebserviceOperations.getCorporaSharedWithMe(params);
+        dstreamSharedWithMeResponse(rs, sharedWithMe);
+        return HTTP_OK;
+    }
+
+    private void dstreamSharedWithMeResponse(ResponseStreamer responseWriter, List<String> corporaSharedWithMe) {
+        DataStream ds = responseWriter.getDataStream();
+        ds.startMap().startDynEntry("corpora").startList();
+        for (String corpusId: corporaSharedWithMe) {
+            ds.item("corpus", corpusId);
+        }
+        ds.endList().endDynEntry().endMap();
+    }
+}

--- a/site/docs/development/changelog.md
+++ b/site/docs/development/changelog.md
@@ -9,6 +9,7 @@
 - BlackLab Corpus Query Language (BCQL) queries now allow dashes in names. Integrated index type allows dash in forEach names.
 - BCQL now allows the not-operator (`!`) to be used at the top level, and "global" constraints (`::`) to be used within parentheses as well.
 - Unicode normalization is applied to documents while indexing.
+- If a corpus directory is named `index`, we used to look at the parent directory for the "real" corpus name, but this quirk has been removed. 
 
 ### Fixed
 

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/Index.java
@@ -409,6 +409,11 @@ public class Index {
         return m.group(1);
     }
 
+    public boolean sharedWith(User user) {
+        // Any user the index is explicitly shared with can read it too
+        return shareWithUsers.contains(user.getUserId());
+    }
+
     public boolean userMayRead(User user) {
         // Superuser can read anything
         if (user.isSuperuser())
@@ -423,7 +428,7 @@ public class Index {
             return true;
 
         // Any user the index is explicitly shared with can read it too
-        return shareWithUsers.contains(user.getUserId());
+        return sharedWith(user);
     }
 
     private boolean authorizedForIndex(User user) {

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -488,16 +488,14 @@ public class IndexManager {
         if (collectionsDirs == null)
             return;
 
-        synchronized (indices) {
-            logger.debug("Looking for indices in collectionsDirs...");
-            for (File dir : collectionsDirs) {
-                logger.debug("Scanning collectionsDir: " + dir);
-                loadIndexesInDir(dir);
-            }
-
-            // Find all user corpora and keep track of them, so we can figure out ones shared with you.
-            loadAllUserCorpora();
+        logger.debug("Looking for indices in collectionsDirs...");
+        for (File dir : collectionsDirs) {
+            logger.debug("Scanning collectionsDir: " + dir);
+            loadIndexesInDir(dir);
         }
+
+        // Find all user corpora and keep track of them, so we can figure out ones shared with you.
+        loadAllUserCorpora();
     }
 
     /** A file filter that accepts all directories (and files) except the userCollectionsDir,
@@ -620,7 +618,7 @@ public class IndexManager {
         }
     }
 
-    private void loadUserCorporaInDir(String userId, File userDir) {
+    private synchronized void loadUserCorporaInDir(String userId, File userDir) {
         /*
          * User indices are stored as a flat list of directories inside the user's private directory like so:
          * 	userDir

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -3,6 +3,7 @@ package nl.inl.blacklab.server.index;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -64,6 +65,9 @@ public class IndexManager {
      */
     private static final int REMOVED_INDICES_MONITOR_CHECK_IN_MS = 1000;
 
+    /** File in user dir containing the original user id */
+    public static final String USER_ID_FILE_NAME = ".userId";
+
     private final SearchManager searchMan;
 
     /** Configured index collections directories */
@@ -82,6 +86,9 @@ public class IndexManager {
     private FinderInputFormatUserFormats userFormatManager;
 
     private final Map<String, Index> indices = new HashMap<>();
+
+    /** Did we (attempt to) load all user corpora? */
+    private boolean allUserCorporaLoaded;
 
     public IndexManager(SearchManager searchMan, BLSConfig blsConfig) throws ConfigurationException {
         this.searchMan = searchMan;
@@ -138,7 +145,7 @@ public class IndexManager {
         try {
             startRemovedIndicesMonitor(allDirs, REMOVED_INDICES_MONITOR_CHECK_IN_MS);
         } catch (Exception ex) {
-            throw  BlackLabRuntimeException.wrap(ex);
+            throw BlackLabRuntimeException.wrap(ex);
         }
     }
 
@@ -168,6 +175,21 @@ public class IndexManager {
             logger.error("(userCollectionsDir = " + userCollectionsDir);
             return null;
         }
+
+        // Make sure the user id is saved in the user directory.
+        // (the directory name cannot be used because it is mangled to be safe and unique)
+        File userIdFile = new File(dir, USER_ID_FILE_NAME);
+        try {
+            if (userIdFile.exists()) {
+                String readUserId = FileUtils.readFileToString(userIdFile, StandardCharsets.UTF_8);
+                assert userId.equals(readUserId);
+            } else {
+                FileUtils.writeStringToFile(userIdFile, userId, StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            throw BlackLabRuntimeException.wrap(e);
+        }
+
         return dir;
     }
 
@@ -396,7 +418,7 @@ public class IndexManager {
      *
      * @return list of loaded corpora
      */
-    public Collection<Index> getAllLoadedCorpora() {
+    public synchronized Collection<Index> getAllLoadedCorpora() {
         // Note that
         return indices.values();
     }
@@ -449,7 +471,7 @@ public class IndexManager {
         Set<Index> availableIndices = new HashSet<>();
 
         loadPublicIndices();
-        for (Index i : indices.values()) {
+        for (Index i: indices.values()) {
             if (!i.isUserIndex())
                 availableIndices.add(i);
         }
@@ -468,93 +490,93 @@ public class IndexManager {
 
         synchronized (indices) {
             logger.debug("Looking for indices in collectionsDirs...");
-            for (File collection : collectionsDirs) {
-                logger.debug("Scanning collectionsDir: " + collection);
-                // A file filter that accepts all directories (and files) except the userCollectionsDir,
-                // so if the userCollectionsDir is inside a collectionsDir, it is not suddenly made public
-                IOFileFilter notUserDirFilter = new IOFileFilter() {
-                    @Override
-                    public boolean accept(File pathName) {
-                        try {
-                            if (userCollectionsDir == null)
-                                return true;
-                            return !pathName.getCanonicalPath().equals(userCollectionsDir.getCanonicalPath());
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
+            for (File dir : collectionsDirs) {
+                logger.debug("Scanning collectionsDir: " + dir);
+                loadIndexesInDir(dir);
+            }
 
-                    @Override
-                    public boolean accept(File pathName, String fileName) {
-                        return accept(new File(pathName, fileName));
-                    }
-                };
-                IOFileFilter symlinkToDirFilter = new IOFileFilter() {
-                    @Override
-                    public boolean accept(File pathName) {
-                        try {
-                            Path indexPath = pathName.toPath().toRealPath();
-                            return Files.isDirectory(indexPath);
-                        } catch (IOException e) {
-                            throw BlackLabRuntimeException.wrap(e);
-                        }
-                    }
+            // Find all user corpora and keep track of them, so we can figure out ones shared with you.
+            loadAllUserCorpora();
+        }
+    }
 
-                    @Override
-                    public boolean accept(File pathName, String fileName) {
-                        return accept(new File(pathName, fileName));
-                    }
-                };
-                for (File subDir : FileUtils.listFilesAndDirs(collection, symlinkToDirFilter,
-                        notUserDirFilter /* can't filter on name yet, or it will only recurse into dirs with that name */)) {
+    /** A file filter that accepts all directories (and files) except the userCollectionsDir,
+     *  so if the userCollectionsDir is inside a collectionsDir, it is not suddenly made public
+     */
+    IOFileFilter notUserDirFilter = new IOFileFilter() {
+        @Override
+        public boolean accept(File pathName) {
+            try {
+                if (userCollectionsDir == null)
+                    return true;
+                return !pathName.getCanonicalPath().equals(userCollectionsDir.getCanonicalPath());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
-                    Path indexPath; // follow symlinks
-                    try {
-                        indexPath = subDir.toPath().toRealPath();
-                    } catch (IOException e) {
-                        throw BlackLabRuntimeException.wrap(e);
-                    }
-                    if (/*!subDir.getName().equals("index") ||*/ !Files.isReadable(indexPath) || !BlackLabIndex.isIndex(indexPath)) {
-                        // Not readable or not an index.
-                        // Warn about this only if this directory is a direct subdir of a collection dir.
-                        // (otherwise we get warnings about all forward index directories)
-                        if (indexPath.toFile().getParentFile().equals(collection)) {
-                            if (!Files.isReadable(indexPath))
-                                logger.debug("  Cannot read direct subdir of collection dir: " + indexPath);
-                            else
-                                logger.debug("  Direct subdir of collection dir not recognized as an index: " + indexPath);
-                        }
-                        continue;
-                    }
+        @Override
+        public boolean accept(File pathName, String fileName) {
+            return accept(new File(pathName, fileName));
+        }
+    };
 
-                    String indexName = subDir.getName();
-                    if (indexName.equals("index")) {
-                        // Not a very useful name; the parent directory usually contains the index name in this case
-                        indexName = subDir.getAbsoluteFile().getParentFile().getName();
-                        if (indices.containsKey(indexName))
-                            continue;
+    /** Accepts both directories and symlinks to directories */
+    IOFileFilter symlinkToDirFilter = new IOFileFilter() {
+        @Override
+        public boolean accept(File pathName) {
+            try {
+                Path indexPath = pathName.toPath().toRealPath();
+                return Files.isDirectory(indexPath);
+            } catch (IOException e) {
+                throw BlackLabRuntimeException.wrap(e);
+            }
+        }
 
-                        logger.warn("Found index directory named 'index': " + subDir);
-                        logger.warn("Replacing this with the parent directory name (" + indexName
-                                + "), but note that this behaviour is deprecated.");
-                    }
-                    if (indices.containsKey(indexName)) {
-                        // Index was already loaded, or name collision
-                        File otherDir = indices.get(indexName).getDir();
-                        if (!otherDir.equals(subDir)) {
-                            logger.warn("  Skipping subdir " + subDir + " because another index (" + otherDir + ") is named '" + indexName + "' as well.");
-                        }
-                        continue;
-                    }
+        @Override
+        public boolean accept(File pathName, String fileName) {
+            return accept(new File(pathName, fileName));
+        }
+    };
 
-                    try {
-                        logger.debug("Index found: " + indexName + " (" + subDir + ")");
-                        indices.put(indexName, new Index(indexName, subDir, searchMan));
-                    } catch (Exception e) {
-                        logger.info("Error while loading index " + indexName + " at location " + subDir + "; "
-                                + e.getMessage());
-                    }
+    private synchronized void loadIndexesInDir(File dir) {
+        for (File subDir: FileUtils.listFilesAndDirs(dir, symlinkToDirFilter, notUserDirFilter)) {
+            // Follow symlinks
+            Path indexPath;
+            try {
+                indexPath = subDir.toPath().toRealPath();
+            } catch (IOException e) {
+                throw BlackLabRuntimeException.wrap(e);
+            }
+            if (!Files.isReadable(indexPath) || !BlackLabIndex.isIndex(indexPath)) {
+                // Not readable or not an index.
+                // Warn about this only if this directory is a direct subdir of a collection dir.
+                // (otherwise we get warnings about all forward index directories)
+                if (indexPath.toFile().getParentFile().equals(dir)) {
+                    if (!Files.isReadable(indexPath))
+                        logger.debug("  Cannot read dir: " + indexPath);
+                    else
+                        logger.debug("  No index found in dir: " + indexPath);
                 }
+                continue;
+            }
+
+            String indexName = subDir.getName();
+            if (indices.containsKey(indexName)) {
+                // Index was already loaded, or name collision
+                File otherDir = indices.get(indexName).getDir();
+                if (!otherDir.equals(subDir)) {
+                    logger.warn("  Skipping subdir " + subDir + " because another index (" + otherDir + ") is named '" + indexName + "' as well.");
+                }
+                continue;
+            }
+
+            try {
+                logger.debug("  Index found: " + indexName + " (" + subDir + ")");
+                indices.put(indexName, new Index(indexName, subDir, searchMan));
+            } catch (Exception e) {
+                logger.info("Error while loading index " + indexName + " at location " + subDir + "; "
+                        + e.getMessage());
             }
         }
     }
@@ -571,6 +593,34 @@ public class IndexManager {
         if (userDir == null)
             return;
 
+        loadUserCorporaInDir(userId, userDir);
+    }
+
+    /**
+     * Load all user corpora.
+     *
+     * Actually loads corpora for all users with a .userId file in the user directory,
+     * but that should be all of them if they were created with a modern BlackLab version
+     * (4.0 or higher). User corpora missed here will still be loaded on demand.
+     */
+    private synchronized void loadAllUserCorpora() {
+        if (allUserCorporaLoaded)
+            return;
+        allUserCorporaLoaded = true;
+        for (File userDir: userCollectionsDir.listFiles(BlsUtils.readableDirFilter)) {
+            File userIdFile = new File(userDir, USER_ID_FILE_NAME);
+            if (userIdFile.exists() && userIdFile.canRead()) {
+                try {
+                    String userId = FileUtils.readFileToString(userIdFile, StandardCharsets.UTF_8).trim();
+                    loadUserCorporaInDir(userId, userDir);
+                } catch (IOException e) {
+                    throw new BlackLabRuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private void loadUserCorporaInDir(String userId, File userDir) {
         /*
          * User indices are stored as a flat list of directories inside the user's private directory like so:
          * 	userDir

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -388,6 +388,20 @@ public class IndexManager {
     }
 
     /**
+     * Return all loaded corpora, regardless of whether we can access them or not.
+     *
+     * Note that this will not return corpora shared with you if they haven't been
+     * loaded yet. To fix this, we should probably find all corpora and which users
+     * they're shared with on startup, but not open them until they're actually used.
+     *
+     * @return list of loaded corpora
+     */
+    public Collection<Index> getAllLoadedCorpora() {
+        // Note that
+        return indices.values();
+    }
+
+    /**
      * Get all public indices plus all indices owned by this user. Attempts to load
      * any new public indices and indices owned by this user.
      *

--- a/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/index/IndexManager.java
@@ -604,7 +604,7 @@ public class IndexManager {
      * (4.0 or higher). User corpora missed here will still be loaded on demand.
      */
     private synchronized void loadAllUserCorpora() {
-        if (allUserCorporaLoaded)
+        if (allUserCorporaLoaded || userCollectionsDir == null)
             return;
         allUserCorporaLoaded = true;
         for (File userDir: userCollectionsDir.listFiles(BlsUtils.readableDirFilter)) {

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/User.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/User.java
@@ -9,6 +9,15 @@ import java.security.NoSuchAlgorithmException;
  * logged in).
  */
 public class User {
+    /** Will be used in character class in regexes below */
+    private static final String USER_ID_CHARS_FOR_REGEXES = "a-zA-Z0-9\\-._!$&'()*+,;=@";
+
+    /** Matches a valid user id */
+    private static final String REGEX_VALID_USER_ID = "^[" + USER_ID_CHARS_FOR_REGEXES + "]+$";
+
+    /** Matches an invalid character in a user id */
+    private static final String REGEX_NON_USERID_CHAR = "[^" + USER_ID_CHARS_FOR_REGEXES + "]";
+
     /** The user id if logged in; null otherwise */
     private String userId;
 
@@ -16,7 +25,7 @@ public class User {
     private final String sessionId;
     
     /** Is this the superuser? */
-    private boolean superuser = false;
+    private final boolean superuser;
 
     /**
      * Create a new logged-in user.
@@ -37,10 +46,6 @@ public class User {
      */
     public static User anonymous(String sessionId) {
         return new User(null, sessionId, false);
-    }
-    
-    public static User superuser(String sessionId) {
-        return new User("_superuser_", sessionId, true);
     }
 
     private User(String userId, String sessionId, boolean superuser) {
@@ -81,10 +86,6 @@ public class User {
         return getUserDirNameFromId(userId);
     }
 
-    public String getSessionId() {
-        return sessionId;
-    }
-
     public static String getUserDirNameFromId(String id) {
         // NOTE: we want a safe directory name, so instead of trying to
         // get rid of non-safe characters, we just strip everything that
@@ -98,26 +99,22 @@ public class User {
             byte[] hashBytes = md5.digest();
             BigInteger hashInt = new BigInteger(1, hashBytes);
             String hashHex = hashInt.toString(16);
-            StringBuilder zeroes = new StringBuilder();
-            for (int i = 0; i < 32 - hashHex.length(); i++) {
-                zeroes.append("0");
-            }
+            String zeroes = "0".repeat(Math.max(0, 32 - hashHex.length()));
             return stripped + "_" + zeroes + hashHex;
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        //return FileUtil.sanitizeFilename(userId);
     }
 
     public static boolean isValidUserId(String userId) {
-        return userId.matches("^[a-zA-Z0-9\\-._!$&'()*+,;=@]+$");
+        return userId.matches(REGEX_VALID_USER_ID);
     }
 
     public static String sanitize(String originalUserId) {
         if (originalUserId == null || originalUserId.isEmpty())
             return null;
 
-        return originalUserId.replaceAll("[^a-zA-Z0-9\\-._!$&'()*+,;=@]", "_");
+        return originalUserId.replaceAll(REGEX_NON_USERID_CHAR, "_");
     }
 
     public boolean isSuperuser() {

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
@@ -562,6 +562,22 @@ public class WebserviceOperations {
         return index.getShareWithUsers();
     }
 
+    public static List<String> getCorporaSharedWithMe(WebserviceParams params) {
+        IndexManager indexMan = params.getIndexManager();
+        User user = params.getUser();
+        List<String> results = new ArrayList<>();
+        // BUG: because private user indices aren't all loaded by default, we may
+        //      miss unloaded corpora shared with you. To fix this, we should probably
+        //      find all corpora and which users they're shared with on startup,
+        //      but not open them until they're actually used.
+        for (Index index: indexMan.getAllLoadedCorpora()) {
+            if (index.sharedWith(user)) {
+                results.add(index.getId());
+            }
+        }
+        return results;
+    }
+
     public static void setUsersToShareWith(WebserviceParams params, String[] users) {
         User user = params.getUser();
         IndexManager indexMan = params.getIndexManager();

--- a/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/lib/results/WebserviceOperations.java
@@ -570,6 +570,7 @@ public class WebserviceOperations {
         //      miss unloaded corpora shared with you. To fix this, we should probably
         //      find all corpora and which users they're shared with on startup,
         //      but not open them until they're actually used.
+        indexMan.getAvailablePublicIndices(); // trigger loading of all user corpora (kinda hacky)
         for (Index index: indexMan.getAllLoadedCorpora()) {
             if (index.sharedWith(user)) {
                 results.add(index.getId());


### PR DESCRIPTION
An endpoint that can answer the question "what corpora have been shared with me" for logged-in users.

Will only be able to recognize shared indexes from users whose user id was stored in their user dir (because we cannot infer the user id from the directory name after mangling). A user id file is now written whenever the user is active or one of their corpora is accessed, but older indexes that are no longer accessed might be missed unfortunately.