### PR TITLE
Resolve XInclude by combining separate Readers.

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/CharPositionsTracker.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/CharPositionsTracker.java
@@ -1,34 +1,31 @@
 package nl.inl.blacklab.indexers.config.saxon;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.xml.sax.Locator;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
-import it.unimi.dsi.fastutil.ints.IntList;
 import net.sf.saxon.om.NodeInfo;
-import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
 
-/**
- *
- */
-public class CharPositionsTracker {
+/** Tracks characters positions for each tag in an XML document. */
+public interface CharPositionsTracker {
+    IntIterator openBracketIterator();
 
-    /**
-     * Estimate of characters per line, for initial sizing of list
-     */
-    private static final int AVERAGE_LINE_LENGTH_ESTIMATE = 40;
+    int charPosForLineAndCol(NodeInfo nodeInfo);
 
-    /**
-     * Estimate of characters per open bracket, for initial sizing of list
-     */
-    private static final int AVERAGE_CHARS_PER_TAG_ESTIMATE = 20;
+    int charPosForLineAndCol(int lineNumber, int columnNumber);
 
-    private static class StartEndPos {
+    int charPosForLineAndCol(Locator locator);
+
+    void putStartEndPos(int end, CharPositionsTrackerImpl.StartEndPos startEndPos);
+
+    int getNodeStartPos(NodeInfo node);
+
+    int getNodeEndPos(NodeInfo node);
+
+    void addNextStartElement(String qName, Locator locator);
+
+    void addNextEndElement(Locator locator);
+
+    class StartEndPos {
         final int startPos;
         int endPos;
 
@@ -39,164 +36,5 @@ public class CharPositionsTracker {
         public void setEndPos(int endPos) {
             this.endPos = endPos;
         }
-    }
-
-    /**
-     * For each line, starting from 0, store the STARTING (cumulative) character position.
-     * Index 0 therefore always has the value 0.
-     * End-of-line characters are included in the count.
-     * Used to translate line/column into character position.
-     */
-    private IntList lineNumberToCharPos;
-
-    /**
-     * The positions of all open brackets &lt; in the document.
-     * We use these to find the starting character position of a tag.
-     */
-    private IntList openBracketPositions;
-
-    /**
-     * Connects recorded SAX positions (just after start and end tags) to the calculated
-     * characters positions of those tags.
-     */
-    private Map<Integer, StartEndPos> startEndPosMap;
-
-    /**
-     * Our element stack while parsing, so we can fill in the end tag character position when we encounter it.
-     */
-    private final Deque<StartEndPos> elStack = new ArrayDeque<>();
-
-    /**
-     * We need to be able to find the start char. position of a tag, but we only know the end position.
-     * This iterator helps us find the corresponding start.
-     */
-    private final IntIterator tagPosIterator;
-
-    /**
-     * The current open bracket position above iterator is on.
-     */
-    private int currentTagPos;
-
-    public CharPositionsTracker(char[] document) {
-        int l = document.length;
-
-        // Find all open brackets and line endings
-        openBracketPositions = new IntArrayList(l / AVERAGE_CHARS_PER_TAG_ESTIMATE);
-        lineNumberToCharPos = new IntArrayList(l / AVERAGE_LINE_LENGTH_ESTIMATE);
-        lineNumberToCharPos.add(0); // first line always starts at character 0
-        for (int i = 0; i < l; i++) {
-            char c = document[i];
-            if (c == '<') {
-                // Keep track of open bracket positions, so we can find the start of a tag
-                openBracketPositions.add(i);
-            } else if (c == '\r' || c == '\n') {
-                // Keep track of line ending positions (or next-line-start-positions if you prefer)
-                if (c == '\r') {
-                    if (i < l - 1 && document[i + 1] == '\n')
-                        i++; // windows-style line ending; also skip newline
-                }
-                lineNumberToCharPos.add(i + 1); // store character position after EOL char(s)
-            }
-        }
-
-        // Initialize tag iterator
-        tagPosIterator = openBracketIterator();
-        assert tagPosIterator.hasNext();
-        currentTagPos = tagPosIterator.nextInt();
-
-        // The map where we keep track of the real start and end positions of tags (as opposed to what Saxon provides,
-        // which is always the position just after the tag)
-        startEndPosMap = new HashMap<>(document.length / AVERAGE_CHARS_PER_TAG_ESTIMATE);
-    }
-
-    public IntIterator openBracketIterator() {
-        return openBracketPositions.intIterator();
-    }
-
-    public int charPosForLineAndCol(NodeInfo nodeInfo) {
-        return charPosForLineAndCol(nodeInfo.getLineNumber(), nodeInfo.getColumnNumber());
-    }
-
-    /**
-     * translation of recorded line and column number to character position in the document
-     */
-    public int charPosForLineAndCol(int lineNumber, int columnNumber) {
-        Integer charPosStartOfLine = lineNumberToCharPos.get(lineNumber - 1);
-        // Note that we subtract 1 at the end because Saxon indicates the columnNumber just AFTER the tag
-        // (JN: or because columnNumber is 1-based, like line number, and we want a character position that is 0-based?)
-        return charPosStartOfLine + columnNumber - 1;
-    }
-
-    public int charPosForLineAndCol(Locator locator) {
-        return charPosForLineAndCol(locator.getLineNumber(), locator.getColumnNumber());
-    }
-
-    public void putStartEndPos(int end, StartEndPos startEndPos) {
-        startEndPosMap.put(end, startEndPos);
-    }
-
-    /**
-     * find where in the character[] of the source the closing tag ends
-     *
-     * @param nodeInfo the node to find the endtag for
-     */
-    int findClosingTagPosition(NodeInfo nodeInfo) {
-        return startEndPosMap.get(charPosForLineAndCol(nodeInfo)).endPos;
-    }
-
-    /**
-     * find the position of the starting character (&lt;) of a node in the characters of a document.
-     * Note that CR and LF are included in the count. It is recomended to cache this number for use in
-     * clients.
-     */
-    public int getNodeStartPos(NodeInfo node) {
-        return startEndPosMap.get(charPosForLineAndCol(node)).startPos;
-    }
-
-    /**
-     * find the position of the end character (>) of a node in the characters of a document.
-     * Note that CR and LF are included in the count. It is recomended to cache this number for use in
-     * clients.
-     */
-    public int getNodeEndPos(NodeInfo node) {
-        return findClosingTagPosition(node);
-    }
-
-    /**
-     * A new start tag was found while parsing.
-     *
-     * Note that this must be called linearly because we iterate through the tag positions we indexed earlier.
-     *
-     * @param qName tag name
-     * @param locator locator for the line and col
-     */
-    public void addNextStartElement(String qName, Locator locator) {
-        int end = charPosForLineAndCol(locator);
-        int begin = end;
-        // Now find the character position of the start of this tag
-        // (last < character before the end position)
-        while (currentTagPos < end) {
-            begin = currentTagPos;
-            currentTagPos = tagPosIterator.nextInt();
-        }
-        // NOTE more testing needed for self closing tags
-        if (begin == end) {
-            throw new BlackLabRuntimeException(String.format("No '<' found for %s at line %d, col %d, charpos %d",
-                    qName, locator.getLineNumber(), locator.getColumnNumber(), end));
-        }
-        StartEndPos startEndPos = new StartEndPos(begin);
-        elStack.push(startEndPos);
-        putStartEndPos(end, startEndPos);
-    }
-
-    /**
-     * A new end tag was found while parsing.
-     *
-     * Updates the end position of the corresponding start tag.
-     *
-     * @param locator locator for the line and col
-     */
-    public void addNextEndElement(Locator locator) {
-        elStack.pop().setEndPos(charPosForLineAndCol(locator));
     }
 }

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/CharPositionsTrackerImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/CharPositionsTrackerImpl.java
@@ -1,0 +1,251 @@
+package nl.inl.blacklab.indexers.config.saxon;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.xml.sax.Locator;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.sf.saxon.om.NodeInfo;
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+
+/** Tracks characters positions for each tag in an XML document.
+ * This is for an XML document in a character array.
+ */
+public class CharPositionsTrackerImpl implements CharPositionsTracker {
+
+    /**
+     * Estimate of characters per line, for initial sizing of list
+     */
+    private static final int AVERAGE_LINE_LENGTH_ESTIMATE = 40;
+
+    /**
+     * Estimate of characters per open bracket, for initial sizing of list
+     */
+    private static final int AVERAGE_CHARS_PER_TAG_ESTIMATE = 20;
+
+    /**
+     * For each line, starting from 0, store the STARTING (cumulative) character position.
+     * Index 0 therefore always has the value 0.
+     * End-of-line characters are included in the count.
+     * Used to translate line/column into character position.
+     */
+    private IntList lineNumberToCharPos;
+
+    /**
+     * The positions of all open brackets &lt; in the document.
+     * We use these to find the starting character position of a tag.
+     */
+    private IntList openBracketPositions;
+
+    /**
+     * Connects recorded SAX positions (just after start and end tags) to the calculated
+     * characters positions of those tags.
+     */
+    private Map<Integer, StartEndPos> startEndPosMap;
+
+    /**
+     * Our element stack while parsing, so we can fill in the end tag character position when we encounter it.
+     */
+    private final Deque<StartEndPos> elStack = new ArrayDeque<>();
+
+    /**
+     * We need to be able to find the start char. position of a tag, but we only know the end position.
+     * This iterator helps us find the corresponding start.
+     */
+    private final IntIterator tagPosIterator;
+
+    /**
+     * The current open bracket position above iterator is on.
+     */
+    private int currentTagPos;
+
+    public CharPositionsTrackerImpl(char[] document) {
+        int lengthInChars = document.length;
+
+        // Find all open brackets and line endings
+        openBracketPositions = new IntArrayList(lengthInChars / AVERAGE_CHARS_PER_TAG_ESTIMATE);
+        lineNumberToCharPos = new IntArrayList(lengthInChars / AVERAGE_LINE_LENGTH_ESTIMATE);
+        lineNumberToCharPos.add(0); // first line always starts at character 0
+        for (int i = 0; i < lengthInChars; i++) {
+            char c = document[i];
+            if (c == '<') {
+                // Keep track of open bracket positions, so we can find the start of a tag
+                openBracketPositions.add(i);
+            } else if (c == '\r' || c == '\n') {
+                // Keep track of line ending positions (or next-line-start-positions if you prefer)
+                if (c == '\r') {
+                    if (i < lengthInChars - 1 && document[i + 1] == '\n')
+                        i++; // windows-style line ending; also skip newline
+                }
+                lineNumberToCharPos.add(i + 1); // store character position after EOL char(s)
+            }
+        }
+
+        // Initialize tag iterator
+        tagPosIterator = openBracketIterator();
+        assert tagPosIterator.hasNext();
+        currentTagPos = tagPosIterator.nextInt();
+
+        // The map where we keep track of the real start and end positions of tags (as opposed to what Saxon provides,
+        // which is always the position just after the tag)
+        startEndPosMap = new HashMap<>(document.length / AVERAGE_CHARS_PER_TAG_ESTIMATE);
+    }
+
+    public CharPositionsTrackerImpl(Reader document) {
+        // Find all open brackets and line endings
+        openBracketPositions = new IntArrayList();
+        lineNumberToCharPos = new IntArrayList();
+        lineNumberToCharPos.add(0); // first line always starts at character 0
+        int readAheadChar = 0;
+        int position = 0;
+        try {
+            while (true) {
+                int iCurrentChar;
+                if (readAheadChar != 0) {
+                    // We already read the next char. Consume it now.
+                    iCurrentChar = readAheadChar;
+                    readAheadChar = 0;
+                } else {
+                    // Read the next char.
+                    iCurrentChar = document.read();
+                }
+                if (iCurrentChar < 0)
+                    break; // end of document
+                char currentChar = (char)iCurrentChar;
+                if (currentChar == '<') {
+                    // Keep track of open bracket positions, so we can find the start of a tag
+                    openBracketPositions.add(position);
+                } else if (currentChar == '\r' || currentChar == '\n') {
+                    // Keep track of line ending positions (or next-line-start-positions if you prefer)
+                    if (currentChar == '\r') {
+                        readAheadChar = document.read();
+                        if (readAheadChar == '\n') {
+                            position++; // windows-style line ending; also skip newline
+                            readAheadChar = 0;
+                        }
+                    }
+                    lineNumberToCharPos.add(position + 1); // store character position after EOL char(s)
+                }
+                position++;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Initialize tag iterator
+        tagPosIterator = openBracketIterator();
+        assert tagPosIterator.hasNext();
+        currentTagPos = tagPosIterator.nextInt();
+
+        // The map where we keep track of the real start and end positions of tags (as opposed to what Saxon provides,
+        // which is always the position just after the tag)
+        startEndPosMap = new HashMap<>(position / AVERAGE_CHARS_PER_TAG_ESTIMATE);
+    }
+
+    @Override
+    public IntIterator openBracketIterator() {
+        return openBracketPositions.intIterator();
+    }
+
+    @Override
+    public int charPosForLineAndCol(NodeInfo nodeInfo) {
+        return charPosForLineAndCol(nodeInfo.getLineNumber(), nodeInfo.getColumnNumber());
+    }
+
+    /**
+     * translation of recorded line and column number to character position in the document
+     */
+    @Override
+    public int charPosForLineAndCol(int lineNumber, int columnNumber) {
+        Integer charPosStartOfLine = lineNumberToCharPos.get(lineNumber - 1);
+        // Note that we subtract 1 at the end because Saxon indicates the columnNumber just AFTER the tag
+        // (JN: or because columnNumber is 1-based, like line number, and we want a character position that is 0-based?)
+        return charPosStartOfLine + columnNumber - 1;
+    }
+
+    @Override
+    public int charPosForLineAndCol(Locator locator) {
+        return charPosForLineAndCol(locator.getLineNumber(), locator.getColumnNumber());
+    }
+
+    @Override
+    public void putStartEndPos(int end, StartEndPos startEndPos) {
+        startEndPosMap.put(end, startEndPos);
+    }
+
+    /**
+     * find where in the character[] of the source the closing tag ends
+     *
+     * @param nodeInfo the node to find the endtag for
+     */
+    int findClosingTagPosition(NodeInfo nodeInfo) {
+        return startEndPosMap.get(charPosForLineAndCol(nodeInfo)).endPos;
+    }
+
+    /**
+     * find the position of the starting character (&lt;) of a node in the characters of a document.
+     * Note that CR and LF are included in the count. It is recomended to cache this number for use in
+     * clients.
+     */
+    @Override
+    public int getNodeStartPos(NodeInfo node) {
+        return startEndPosMap.get(charPosForLineAndCol(node)).startPos;
+    }
+
+    /**
+     * find the position of the end character (>) of a node in the characters of a document.
+     * Note that CR and LF are included in the count. It is recomended to cache this number for use in
+     * clients.
+     */
+    @Override
+    public int getNodeEndPos(NodeInfo node) {
+        return findClosingTagPosition(node);
+    }
+
+    /**
+     * A new start tag was found while parsing.
+     *
+     * Note that this must be called linearly because we iterate through the tag positions we indexed earlier.
+     *
+     * @param qName tag name
+     * @param locator locator for the line and col
+     */
+    @Override
+    public void addNextStartElement(String qName, Locator locator) {
+        int end = charPosForLineAndCol(locator);
+        int begin = end;
+        // Now find the character position of the start of this tag
+        // (last < character before the end position)
+        while (currentTagPos < end) {
+            begin = currentTagPos;
+            currentTagPos = tagPosIterator.nextInt();
+        }
+        // NOTE more testing needed for self closing tags
+        if (begin == end) {
+            throw new BlackLabRuntimeException(String.format("No '<' found for %s at line %d, col %d, charpos %d",
+                    qName, locator.getLineNumber(), locator.getColumnNumber(), end));
+        }
+        StartEndPos startEndPos = new StartEndPos(begin);
+        elStack.push(startEndPos);
+        putStartEndPos(end, startEndPos);
+    }
+
+    /**
+     * A new end tag was found while parsing.
+     *
+     * Updates the end position of the corresponding start tag.
+     *
+     * @param locator locator for the line and col
+     */
+    @Override
+    public void addNextEndElement(Locator locator) {
+        elStack.pop().setEndPos(charPosForLineAndCol(locator));
+    }
+}

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolver.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolver.java
@@ -1,0 +1,11 @@
+package nl.inl.blacklab.indexers.config.saxon;
+
+import java.io.Reader;
+
+public interface XIncludeResolver {
+    DocumentReference getDocumentReference();
+
+    Reader getDocumentReader();
+
+    CharPositionsTracker getCharPositionsTracker();
+}

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolverConcatenate.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolverConcatenate.java
@@ -1,0 +1,93 @@
+package nl.inl.blacklab.indexers.config.saxon;
+
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOUtils;
+
+import nl.inl.blacklab.exceptions.BlackLabRuntimeException;
+
+public class XIncludeResolverConcatenate implements XIncludeResolver {
+
+    private final DocumentReference documentReference;
+
+    private final CharArrayReader documentReader;
+
+    private final CharPositionsTracker charPositions;
+
+    public XIncludeResolverConcatenate(DocumentReference documentReference, File curDir) {
+        File file = documentReference.getFile();
+        Charset charset = documentReference.getCharset();
+        char[] documentContent = documentReference.getContents();
+        File baseDir = file == null ? curDir : file.getParentFile();
+        char[] documentContentNew = resolveXInclude(documentContent, baseDir);
+        if (documentContentNew != documentContent) {
+            documentContent = documentContentNew;
+            this.documentReference = new DocumentReference(documentContent, charset, file, true, this);
+        } else {
+            this.documentReference = documentReference;
+        }
+        this.charPositions = new CharPositionsTrackerImpl(documentContent);
+        this.documentReader = new CharArrayReader(documentContent);
+    }
+
+    @Override
+    public DocumentReference getDocumentReference() {
+        return documentReference;
+    }
+
+    @Override
+    public Reader getDocumentReader() {
+        return documentReader;
+    }
+
+    @Override
+    public CharPositionsTracker getCharPositionsTracker() {
+        return charPositions;
+    }
+
+    private char[] resolveXInclude(char[] documentContent, File dir) {
+        // Implement XInclude support.
+        // We need to do this before parsing so our character position tracking keeps working.
+        // This basic support uses regex; we can improve it later if needed.
+        // <xi:include href="../content/en_1890_Darby.1Chr.xml"/>
+
+        Pattern xIncludeTag = Pattern.compile("<xi:include\\s+href=\"([^\"]+)\"\\s*/>");
+        CharSequence doc = CharBuffer.wrap(documentContent);
+        Matcher matcher = xIncludeTag.matcher(doc);
+        StringBuilder result = new StringBuilder(documentContent.length / 2 * 3);
+        int pos = 0;
+        boolean anyFound = false;
+        while (matcher.find()) {
+            anyFound = true;
+            // Append the part before the XInclude tag
+            result.append(doc.subSequence(pos, matcher.start()));
+            try {
+                // Append the included file
+                String href = matcher.group(1);
+                File f = new File(href);
+                if (!f.isAbsolute())
+                    f = new File(dir, href);
+                InputStream is = new FileInputStream(f);
+                result.append(IOUtils.toString(is, StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw BlackLabRuntimeException.wrap(e);
+            }
+            pos = matcher.end();
+        }
+        if (!anyFound)
+            return documentContent;
+        // Append the rest of the document
+        result.append(doc.subSequence(pos, doc.length()));
+        return result.toString().toCharArray();
+    }
+}

--- a/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolverSeparate.java
+++ b/engine/src/main/java/nl/inl/blacklab/indexers/config/saxon/XIncludeResolverSeparate.java
@@ -1,0 +1,111 @@
+package nl.inl.blacklab.indexers.config.saxon;
+
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XIncludeResolverSeparate implements XIncludeResolver {
+
+    private final DocumentReference document;
+
+    private final File baseDir;
+
+    private final CharPositionsTrackerImpl charPositionsTracker;
+
+    public XIncludeResolverSeparate(DocumentReference document, File curDir) {
+        this.document = document;
+        File file = document.getFile();
+        this.baseDir = file == null ? curDir : file.getParentFile();
+
+        // Read through the document(s) once, capturing the character positions for each tag.
+        charPositionsTracker = new CharPositionsTrackerImpl(getDocumentReader());
+    }
+
+    @Override
+    public DocumentReference getDocumentReference() {
+        return document;
+    }
+
+    @Override
+    public Reader getDocumentReader() {
+        // Find XInclude tags and construct a list of readers
+        List<Reader> readers = findXIncludesAndConstructReaderList(document.getContents(), baseDir);
+
+        return new Reader() {
+            @Override
+            public int read(char[] chars, int offset, int length) throws IOException {
+                if (length == 0)
+                    return 0;
+                int totalRead = 0;
+                while (!readers.isEmpty() && length > 0) {
+                    Reader currentReader = readers.get(0);
+                    int read = currentReader.read(chars, offset, length);
+                    if (read == -1) {
+                        // No chars read, end of reader
+                        currentReader.close();
+                        readers.remove(0);
+                    } else {
+                        // Some chars read; update variables
+                        offset += read;
+                        length -= read;
+                        totalRead += read;
+                    }
+                }
+                return totalRead == 0 ? -1 : totalRead;
+            }
+
+            @Override
+            public void close() throws IOException {
+                for (Reader reader: readers) {
+                    reader.close();
+                }
+            }
+        };
+    }
+
+    @Override
+    public CharPositionsTracker getCharPositionsTracker() {
+        return charPositionsTracker;
+    }
+
+    private List<Reader> findXIncludesAndConstructReaderList(char[] documentContent, File dir) {
+        // Implement XInclude support.
+        // We need to do this before parsing so our character position tracking keeps working.
+        // This basic support uses regex; we can improve it later if needed.
+        // <xi:include href="../content/en_1890_Darby.1Chr.xml"/>
+        Pattern xIncludeTag = Pattern.compile("<xi:include\\s+href=\"([^\"]+)\"\\s*/>");
+        CharSequence doc = CharBuffer.wrap(documentContent);
+        Matcher matcher = xIncludeTag.matcher(doc);
+        List<Reader> readers = new ArrayList<>();
+        int pos = 0;
+        while (matcher.find()) {
+            // The part before the XInclude tag
+            if (pos < matcher.start())
+                readers.add(new CharArrayReader(documentContent, pos, matcher.start() - pos));
+            pos = matcher.end();
+
+            // The included file
+            String href = matcher.group(1);
+            File f = new File(href);
+            if (!f.isAbsolute())
+                f = new File(dir, href);
+            try {
+                readers.add(new FileReader(f));
+            } catch (FileNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // The rest of the document
+        if (pos < documentContent.length)
+            readers.add(new CharArrayReader(documentContent, pos, documentContent.length - pos));
+        return readers;
+    }
+}


### PR DESCRIPTION
We resolved `<xi:include>` tags by concatenating the files together, but ran into Java's maximum UTF-16 string length of around 1G. Now we construct a `Reader` that reads through the main file and included files as though it were a single document. Should fix this problem and save quite a bit of memory as included files aren't read into memory entirely anymore.

Could be further improved if necessary (the main file is still read into a char array), but we only use these includes for parallel corpora right now, so it's probably not a priority.