### PR TITLE
Fix BCQL escape issues

### DIFF
--- a/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestSearches.java
@@ -44,6 +44,7 @@ import nl.inl.blacklab.search.results.Hits;
 import nl.inl.blacklab.search.textpattern.TextPattern;
 import nl.inl.blacklab.search.textpattern.TextPatternFixedSpan;
 import nl.inl.blacklab.search.textpattern.TextPatternRegex;
+import nl.inl.blacklab.search.textpattern.TextPatternTerm;
 import nl.inl.blacklab.testutil.TestIndex;
 
 @RunWith(Parameterized.class)
@@ -673,37 +674,36 @@ public class TestSearches {
         Assert.assertEquals(expected, testIndex.findConc(query));
     }
 
-    @Test
-    public void testEscapedQuote2() throws InvalidQuery {
-        String[] patts = { "[word=\"\\\"\"]" /*, "[word=\"\\\\\\\"\"]"*/ };
-        // In Lucene regex, double quote must be escaped; this is correct
-        for (String patt: patts) {
-            TextPattern tp = CorpusQueryLanguageParser.parse(patt);
-            Assert.assertTrue(tp instanceof TextPatternRegex);
-            Assert.assertEquals("\\\"", ((TextPatternRegex) tp).getValue());
-            BLSpanQuery q = tp.translate(QueryExecutionContext.get(testIndex.index(),
-                    testIndex.index().mainAnnotatedField().mainAnnotation(), MatchSensitivity.INSENSITIVE));
-            Assert.assertTrue(q instanceof BLSpanMultiTermQueryWrapper);
-            Assert.assertEquals("contents%word@i:/\\\"/", q.toString());
-        }
-    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     @Test
     public void testEscape() throws InvalidQuery {
         // Keys are CQL regexes (i.e. the $ part in [word="$"]), values are the expected Lucene regex
         Map<String, String> bcqlToLucene = new HashMap<>();
-        testEscaping("\\.", "\\.");
-        testEscaping(".", ".");
-        testEscaping("\\\"", "\\\"");
-        testEscaping("\\\"", "\\\"");
+//        testEscaping("\\.", "\\.");
+//        testEscaping(".", ".");
+//        testEscaping("\"", "\\\"");
+        testEscaping("\\\\\\\"", "\\\\\\\"");
         testEscaping("\\(", "\\(");
         testEscaping("\\\\\\(", "\\\\\\(");
     }
 
     private void testEscaping(String expectedLuceneRegex, String bcqlPattern) throws InvalidQuery {
         TextPattern tp = CorpusQueryLanguageParser.parse("\"" + bcqlPattern + "\"");
-        Assert.assertTrue(tp instanceof TextPatternRegex);
-        Assert.assertEquals(bcqlPattern, ((TextPatternRegex) tp).getValue());
+        Assert.assertTrue(tp instanceof TextPatternTerm);
         BLSpanQuery q = tp.translate(QueryExecutionContext.get(testIndex.index(),
                 testIndex.index().mainAnnotatedField().mainAnnotation(), MatchSensitivity.INSENSITIVE));
         Assert.assertTrue(q instanceof BLSpanMultiTermQueryWrapper);

--- a/core/src/test/java/nl/inl/blacklab/search/TestTextPatternToCorpusQL.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestTextPatternToCorpusQL.java
@@ -71,6 +71,13 @@ public class TestTextPatternToCorpusQL {
     }
 
     @Test
+    public void testEscape() throws InvalidQuery {
+        assertCanonicalized("'c\\\\at'", "'c\\\\at'");
+        assertCanonicalized("'c\'at'", "'c\'at'");
+        assertCanonicalized("'c\\at'", "'c\\at'");
+    }
+
+    @Test
     public void testExtraParens() throws InvalidQuery {
         assertCanonicalized("('the' & ('c\\\\at' | 'do\\'g')) 'turtle'",
                 "(('the' & ('c\\\\at' | 'do\\'g')) ('turtle'))");

--- a/core/src/test/java/nl/inl/blacklab/search/TestTextPatternToCorpusQL.java
+++ b/core/src/test/java/nl/inl/blacklab/search/TestTextPatternToCorpusQL.java
@@ -73,7 +73,7 @@ public class TestTextPatternToCorpusQL {
     @Test
     public void testEscape() throws InvalidQuery {
         assertCanonicalized("'c\\\\at'", "'c\\\\at'");
-        assertCanonicalized("'c\'at'", "'c\'at'");
+        assertCanonicalized("'c\\'at'", "'c\\'at'");
         assertCanonicalized("'c\\at'", "'c\\at'");
     }
 

--- a/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternRegex.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternRegex.java
@@ -65,11 +65,6 @@ public class TextPatternRegex extends TextPatternTerm {
      * @return the TextPattern
      */
     private TextPattern rewriteForQuery() {
-        // Is it "any token"?
-        if (value.equals(".*")) {
-            return new TextPatternAnyToken(1, 1);
-        }
-
         // Do we want to force an (in)sensitive search?
         boolean forceSensitive = false;
         boolean forceInsensitive = false;
@@ -83,6 +78,11 @@ public class TextPatternRegex extends TextPatternTerm {
         } else if (newValue.startsWith("(?i)")) {
             forceInsensitive = true;
             newValue = newValue.substring(4);
+        }
+
+        // Is it "any token"?
+        if (value.equals(".*")) {
+            return new TextPatternAnyToken(1, 1);
         }
 
         // If this contains no funny characters, only (Unicode) letters and digits,

--- a/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternRegex.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternRegex.java
@@ -11,6 +11,7 @@ import nl.inl.blacklab.search.QueryExecutionContext;
 import nl.inl.blacklab.search.indexmetadata.MatchSensitivity;
 import nl.inl.blacklab.search.lucene.BLSpanMultiTermQueryWrapper;
 import nl.inl.blacklab.search.lucene.BLSpanQuery;
+import nl.inl.util.StringUtil;
 
 /**
  * A TextPattern matching a regular expression.
@@ -36,8 +37,13 @@ public class TextPatternRegex extends TextPatternTerm {
             return result.translate(context);
         context = context.withAnnotationAndSensitivity(annotation, sensitivity);
         String valueNoStartEndMatch = optInsensitive(context, value);
+
+        // Lucene's regex engine requires double quotes to be escaped, unlike most others.
+        // Escape double quotes
+        valueNoStartEndMatch = StringUtil.escapeQuote(valueNoStartEndMatch, "\"");
+
         try {
-            Term term = new Term(context.luceneField(), context.optDesensitize(valueNoStartEndMatch));
+            Term term = new Term(context.luceneField(), valueNoStartEndMatch);
             RegexpQuery regexpQuery = new RegexpQuery(term); //, RegExp.COMPLEMENT); causes issues with NFA matching!
             return new BLSpanMultiTermQueryWrapper<>(context.queryInfo(), regexpQuery);
         } catch (IllegalArgumentException e) {

--- a/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternSerializerCql.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/textpattern/TextPatternSerializerCql.java
@@ -72,10 +72,8 @@ public class TextPatternSerializerCql {
         if (!isRegexPattern) {
             // We're looking for an exact value, which may include regex characters.
             value = StringUtil.escapeLuceneRegexCharacters(value);
-        } else {
-            b.append("\"").append(value).append("\"");
         }
-        serializeQuotedString(b, value, isRegexPattern);
+        serializeToSingleQuotedString(b, value);
         if (annotation != null)
             b.append(optCloseBracket);
     }
@@ -301,7 +299,7 @@ public class TextPatternSerializerCql {
         // MatchFilter string
         cqlSerializers.put(MatchFilterString.class, (pattern, b, parenthesizeIfNecessary, insideTokenBrackets) -> {
             MatchFilterString tp = (MatchFilterString) pattern;
-            serializeQuotedString(b, tp.getValue(), false);
+            serializeToSingleQuotedString(b, tp.getValue());
         });
 
         // MatchFilter token annotation
@@ -365,7 +363,7 @@ public class TextPatternSerializerCql {
             if (arg instanceof TextPattern) {
                 serialize((TextPattern) arg, b, false, insideTokenBrackets);
             } else if (arg instanceof String) {
-                serializeQuotedString(b, (String) arg, false);
+                serializeToSingleQuotedString(b, (String) arg);
             } else if (arg instanceof Integer) {
                 b.append((int) arg);
             } else {
@@ -407,16 +405,8 @@ public class TextPatternSerializerCql {
         }
     }
 
-    private static StringBuilder serializeQuotedString(StringBuilder b, String regex, boolean isRegex) {
-        if (isRegex) {
-            // In Lucene regexes (which TextPatterns use), backslash is already escaped,
-            // so no need to do this again
-            return b.append("'").append(regex.replaceAll("'", "\\\\'")).append("'");
-        } else {
-            // Not a regex, but a regular literal term.
-            // Nothing is escaped yet; escape quote and backslash
-            return b.append("'").append(regex.replaceAll("[\\\\']", "\\\\$0")).append("'");
-        }
+    private static StringBuilder serializeToSingleQuotedString(StringBuilder b, String value) {
+        return b.append("'").append(StringUtil.escapeQuote(value, "'")).append("'");
     }
 
     private static String serializeAttributes(Map<String, String> attr) {

--- a/query-parser/src/main/java/nl/inl/blacklab/queryParser/corpusql/CorpusQueryLanguageParser.java
+++ b/query-parser/src/main/java/nl/inl/blacklab/queryParser/corpusql/CorpusQueryLanguageParser.java
@@ -67,8 +67,14 @@ public class CorpusQueryLanguageParser {
     String getStringBetweenQuotes(String input) throws SingleQuotesException {
         if (!allowSingleQuotes && input.charAt(0) == '\'')
             throw new SingleQuotesException();
-        // Eliminate the quotes and unescape backslashes
-        return chopEnds(input).replaceAll("\\\\(.)", "$1");
+
+        // Eliminate the quotes
+        String result = chopEnds(input);
+
+        // Unescape backslashes
+        //result = result.replaceAll("\\\\(.)", "$1");
+
+        return result;
     }
 
     TextPatternTerm simplePattern(String str) {

--- a/query-parser/src/test/java/nl/inl/blacklab/search/TestBcqlParser.java
+++ b/query-parser/src/test/java/nl/inl/blacklab/search/TestBcqlParser.java
@@ -17,6 +17,6 @@ public class TestBcqlParser {
         String pattern = "[lemma=\"\\\"\"]";
         TextPattern tp = CorpusQueryLanguageParser.parse(pattern);
         Assert.assertTrue(tp instanceof TextPatternTerm);
-        Assert.assertEquals("\\\"", ((TextPatternTerm) tp).getValue());
+        Assert.assertEquals("\"", ((TextPatternTerm) tp).getValue());
     }
 }

--- a/util/src/main/java/nl/inl/util/StringUtil.java
+++ b/util/src/main/java/nl/inl/util/StringUtil.java
@@ -1,6 +1,7 @@
 package nl.inl.util;
 
 import java.text.Normalizer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -275,5 +276,47 @@ public final class StringUtil {
 
     public static String removeCharsIgnoredByInsensitiveCollator(String s) {
         return s.replaceAll("[\t\n\r" + CHAR_EM_SPACE + CHAR_NON_BREAKING_SPACE + CHAR_DELETE + "]", "");
+    }
+
+    /** A backslash followed by any other character (which will be captured). */
+    private static final Pattern ANY_BACKSLASH_ESCAPED_CHAR = Pattern.compile("\\\\(.)");
+
+    /** Unescape backslash-escaped single or double quote.
+     */
+    public static String unescapeQuote(String input, String quoteToUnescape) {
+        assert quoteToUnescape.equals("'") || quoteToUnescape.equals("\"") : "only meant for quotes";
+        StringBuilder result = new StringBuilder();
+        Matcher matcher = ANY_BACKSLASH_ESCAPED_CHAR.matcher(input);
+        while (matcher.find()) { // NOTE: will NOT find overlapping matches, which is exactly what we want!
+            String escapedChar = matcher.group(1);
+            // See if we want to keep this character escaped or unescape it
+            String optionalBackslash = escapedChar.equals(quoteToUnescape) ? "" : "\\";
+            matcher.appendReplacement(result, Matcher.quoteReplacement(optionalBackslash + escapedChar));
+        }
+        matcher.appendTail(result); // add the final bit
+        return result.toString();
+    }
+
+    /** A character optionally preceded by a backslash */
+    private static final Pattern REGULAR_OR_ESCAPED_CHAR = Pattern.compile("(\\\\?)(.)");
+
+    /** Backslash-escape single or double quote.
+     */
+    public static String escapeQuote(String input, String quoteToEscape) {
+        assert quoteToEscape.equals("'") || quoteToEscape.equals("\"") : "only meant for quotes";
+        StringBuilder result = new StringBuilder();
+        Matcher matcher = REGULAR_OR_ESCAPED_CHAR.matcher(input);
+        while (matcher.find()) { // NOTE: will NOT find overlapping matches, which is exactly what we want!
+            String optEscape = matcher.group(1); // either a backslash or empty string; we can just double it below
+            String charFound = matcher.group(2);
+            // See if we want to escape this character.
+            // If yes, and the character was already escaped, also escape that backslash.
+            // (so ' becomes \' but \' becomes \\')
+            // This ensures that unescaping later will work correctly.
+            String optionalBackslash = charFound.equals(quoteToEscape) ? "\\" : "";
+            matcher.appendReplacement(result, Matcher.quoteReplacement(optEscape + optionalBackslash + charFound));
+        }
+        matcher.appendTail(result); // add the final bit
+        return result.toString();
     }
 }

--- a/util/src/test/java/nl/inl/util/TestStringUtil.java
+++ b/util/src/test/java/nl/inl/util/TestStringUtil.java
@@ -46,4 +46,50 @@ public class TestStringUtil {
         Assert.assertEquals("trim", StringUtil.trimWhitespace("" + StringUtil.CHAR_EM_SPACE + StringUtil.CHAR_NON_BREAKING_SPACE + "trim"));
         Assert.assertEquals("tr  im", StringUtil.trimWhitespace(" tr  im "));
     }
+
+    @Test
+    public void testEscapeQuote() {
+        // Escape the correct quote
+        Assert.assertEquals("test'\\\"test", StringUtil.escapeQuote("test'\"test", "\""));
+        Assert.assertEquals("test\\'\"test", StringUtil.escapeQuote("test'\"test", "'"));
+
+        // Don't do anything to non-quote and non-backslash, whether they're already escaped or not
+        Assert.assertEquals("test\\s\\n\\test", StringUtil.escapeQuote("test\\s\\n\\test", "\""));
+        Assert.assertEquals("test\\s\\n\\test", StringUtil.escapeQuote("test\\s\\n\\test", "'"));
+
+        // Double-escape if you have to
+        Assert.assertEquals("test\\\\\"test", StringUtil.escapeQuote("test\\\"test", "\""));
+        Assert.assertEquals("test\\\\'test", StringUtil.escapeQuote("test\\'test", "'"));
+
+        Assert.assertEquals("bla\\\\\"\\'\\\\\\s\\n\\\"'bla\\", StringUtil.escapeQuote("bla\\\"\\'\\\\\\s\\n\"'bla\\", "\""));
+
+        // Test roundtrip as well
+        String input = "bla\\\"\\'\\\\\\s\\n\"'bla\\";
+        Assert.assertEquals(input, StringUtil.unescapeQuote(StringUtil.escapeQuote(input, "\""), "\""));
+        Assert.assertEquals(input, StringUtil.unescapeQuote(StringUtil.escapeQuote(input, "'"), "'"));
+    }
+
+    @Test
+    public void testUnescapeQuote() {
+        // Don't trip over quotes that are not escaped
+        Assert.assertEquals("test'\"test", StringUtil.unescapeQuote("test'\"test", "\""));
+        Assert.assertEquals("test'\"test", StringUtil.unescapeQuote("test'\"test", "'"));
+
+        // Don't unescape non-quote and non-backslash
+        Assert.assertEquals("test\\s\\n\\test", StringUtil.unescapeQuote("test\\s\\n\\test", "\""));
+        Assert.assertEquals("test\\s\\n\\test", StringUtil.unescapeQuote("test\\s\\n\\test", "'"));
+
+        // Do unescape
+        Assert.assertEquals("test\"test", StringUtil.unescapeQuote("test\\\"test", "\""));
+        Assert.assertEquals("test'test", StringUtil.unescapeQuote("test\\'test", "'"));
+
+        // Don't unescape other quote type
+        Assert.assertEquals("test\\\"test", StringUtil.unescapeQuote("test\\\"test", "'"));
+        Assert.assertEquals("test\\'test", StringUtil.unescapeQuote("test\\'test", "\""));
+
+        // Don't get confused by multiple backslashes
+        Assert.assertEquals("test\\\\test", StringUtil.unescapeQuote("test\\\\test", "\""));
+        Assert.assertEquals("test\\\\\"test", StringUtil.unescapeQuote("test\\\\\\\"test", "\""));
+        Assert.assertEquals("test\\\\\"test", StringUtil.unescapeQuote("test\\\\\"test", "\""));
+    }
 }

--- a/util/src/test/java/nl/inl/util/TestStringUtil.java
+++ b/util/src/test/java/nl/inl/util/TestStringUtil.java
@@ -48,6 +48,14 @@ public class TestStringUtil {
     }
 
     @Test
+    public void testEscapeQuote2() {
+        String escaped = "\\\\\\\"";  // user entered \\\"
+        String unescaped = "\\\\\"";  // only quote is unescaped
+        Assert.assertEquals(unescaped, StringUtil.unescapeQuote(escaped, "\""));
+        Assert.assertEquals(escaped, StringUtil.escapeQuote(unescaped, "\""));
+    }
+
+    @Test
     public void testEscapeQuote() {
         // Escape the correct quote
         Assert.assertEquals("test'\\\"test", StringUtil.escapeQuote("test'\"test", "\""));
@@ -61,12 +69,20 @@ public class TestStringUtil {
         Assert.assertEquals("test\\\\\"test", StringUtil.escapeQuote("test\\\"test", "\""));
         Assert.assertEquals("test\\\\'test", StringUtil.escapeQuote("test\\'test", "'"));
 
-        Assert.assertEquals("bla\\\\\"\\'\\\\\\s\\n\\\"'bla\\", StringUtil.escapeQuote("bla\\\"\\'\\\\\\s\\n\"'bla\\", "\""));
+        // Let's combine a bunch of stuff
+        String escaped   = "bla\\\\\\\"\\'\\\\\\s\\n\\\"\\'bla\\";
+        String unescapedDouble = "bla\\\\\"\\'\\\\\\s\\n\"\\'bla\\";
+        Assert.assertEquals(unescapedDouble, StringUtil.unescapeQuote(escaped, "\""));
+        Assert.assertEquals(escaped, StringUtil.escapeQuote(unescapedDouble, "\""));
+        String unescapedSingle = "bla\\\\\\\"'\\\\\\s\\n\\\"'bla\\";
+        Assert.assertEquals(unescapedSingle, StringUtil.unescapeQuote(escaped, "'"));
+        Assert.assertEquals(escaped, StringUtil.escapeQuote(unescapedSingle, "'"));
 
         // Test roundtrip as well
-        String input = "bla\\\"\\'\\\\\\s\\n\"'bla\\";
-        Assert.assertEquals(input, StringUtil.unescapeQuote(StringUtil.escapeQuote(input, "\""), "\""));
-        Assert.assertEquals(input, StringUtil.unescapeQuote(StringUtil.escapeQuote(input, "'"), "'"));
+        Assert.assertEquals(unescapedDouble, StringUtil.unescapeQuote(StringUtil.escapeQuote(unescapedDouble, "\""), "\""));
+        Assert.assertEquals(escaped, StringUtil.escapeQuote(StringUtil.unescapeQuote(escaped, "\""), "\""));
+        Assert.assertEquals(unescapedSingle, StringUtil.unescapeQuote(StringUtil.escapeQuote(unescapedSingle, "'"), "'"));
+        Assert.assertEquals(escaped, StringUtil.escapeQuote(StringUtil.unescapeQuote(escaped, "'"), "'"));
     }
 
     @Test


### PR DESCRIPTION
As a result of some refactoring, how escape characters worked in BCQL changed. It was also probably never completely correct.

Now it should work properly, i.e. single `\` escaping should just work (although there may be additional edge cases, depending on the specifics of how Lucene's regex engine handles escaping).

So these should all work properly:

- `"\""` (find a double quote)
- `"\\"` (find a backslash)
- `"\."` (find a period)
etc.