### PR TITLE
Make `/data/blacklab-corpora` permissions command recursive in getting started guide

### DIFF
--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -38,7 +38,7 @@ sudo mkdir -p /data/blacklab-corpora
 sudo chown $USER:$GROUP /data/blacklab-corpora
 
 # Make sure it's world-readable so Tomcat can read it
-chmod a+rx /data/blacklab-corpora
+chmod -R a+rx /data/blacklab-corpora
 ```
 
 Now create a directory `/etc/blacklab` with a file named `blacklab-server.yaml`:


### PR DESCRIPTION
The current command for giving BlackLab read access to the corpora is not recursive. When I ran the BlackLab server I got an error. After running the command as follows: `chmod -R a+rx /data/blacklab-corpora` the error was fixed. 

A little bit of background: I was running BlackLab version 4 on a VPS from TransIP. Without adding the recursive option to the `chmod` command I got this error:

```html
<!doctype html><html lang="en"><head><title>HTTP Status 500 – Internal Server Error</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 500 – Internal Server Error</h1><hr class="line" /><p><b>Type</b> Exception Report</p><p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.</p><p><b>Exception</b></p><pre>java.lang.NullPointerException
	nl.inl.blacklab.server.BlackLabServer.initializationErrorResponse(BlackLabServer.java:321)
	nl.inl.blacklab.server.BlackLabServer.handleRequest(BlackLabServer.java:218)
	nl.inl.blacklab.server.BlackLabServer.doGet(BlackLabServer.java:182)
	javax.servlet.http.HttpServlet.service(HttpServlet.java:634)
	javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	org.apache.logging.log4j.web.Log4jServletFilter.doFilter(Log4jServletFilter.java:71)
</pre><p><b>Note</b> The full stack trace of the root cause is available in the server logs.</p><hr class="line" /><h3>Apache Tomcat/9.0.31 (Ubuntu)</h3></body></html>
```