### PR TITLE
Update several places from polling to wait/notify for faster responses

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/search/results/DocResults.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/DocResults.java
@@ -161,6 +161,9 @@ public class DocResults extends ResultsList<DocResult, DocProperty> implements R
 
     Lock ensureResultsReadLock;
 
+    /** Timeout for waiting on monitor (fallback in case of missed signals) */
+    private static final int WAIT_TIMEOUT_MS = 100;
+
     /** Largest number of hits in a single document */
     private long mostHitsInDocument = 0;
 
@@ -282,10 +285,12 @@ public class DocResults extends ResultsList<DocResult, DocProperty> implements R
             while (!ensureResultsReadLock.tryLock()) {
                 /*
                 * Another thread is already counting, we don't want to straight up block until it's done
-                * as it might be counting/retrieving all results, while we might only want trying to retrieve a small fraction
-                * So instead poll our own state, then if we're still missing results after that just count them ourselves
+                * as it might be counting/retrieving all results, while we might only want trying to retrieve a small fraction.
+                * Wait for notification that results have been added, then check if we have enough.
                 */
-                Thread.sleep(50);
+                synchronized (results) {
+                    results.wait(WAIT_TIMEOUT_MS);
+                }
                 if (doneProcessingAndCounting() || (number >= 0 && results.size() >= number))
                     return;
             }
@@ -330,6 +335,10 @@ public class DocResults extends ResultsList<DocResult, DocProperty> implements R
                     }
                 }
             } finally {
+                // Signal waiting threads we're done, they may be waiting for more results than we can provide.
+                synchronized (results) {
+                    results.notifyAll();
+                }
                 ensureResultsReadLock.unlock();
             }
         } catch (InterruptedException e) {
@@ -353,6 +362,10 @@ public class DocResults extends ResultsList<DocResult, DocProperty> implements R
         else
             docResult = DocResult.fromHits(doc, docHits, totalNumberOfHits);
         results.add(docResult);
+        // Signal waiting threads that a new result is available
+        synchronized (results) {
+            results.notifyAll();
+        }
         if (docHits.size() > mostHitsInDocument)
             mostHitsInDocument = docHits.size();
         totalHits += docHits.size();

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsFiltered.java
@@ -12,6 +12,9 @@ import nl.inl.blacklab.resultproperty.PropertyValue;
  */
 public class HitsFiltered extends HitsMutable {
 
+    /** Timeout for waiting on monitor (fallback in case of missed signals) */
+    private static final int WAIT_TIMEOUT_MS = 100;
+
     private final Lock ensureHitsReadLock = new ReentrantLock();
 
     /**
@@ -77,10 +80,12 @@ public class HitsFiltered extends HitsMutable {
             while (!ensureHitsReadLock.tryLock()) {
                 /*
                  * Another thread is already counting, we don't want to straight up block until it's done
-                 * as it might be counting/retrieving all results, while we might only want trying to retrieve a small fraction
-                 * So instead poll our own state, then if we're still missing results after that just count them ourselves
+                 * as it might be counting/retrieving all results, while we might only want trying to retrieve a small fraction.
+                 * Wait for notification that results have been added, then check if we have enough.
                  */
-                Thread.sleep(50);
+                synchronized (hitsInternalMutable) {
+                    hitsInternalMutable.wait(WAIT_TIMEOUT_MS);
+                }
                 if (doneFiltering || number >= 0 && hitsInternalMutable.size() >= number)
                     return;
             }
@@ -104,6 +109,10 @@ public class HitsFiltered extends HitsMutable {
                                 docsRetrieved++;
                                 previousHitDoc = hit.doc();
                             }
+                            // Signal waiting threads that a new hit is available
+                            synchronized (hitsInternalMutable) {
+                                hitsInternalMutable.notifyAll();
+                            }
                         }
                     } else {
                         doneFiltering = true;
@@ -113,6 +122,10 @@ public class HitsFiltered extends HitsMutable {
                 }
             } finally {
                 ensureHitsReadLock.unlock();
+                // Signal waiting threads we're done, they may be waiting for more results than we can provide.
+                synchronized (hitsInternalMutable) {
+                    hitsInternalMutable.notifyAll();
+                }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // preserve interrupted status

--- a/engine/src/main/java/nl/inl/blacklab/search/results/HitsFromQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/HitsFromQuery.java
@@ -29,8 +29,9 @@ import nl.inl.util.CurrentThreadExecutorService;
 
 public class HitsFromQuery extends HitsMutable {
 
-    /** If another thread is busy fetching hits and we're monitoring it, how often should we check? */
-    private static final int HIT_POLLING_TIME_MS = 50;
+    /** Maximum time to wait for hits to be signaled before checking state (ms).
+     *  This is a fallback in case of missed signals; normally the Condition will wake us immediately. */
+    private static final int HIT_WAIT_TIMEOUT_MS = 100;
 
     protected final AtomicLong globalDocsProcessed = new AtomicLong();
     protected final AtomicLong globalDocsCounted = new AtomicLong();
@@ -115,7 +116,7 @@ public class HitsFromQuery extends HitsMutable {
                     leafReaderContext,
                     this.hitQueryContext,
                     this.hitsInternalMutable,
-                        this.globalDocsProcessed,
+                    this.globalDocsProcessed,
                     this.globalDocsCounted,
                     this.globalHitsProcessed,
                     this.globalHitsCounted,
@@ -170,14 +171,18 @@ public class HitsFromQuery extends HitsMutable {
         boolean hasLock = false;
         List<Future<?>> pendingResults = null;
         try {
-            while (!ensureHitsReadLock.tryLock(HIT_POLLING_TIME_MS, TimeUnit.MILLISECONDS)) {
+            while (!ensureHitsReadLock.tryLock(0, TimeUnit.MILLISECONDS)) {
                 /*
                 * Another thread is already working on hits, we don't want to straight up block until it's done,
                 * as it might be counting/retrieving all results, while we might only want trying to retrieve a small fraction.
-                * So instead poll our own state, then if we're still missing results after that just count them ourselves
+                * So instead wait for notification that hits have been added, then check if we have enough.
                 */
                 if (allSourceSpansFullyRead || (hitsInternalMutable.size() >= clampedNumber)) {
                     return;
+                }
+                // Wait for hits to be added (with timeout as fallback)
+                synchronized (hitsInternalMutable) {
+                    hitsInternalMutable.wait(HIT_WAIT_TIMEOUT_MS);
                 }
             }
             hasLock = true;

--- a/engine/src/main/java/nl/inl/blacklab/search/results/SpansReader.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/SpansReader.java
@@ -116,7 +116,7 @@ class SpansReader implements Runnable {
      * @param weight                span weight we're querying
      * @param leafReaderContext     leaf reader we're running on
      * @param sourceHitQueryContext source HitQueryContext from HitsFromQueryParallel; we'll derive our own context from it
-     * @param globalResults         global results object (must be locked before writing)
+     * @param globalResults         global results object (must be locked before writing) - we'll send a notify() on it when we add hits
      * @param globalDocsProcessed   global docs retrieved counter
      * @param globalDocsCounted     global docs counter (includes ones that weren't retrieved because of max. settings)
      * @param globalHitsProcessed   global hits retrieved counter
@@ -130,7 +130,7 @@ class SpansReader implements Runnable {
         HitQueryContext sourceHitQueryContext,
 
         HitsInternalMutable globalResults,
-            AtomicLong globalDocsProcessed,
+        AtomicLong globalDocsProcessed,
         AtomicLong globalDocsCounted,
         AtomicLong globalHitsProcessed,
         AtomicLong globalHitsCounted,
@@ -350,6 +350,11 @@ class SpansReader implements Runnable {
             if (results.size() > 0) {
                 addToGlobalResults(results);
                 results.clear();
+            } else {
+                // Signal that we're done expicitly, even though we had no leftover hits.
+                synchronized(globalResults) {
+                    globalResults.notifyAll();
+                }
             }
         }
 
@@ -363,6 +368,10 @@ class SpansReader implements Runnable {
 
     void addToGlobalResults(HitsInternal hits) {
         globalResults.addAll(hits);
+        // Signal any waiting threads that new hits are available
+        synchronized(globalResults) {
+            globalResults.notifyAll();
+        }
     }
 
     public HitQueryContext getHitContext() {

--- a/wslib/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
+++ b/wslib/src/main/java/nl/inl/blacklab/server/search/BlsCacheEntry.java
@@ -5,6 +5,7 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -21,9 +22,6 @@ import nl.inl.blacklab.searches.SearchCacheEntry;
 import nl.inl.blacklab.searches.SearchCount;
 
 public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
-
-    /** When waiting for the task to complete, poll how often? (ms) */
-    static final int POLLING_TIME_MS = 100;
 
     /** id for the next job started */
     private static Long nextEntryId = 0L;
@@ -62,6 +60,9 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
 
     /** Exception thrown by our thread, or null if no exception was thrown (set by thread) */
     private Throwable exceptionThrown = null;
+
+    /** Latch to signal completion - allows efficient blocking instead of polling */
+    private final CountDownLatch completionLatch = new CountDownLatch(1);
 
     /** If the search couldn't complete or was aborted, this may contain the exact reason why, e.g.
      *  "Search aborted because it took longer than the maximum of 5 minutes. This may be a very demanding
@@ -147,6 +148,9 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
 
             // Record the time the task was done, for e.g. cache management.
             doneTime = now();
+            
+            // Signal completion to any waiting threads
+            completionLatch.countDown();
         }
     }
 
@@ -250,11 +254,12 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
 
     @Override
     public T get(long time, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        // Wait until result available
-        long ms = unit.toMillis(time);
-        while (ms > 0 && !isDone() && !isCancelled()) {
-            Thread.sleep(POLLING_TIME_MS);
-            ms -= POLLING_TIME_MS;
+        // Wait efficiently using the latch instead of polling
+        if (!isDone() && !isCancelled()) {
+            boolean completed = completionLatch.await(time, unit);
+            if (!completed && !isDone() && !isCancelled()) {
+                throw new TimeoutException("Result still not available after " + unit.toMillis(time) + "ms");
+            }
         }
         if (isCancelled()) {
             InterruptedSearch interruptedSearch = InterruptedSearch.cancelled();
@@ -263,8 +268,6 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
         }
         if (exceptionThrown != null)
             throw new ExecutionException(exceptionThrown);
-        if (!isDone())
-            throw new TimeoutException("Result still not available after " + ms + "ms");
         return result;
     }
 
@@ -341,6 +344,9 @@ public class BlsCacheEntry<T extends SearchResult> extends SearchCacheEntry<T> {
             this.result = null;
 
             doneTime = now();
+            
+            // Signal completion to any waiting threads
+            completionLatch.countDown();
         }
         return result;
     }


### PR DESCRIPTION
Basic query responses always take ~200-300ms, no matter how small the corpus. 
Turns out this is because of some naive code that uses polling across threads instead of using wait/notify. We always stack at least one sleep() in all those spots, and it adds up. 

These changes make the same queries (admittedly very simple) queries return in <20ms in my tests. As a nice side effect it also saves some time in the CI tests.


Since hits have significantly changed in `dev` we'll have to see how to port this, and if it's still necessary. The change in `BlsCache` seems useful at the least.