### PR TITLE
Issue #646: Upgrade to Lucene 10

### DIFF
--- a/engine/src/main/java/nl/inl/blacklab/codec/blacklab50/BlackLab50Codec.java
+++ b/engine/src/main/java/nl/inl/blacklab/codec/blacklab50/BlackLab50Codec.java
@@ -1,6 +1,6 @@
 package nl.inl.blacklab.codec.blacklab50;
 
-import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 
 import nl.inl.blacklab.codec.BlackLabCodec;
 import nl.inl.blacklab.codec.BlackLabPostingsFormat;
@@ -41,7 +41,7 @@ public class BlackLab50Codec extends BlackLabCodec {
     private BlackLabStoredFieldsFormat storedFieldsFormat;
 
     public BlackLab50Codec() {
-        super(NAME, Lucene99Codec.class, "Lucene99");
+        super(NAME, Lucene104Codec.class, "Lucene104");
     }
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/mocks/MockBlackLabIndex.java
+++ b/engine/src/main/java/nl/inl/blacklab/mocks/MockBlackLabIndex.java
@@ -10,7 +10,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.BooleanQuery.TooManyClauses;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -172,12 +171,12 @@ public class MockBlackLabIndex implements BlackLabIndex {
     }
 
     @Override
-    public HitResults find(QueryInfo queryInfo, BLSpanQuery query, SearchSettings settings) throws TooManyClauses {
+    public HitResults find(QueryInfo queryInfo, BLSpanQuery query, SearchSettings settings) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public QueryExplanation explain(BLSpanQuery query) throws TooManyClauses {
+    public QueryExplanation explain(BLSpanQuery query) {
         throw new UnsupportedOperationException();
     }
 
@@ -276,7 +275,7 @@ public class MockBlackLabIndex implements BlackLabIndex {
         if (includeContentStores)
             throw new UnsupportedOperationException("Always skips content stores");
         try {
-            return reader().document(docId);
+            return reader().storedFields().document(docId);
         } catch (IOException e) {
             throw new InvalidIndex(e);
         }

--- a/engine/src/main/java/nl/inl/blacklab/resultproperty/HitPropertyDocumentStoredField.java
+++ b/engine/src/main/java/nl/inl/blacklab/resultproperty/HitPropertyDocumentStoredField.java
@@ -148,7 +148,7 @@ public class HitPropertyDocumentStoredField extends HitProperty {
             return IntPoint.newSetQuery(fieldName, List.of(Integer.parseInt(value)));
         } else {
             // https://github.com/apache/lucene/commit/0bc41356955cbf0144aa37203c6269256cf62555#diff-8d710e550a9661ad8a40b284a1f2ddc26a3b58477bf55d52eeed3f2f0576385cL169
-            return SortedDocValuesField.newSlowSetQuery(fieldName, new BytesRef(value));
+            return SortedDocValuesField.newSlowSetQuery(fieldName, List.of(new BytesRef(value)));
             // TermQuery doesn't work here! Why!?
             // (tested with field authorCombined in CHN;
             //  if that field is not indexed but does have docvalues,

--- a/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/BlackLabIndexAbstract.java
@@ -27,7 +27,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.TieredMergePolicy;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
@@ -532,7 +531,7 @@ public abstract class BlackLabIndexAbstract implements BlackLabIndexWriter, Blac
         // Make sure large wildcard/regex expansions succeed
         if (traceIndexOpening())
             logger.debug("  Setting maxClauseCount...");
-        BooleanQuery.setMaxClauseCount(100_000);
+        IndexSearcher.setMaxClauseCount(100_000);
 
         // Open the forward indices
         if (!createNewIndex) {

--- a/engine/src/main/java/nl/inl/blacklab/search/DocUtil.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/DocUtil.java
@@ -68,7 +68,7 @@ public class DocUtil {
 
             String fieldPropName = field.offsetsField();
 
-            org.apache.lucene.index.Terms terms = index.reader().getTermVector(docId, fieldPropName);
+            org.apache.lucene.index.Terms terms = index.reader().termVectors().get(docId, fieldPropName);
             if (terms == null)
                 throw new IllegalArgumentException("Field " + fieldPropName + " in doc " + docId + " has no term vector");
             if (!terms.hasPositions())

--- a/engine/src/main/java/nl/inl/blacklab/search/SingleDocIdFilter.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/SingleDocIdFilter.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 
 import nl.inl.blacklab.exceptions.BlackLabException;
@@ -49,48 +50,53 @@ public class SingleDocIdFilter extends Query {
             }*/
 
             @Override
-            public Scorer scorer(final LeafReaderContext ctx) {
-                return new Scorer(this) {
+            public ScorerSupplier scorerSupplier(final LeafReaderContext ctx) {
+                return new ScorerSupplier() {
                     @Override
-                    public int docID() {
-                        return luceneDocId;
-                    }
-
-                    @Override
-                    public float score() {
-                        return 1.0f;
-                    }
-
-                    /*zyw @Override
-                    public int freq() throws IOException {
-                        return 1;
-                    }*/
-
-                    @Override
-                    public DocIdSetIterator iterator() {
-                        // Check that id could be in this segment, and bits allows this doc id
-                        if (luceneDocId >= ctx.docBase) {
-
-                            // Check that the id is really in this segment by looking at the next segment
-                            Optional<LeafReaderContext> nextSegment = ctx.parent.leaves().stream()
-                                    .filter(l -> l.docBase > ctx.docBase)
-                                    .findFirst();
-                            if (nextSegment.isEmpty() || nextSegment.get().docBase > luceneDocId) {
-                                // Doc occurs in this segment.
-                                return new SingleDocIdSet(luceneDocId - ctx.docBase).iterator();
+                    public Scorer get(long leadCost) {
+                        return new Scorer() {
+                            @Override
+                            public int docID() {
+                                return luceneDocId;
                             }
-                        }
-                        // We're in the wrong segment. Return empty set.
-                        try {
-                            return DocIdSet.EMPTY.iterator();
-                        } catch (IOException e) {
-                            throw BlackLabException.wrapRuntime(e);
-                        }
+
+                            @Override
+                            public float score() {
+                                return 1.0f;
+                            }
+
+                            @Override
+                            public DocIdSetIterator iterator() {
+                                // Check that id could be in this segment, and bits allows this doc id
+                                if (luceneDocId >= ctx.docBase) {
+
+                                    // Check that the id is really in this segment by looking at the next segment
+                                    Optional<LeafReaderContext> nextSegment = ctx.parent.leaves().stream()
+                                            .filter(l -> l.docBase > ctx.docBase)
+                                            .findFirst();
+                                    if (nextSegment.isEmpty() || nextSegment.get().docBase > luceneDocId) {
+                                        // Doc occurs in this segment.
+                                        return new SingleDocIdSet(luceneDocId - ctx.docBase).iterator();
+                                    }
+                                }
+                                // We're in the wrong segment. Return empty set.
+                                try {
+                                    return DocIdSet.EMPTY.iterator();
+                                } catch (IOException e) {
+                                    throw BlackLabException.wrapRuntime(e);
+                                }
+                            }
+
+                            @Override
+                            public float getMaxScore(int upTo) {
+                                return 0;
+                            }
+                        };
                     }
 
                     @Override
-                    public float getMaxScore(int upTo) {
-                        return 0;
+                    public long cost() {
+                        return 1;
                     }
                 };
             }

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataImpl.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/IndexMetadataImpl.java
@@ -135,7 +135,7 @@ public class IndexMetadataImpl implements IndexMetadataWriter {
         private static final TermQuery METADATA_DOC_QUERY = new TermQuery(new Term(METADATA_MARKER, METADATA_MARKER));
 
         public static String getMetadataJson(IndexReader reader, int docId) throws IOException {
-            return reader.document(docId).get(METADATA_FIELD_NAME);
+            return reader.storedFields().document(docId).get(METADATA_FIELD_NAME);
         }
 
         public static Integer getMetadataDocId(IndexReader reader) throws IOException {

--- a/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationsStrategySeparateTerms.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/indexmetadata/RelationsStrategySeparateTerms.java
@@ -232,7 +232,7 @@ public class RelationsStrategySeparateTerms implements RelationsStrategy {
         assert regexes.size() == (attributes == null ? 0 : attributes.size()) + 1;
         List<BLSpanQuery> queries = new ArrayList<>();
         for (String regex: regexes) {
-            RegexpQuery regexpQuery = new RegexpQuery(new Term(relationField.luceneField(), regex), RegExp.COMPLEMENT);
+            RegexpQuery regexpQuery = new RegexpQuery(new Term(relationField.luceneField(), regex), RegExp.DEPRECATED_COMPLEMENT);
             queries.add(new BLSpanMultiTermQueryWrapper<>(queryInfo, regexpQuery));
         }
         SpanQueryAnd q =  new SpanQueryAnd(queries);

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanMultiTermQueryWrapper.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanMultiTermQueryWrapper.java
@@ -83,7 +83,7 @@ public class BLSpanMultiTermQueryWrapper<Q extends MultiTermQuery>
 
     @Override
     public BLSpanQuery rewrite(IndexReader reader) throws IOException {
-        Query q = query.rewrite(reader);
+        Query q = query.rewrite(new IndexSearcher(reader));
         if (!(q instanceof SpanQuery))
             throw new UnsupportedOperationException(
                     "You can only use BLSpanMultiTermQueryWrapper with a suitable SpanRewriteMethod.");

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/BLSpanQuery.java
@@ -173,7 +173,6 @@ public abstract class BLSpanQuery extends SpanQuery implements SpanGuaranteeGive
         return this; // by default, don't do any optimization
     }
 
-    @Override
     public abstract BLSpanQuery rewrite(IndexReader reader) throws IOException;
 
     @Override

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanFuzzyQuery.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanFuzzyQuery.java
@@ -71,7 +71,7 @@ public class SpanFuzzyQuery extends BLSpanQuery {
     public BLSpanQuery rewrite(IndexReader reader) throws IOException {
         FuzzyQuery fuzzyQuery = new FuzzyQuery(term, maxEdits, prefixLength);
 
-        Query rewrittenFuzzyQuery = fuzzyQuery.rewrite(reader);
+        Query rewrittenFuzzyQuery = fuzzyQuery.rewrite(new IndexSearcher(reader));
         if (rewrittenFuzzyQuery instanceof BooleanQuery) {
             // BooleanQuery; make SpanQueries from each of the TermQueries and combine with OR
             List<BooleanClause> clauses = ((BooleanQuery) rewrittenFuzzyQuery).clauses();
@@ -79,7 +79,7 @@ public class SpanFuzzyQuery extends BLSpanQuery {
             for (int i = 0; i < clauses.size(); i++) {
                 BooleanClause clause = clauses.get(i);
 
-                TermQuery termQuery = (TermQuery) clause.getQuery();
+                TermQuery termQuery = (TermQuery) clause.query();
 
                 // ONLY DIFFERENCE WITH SpanFuzzyQuery:
                 // Use a BLSpanTermQuery instead of default Lucene one.

--- a/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryFiltered.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/lucene/SpanQueryFiltered.java
@@ -50,7 +50,7 @@ public class SpanQueryFiltered extends BLSpanQueryAbstract {
         List<BLSpanQuery> rewritten = rewriteClauses(reader);
         boolean clauseRewritten = rewritten != null;
         BLSpanQuery rewrittenClause = clauseRewritten ? rewritten.get(0) : clauses.get(0);
-        Query rewrittenFilter = filter.rewrite(reader);
+        Query rewrittenFilter = filter.rewrite(new IndexSearcher(reader));
         if (rewrittenFilter instanceof MultiTermQuery) {
             // Wrap it so it is rewritten to a BooleanQuery and we avoid the
             // "doesn't implement createWeight" problem.
@@ -73,7 +73,7 @@ public class SpanQueryFiltered extends BLSpanQueryAbstract {
     @Override
     public BLSpanWeight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
         BLSpanWeight weight = clauses.get(0).createWeight(searcher, scoreMode, boost);
-        Query rewrite = filter.rewrite(searcher.getIndexReader());
+        Query rewrite = filter.rewrite(searcher);
         if (rewrite instanceof MultiTermQuery) {
             // Wrap it so it is rewritten to a BooleanQuery and we avoid the
             // "doesn't implement createWeight" problem.

--- a/engine/src/main/java/nl/inl/blacklab/search/results/docs/DocResults.java
+++ b/engine/src/main/java/nl/inl/blacklab/search/results/docs/DocResults.java
@@ -572,7 +572,7 @@ public class DocResults extends ResultsList<DocResult> implements ResultGroups, 
 
                 // Rewrite query (we store the original query, not the rewritten one)
                 try {
-                    query = query.rewrite(queryInfo().index().reader());
+                    query = query.rewrite(queryInfo().index().searcher());
                 } catch (IOException e) {
                     throw new InvalidIndex(e);
                 }

--- a/engine/src/main/java/nl/inl/util/LuceneUtil.java
+++ b/engine/src/main/java/nl/inl/util/LuceneUtil.java
@@ -148,7 +148,7 @@ public final class LuceneUtil {
         // NOTE: might be faster to retrieve all term vectors at once
 
         try {
-            Terms terms = reader.getTermVector(doc, luceneName);
+            Terms terms = reader.termVectors().get(doc, luceneName);
             if (terms == null) {
                 throw new IllegalArgumentException("Field " + luceneName + " has no Terms");
             }
@@ -221,7 +221,7 @@ public final class LuceneUtil {
         for (int n = 0; n < reader.maxDoc(); n++) {
             if (liveDocs == null || liveDocs.get(n)) {
                 try {
-                    Terms terms = reader.getTermVector(n, fieldName);
+                    Terms terms = reader.termVectors().get(n, fieldName);
                     if (terms == null) {
                         // No term vector; probably not stored in this document.
                         continue;
@@ -393,7 +393,7 @@ public final class LuceneUtil {
                     DocIdSetIterator documentIterator = scorer.iterator();
                     int doc;
                     while ((doc = documentIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-                        Terms terms = reader.getTermVector(doc, field);
+                        Terms terms = reader.termVectors().get(doc, field);
                         if (terms == null) {
                             throw new IllegalArgumentException("Field " + field + " has no Terms");
                         }

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
 
         <!-- Library versions -->
         <servlet.version>6.0.0</servlet.version>
-        <blacklab.luceneVersion>9.11.1</blacklab.luceneVersion>
-        <solr.version>9.8.1</solr.version>
+        <blacklab.luceneVersion>10.4.0</blacklab.luceneVersion>
+        <solr.version>10.0.0</solr.version>
         <log4j.version>2.25.4</log4j.version>
         <eclipse.collections.version>12.0.0.M3</eclipse.collections.version>
 

--- a/tools/src/main/java/nl/inl/blacklab/testutil/GetFieldValues.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/GetFieldValues.java
@@ -45,7 +45,7 @@ public class GetFieldValues {
 
             int numDocs = r.numDocs();
             for (int i = 1; i < numDocs; i++) {
-                r.document(i, fieldVisitor);
+                r.storedFields().document(i, fieldVisitor);
                 Document d = fieldVisitor.getDocument();
                 for (String fieldName : fieldNames) {
                     String value = d.get(fieldName);

--- a/tools/src/main/java/nl/inl/blacklab/testutil/RunTermQuery.java
+++ b/tools/src/main/java/nl/inl/blacklab/testutil/RunTermQuery.java
@@ -98,7 +98,7 @@ public class RunTermQuery {
         String luceneName = term.field();
         String word = term.text();
         try {
-            org.apache.lucene.index.Terms terms = reader.getTermVector(doc, luceneName);
+            org.apache.lucene.index.Terms terms = reader.termVectors().get(doc, luceneName);
             if (terms == null) {
                 System.out.println("Field " + luceneName + " has no Terms");
                 return;
@@ -165,10 +165,10 @@ public class RunTermQuery {
 
     private static void doQuery(Term term, IndexReader reader) throws IOException {
         Query query = new TermQuery(term);
-        query = query.rewrite(reader);
+        IndexSearcher searcher = new IndexSearcher(reader);
+        query = query.rewrite(searcher);
         System.out.println("REGULAR QUERY");
 
-        IndexSearcher searcher = new IndexSearcher(reader);
         final BitSet bits = new BitSet(reader.maxDoc());
         docsFound = false;
         searcher.search(query, new SimpleCollector() {
@@ -203,7 +203,7 @@ public class RunTermQuery {
         IndexSearcher searcher = new IndexSearcher(reader);
 
         SpanQuery spanQuery = new SpanTermQuery(term);
-        spanQuery = (SpanQuery) spanQuery.rewrite(reader);
+        spanQuery = (SpanQuery) spanQuery.rewrite(searcher);
 
         System.out.println("SPANQUERY");
 

--- a/tools/src/main/java/nl/inl/blacklab/tools/frequency/counter/index/DocumentFrequencyCounter.java
+++ b/tools/src/main/java/nl/inl/blacklab/tools/frequency/counter/index/DocumentFrequencyCounter.java
@@ -50,7 +50,7 @@ final public class DocumentFrequencyCounter {
         fieldsToLoad.add(docLengthField);
         final var metaFieldNames = cfg.metadata().stream().map(MetadataConfig::name).toList();
         fieldsToLoad.addAll(metaFieldNames);
-        return index.reader().document(docId, fieldsToLoad);
+        return index.reader().storedFields().document(docId, fieldsToLoad);
     }
 
     /**


### PR DESCRIPTION
- Lucene 9.8.1 -> 10.4.0
- Solr 9.8.1 -> 10.0.0
- IndexReader.document(int) -> reader.storedFields().document(int)
- IndexReader.getTermVector(int, field) -> reader.termVectors().get(int, field)
- BooleanQuery.setMaxClauseCount -> IndexSearcher.setMaxClauseCount
- BooleanQuery.TooManyClauses moved to IndexSearcher.TooManyClauses (drop now-unneeded throws clauses in MockBlackLabIndex)
- Query.rewrite(IndexReader) replaced by Query.rewrite(IndexSearcher) at all Lucene-API call sites
- BooleanClause is now a record: getQuery() -> query()
- SortedDocValuesField.newSlowSetQuery now takes Collection<BytesRef>; wrap value in List.of(...)
- RegExp.COMPLEMENT removed; opt back in via RegExp.DEPRECATED_COMPLEMENT to preserve relation-query behaviour
- Codec lucene99.Lucene99Codec replaced by lucene104.Lucene104Codec in BlackLab50Codec
- BLSpanQuery: drop @Override on internal abstract rewrite(IndexReader); the public Query.rewrite(IndexSearcher) override delegates to it, leaving all subclass overrides untouched
- SingleDocIdFilter: rewrite anonymous Weight to implement scorerSupplier(LeafReaderContext) returning a ScorerSupplier (Weight.scorer is now final); Scorer no longer takes a Weight in its constructor